### PR TITLE
fix(input): route AYANEO MCU japanese-layout QAM + enroll paddles (Pocket ACE tested)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Includes:
 | Retroid Pocket 6 | SM8550 | ✅ Tested |
 | KONKR Pocket FIT (G3 Gen 3) | SM8650 | ✅ Tested |
 | AYANEO Pocket S2 | SM8650 | ⚪ Untested |
-| AYANEO Pocket ACE | SM8550 | ⚪ Untested |
+| AYANEO Pocket ACE | SM8550 | ✅ Tested |
 | AYANEO Pocket DMG | SM8550 | ⚪ Untested |
 | AYANEO Pocket DS | SM8550 | ⚪ Untested |
 | AYANEO Pocket S 2K | SM8550 | ⚪ Untested |

--- a/system_files/usr/share/inputplumber/capability_maps/ayaneo_mcu_japanese.yaml
+++ b/system_files/usr/share/inputplumber/capability_maps/ayaneo_mcu_japanese.yaml
@@ -83,14 +83,55 @@ mapping:
       gamepad:
         button: Select
 
-  - name: F1 Key
+  - name: QuickAccess (QAM)
     source_events:
       - evdev:
           event_type: KEY
           event_code: BTN5
           value_type: button
     target_event:
-      keyboard: KeyF1
+      gamepad:
+        button: QuickAccess
+
+  - name: Left Paddle 1 (L4)
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN3
+          value_type: button
+    target_event:
+      gamepad:
+        button: LeftPaddle1
+
+  - name: Right Paddle 1 (R4)
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN4
+          value_type: button
+    target_event:
+      gamepad:
+        button: RightPaddle1
+
+  - name: Left Paddle 2 (L5)
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN7
+          value_type: button
+    target_event:
+      gamepad:
+        button: LeftPaddle2
+
+  - name: Right Paddle 2 (R5 / physical Aya)
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN6
+          value_type: button
+    target_event:
+      gamepad:
+        button: RightPaddle2
 
   - name: Right Trigger
     source_events:


### PR DESCRIPTION
Enroll the AYANEO Pocket ACE's QAM key and back paddles on the shared `ayaneo_mcu_japanese` capability map.

## Summary of changes

Before: only the standard face/shoulder/trigger/stick/D-pad events plus `BTN_MODE` reached target capabilities. QAM was misrouted to `keyboard.KeyF1` (wrong namespace, Steam can't surface QAM from a keyboard chord) and all four back paddles were dropped silently.

| Physical button | Source event | Previous target | New target |
|---|---|---|---|
| **QAM** (front) | `KEY BTN5` (261) + `MSC_SCAN=0x90006` | `keyboard.KeyF1` ❌ | `gamepad.QuickAccess` ✅ |
| **L4** (primary back paddle L) | `KEY BTN3` (259) + `MSC_SCAN=0x90004` | *unmapped* | `gamepad.LeftPaddle1` |
| **R4** (primary back paddle R) | `KEY BTN4` (260) + `MSC_SCAN=0x90005` | *unmapped* | `gamepad.RightPaddle1` |
| **L5** (secondary back paddle L) | `KEY BTN7` (263) + `MSC_SCAN=0x90008` | *unmapped* | `gamepad.LeftPaddle2` |
| **R5** (secondary back paddle R, physical "Aya") | `KEY BTN6` (262) + `MSC_SCAN=0x90007` | *unmapped* | `gamepad.RightPaddle2` |

## Background

The Pocket ACE matches `01-ayaneo-controller-japanese.yaml`, which uses the shared `ayaneo_mcu_japanese` capability map. That map currently only routes the composite gamepad's standard face/shoulder/trigger/stick/D-pad events plus `BTN_MODE`; all of the ACE's front QAM key and back paddles emit events on the paired MCU keyboard device (`AYANEO DEVICE`, `1c4f:0002`, `event3`) that the map drops silently.

The QAM issue is a targeting bug — the mapping existed but pointed at the keyboard namespace (`KeyF1`), so Steam never received a QAM-open signal.

## Empirical verification

Captured on hardware (Pocket ACE, Armada `7.0.11` aarch64, InputPlumber `v0.77.2`) with the ipcap tool (https://github.com/pacoa-kdbg/inputplumber-capture-suite `v0.3.0`):

1. Stop InputPlumber, relax perms on `/dev/input/event3` (MCU keyboard) and `event4` (composite gamepad), capture events for 20s while pressing Guide, L5, R5, QAM in that exact order.
2. Verify each press produced exactly one paired `KEY` + `MSC_SCAN` event on the expected node (see table above).
3. Install patched map as runtime override at `/etc/inputplumber/capability_maps.d/ayaneo_mcu_japanese.yaml`.
4. `systemctl restart inputplumber` → cleanly re-matches `01-ayaneo-controller-japanese.yaml`.
5. Test each button in Steam Big Picture and via `evtest` on the virtual X-Box 360 pad `/dev/input/event9`: QAM opens sidebar, L4/L5/R4/R5 each register on their target paddle slot, no regressions on standard controller inputs.

## Compatibility with other AYANEO devices

The pre-existing `BTN_C → RightPaddle1` and `BTN_Z → LeftPaddle1` entries (used by older AYANEO paddle firmware) are **preserved**. On the ACE those source codes never fire, and on older hardware the new `BTN3/BTN4/BTN6/BTN7` codes never fire, so both hardware families reach `LeftPaddle1/RightPaddle1` without conflict.

## Related devices

Per `01-ayaneo-controller-japanese.yaml`, this device match applies to **AYANEO Pocket ACE** and **AYANEO Pocket DMG**. Only the ACE was hardware-verified here. The DMG shares the same MCU family and is expected to work identically, but remains formally untested (README kept as ⚪ Untested).

## Companion PR

The same class of paddle/QAM enrollment for the sibling `ayaneo_mcu_xbox` capability map (used by Pocket DS / EVO / Pocket S 2K) is filed as **#75**.

## README

Flips `AYANEO Pocket ACE` status from ⚪ Untested to ✅ Tested.