### PR TITLE
feat(input): map AYANEO Pocket DS extra buttons (Aya→QAM, L4/L5/R4/R5 paddles, Steam→Guide)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Includes:
 | AYANEO Pocket S2 | SM8650 | ⚪ Untested |
 | AYANEO Pocket ACE | SM8550 | ⚪ Untested |
 | AYANEO Pocket DMG | SM8550 | ⚪ Untested |
-| AYANEO Pocket DS | SM8550 | ⚪ Untested |
+| AYANEO Pocket DS | SM8550 | 🟢 Verified |
 | AYANEO Pocket S 2K | SM8550 | ⚪ Untested |
 
 ## Flash to SD card

--- a/system_files/usr/share/inputplumber/capability_maps/ayaneo_mcu_xbox.yaml
+++ b/system_files/usr/share/inputplumber/capability_maps/ayaneo_mcu_xbox.yaml
@@ -83,14 +83,66 @@ mapping:
       gamepad:
         button: Select
 
-  - name: F1 Key
+  - name: QAM (Aya)
     source_events:
       - evdev:
           event_type: KEY
           event_code: BTN5
           value_type: button
     target_event:
-      keyboard: KeyF1
+      gamepad:
+        button: QuickAccess
+
+  - name: Guide (Steam button, redundant)
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN2
+          value_type: button
+    target_event:
+      gamepad:
+        button: Guide
+
+  - name: Left Paddle 1 (L4)
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN3
+          value_type: button
+    target_event:
+      gamepad:
+        button: LeftPaddle1
+
+  - name: Right Paddle 1 (R4)
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN4
+          value_type: button
+    target_event:
+      gamepad:
+        button: RightPaddle1
+
+  - name: Left Paddle 2 (L5)
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN7
+          value_type: button
+    target_event:
+      gamepad:
+        button: LeftPaddle2
+
+  - name: Right Paddle 2 (R5)
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN6
+          value_type: button
+    target_event:
+      gamepad:
+        button: RightPaddle2
+
 
   - name: Right Trigger
     source_events:


### PR DESCRIPTION
Enroll the AYANEO Pocket DS's front menu keys and back paddles by extending the shared `ayaneo_mcu_xbox` capability map with 5 new entries and fixing one incorrect mapping.

## Summary of changes

| Physical button | Source event | Previous target | New target |
|---|---|---|---|
| **Aya** (QAM key on front) | `KEY BTN5` (261) + `MSC_SCAN=0x90006` | `keyboard.KeyF1` ❌ | `gamepad.QuickAccess` ✅ |
| **Steam button** (front menu) | `KEY BTN2` (258) + `MSC_SCAN=0x90003` | *unmapped* | `gamepad.Guide` (redundant with `BTN_MODE`) |
| **L4** (primary back paddle) | `KEY BTN3` (259) + `MSC_SCAN=0x90004` | *unmapped* | `gamepad.LeftPaddle1` |
| **R4** (primary back paddle) | `KEY BTN4` (260) + `MSC_SCAN=0x90005` | *unmapped* | `gamepad.RightPaddle1` |
| **L5** (secondary back paddle) | `KEY BTN7` (263) + `MSC_SCAN=0x90008` | *unmapped* | `gamepad.LeftPaddle2` |
| **R5** (secondary back paddle) | `KEY BTN6` (262) + `MSC_SCAN=0x90007` | *unmapped* | `gamepad.RightPaddle2` |

## Background

The Pocket DS matches `01-ayaneo-controller.yaml`, which in turn uses the shared `ayaneo_mcu_xbox` capability map. That capability map currently only handles the composite gamepad's standard face/shoulder/trigger/stick/D-pad events plus BTN_MODE. All of the DS's front menu keys and back paddles emit events on the paired MCU keyboard device (`AYANEO DEVICE`, `1c4f:0002`, `event3`) that the map drops silently.

The `BTN5 → keyboard.KeyF1` mapping in the same file is the same class of bug as https://github.com/virtudude/armada/pull/74: on both hardware families the "QAM key" is designed to trigger the Steam QAM overlay via the gamepad capability namespace, not by chording `F1`.

## Empirical verification

Captured on hardware (Pocket DS, Armada `7.0.11` aarch64, InputPlumber `v0.77.2`) with the ipcap tool (https://github.com/pacoa-kdbg/inputplumber-capture-suite `v0.3.0`):

1. Stop InputPlumber, relax perms on `/dev/input/event3` and `event4`, capture events for 25s while pressing L4/L5/R4/R5 in that exact order.
2. Verify events on `event3` (MCU keyboard) match the table above.
3. Install patched map as runtime override at `/etc/inputplumber/capability_maps.d/ayaneo_mcu_xbox.yaml`.
4. `systemctl restart inputplumber` → cleanly re-matches `01-ayaneo-controller.yaml`.
5. Test each button in Steam Big Picture and via `evtest` on the virtual X-Box 360 pad `/dev/input/event9`: every mapped button reaches its target slot.

Journal excerpt after restart:
```
inputplumber::input::manager] Found a matching input device evdev://event3 in
config "/usr/share/inputplumber/devices/01-ayaneo-controller.yaml", creating
CompositeDevice
inputplumber::input::composite_device] Loading device profile `Default` from:
/usr/share/inputplumber/profiles/default.yaml
```

## Compatibility with other AYANEO devices

The pre-existing `BTN_C → RightPaddle1` and `BTN_Z → LeftPaddle1` entries (used by older AYANEO models) are **preserved**. On the DS those source codes never fire, and on older hardware the new `BTN3/BTN4/BTN6/BTN7` codes never fire, so both hardware families reach `LeftPaddle1/RightPaddle1` without conflict.

The Pocket ACE and Pocket DMG use a **different** capability map (`ayaneo_mcu_japanese` via `01-ayaneo-controller-japanese.yaml`), so this PR has zero effect on those devices. The same class of paddle/Steam-button enrollment can be applied to the japanese map in a follow-up PR once the ACE is available for a matching capture.

## Related devices

Per `01-ayaneo-controller.yaml`, three devices match this config: **AYANEO Pocket EVO**, **AYANEO Pocket DS**, and **AYANEO Pocket S 2K**. Only the DS was hardware-verified here. Since all three share the same MCU family and firmware line, the mapping is expected to work identically on EVO and Pocket S 2K, but they remain formally untested.

## README

Flips `AYANEO Pocket DS` status from ⚪ Untested to 🟢 Verified.
