### PR TITLE
fix(power): prevent wake-key rebound after mem resume

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -21,6 +21,7 @@ check:
     done
     echo "Checking syntax: Justfile"
     just --unstable --fmt --check -f Justfile
+    bash tests/run.sh
 
 [group('Just')]
 fix:

--- a/system_files/usr/lib/armada/powerbutton-guard
+++ b/system_files/usr/lib/armada/powerbutton-guard
@@ -1,0 +1,226 @@
+#!/bin/bash
+# Resume-generation guard shared by powerbuttond and its replay tests.
+
+ARMADA_RESUME_MARKER=${ARMADA_RESUME_MARKER:-/run/armada/last-resume}
+ARMADA_RESUME_GUARD_MS=${ARMADA_RESUME_GUARD_MS:-1500}
+ARMADA_RESUME_GUARD_HARD_MS=${ARMADA_RESUME_GUARD_HARD_MS:-5000}
+ARMADA_UPTIME_FILE=${ARMADA_UPTIME_FILE:-/proc/uptime}
+ARMADA_BOOT_ID_FILE=${ARMADA_BOOT_ID_FILE:-/proc/sys/kernel/random/boot_id}
+
+armada_resume_identity=
+armada_resume_generation=
+armada_resume_phase=
+armada_resume_guard_active=0
+armada_resume_guard_seen_event=0
+armada_resume_guard_release_seen=0
+armada_resume_guard_until_ms=0
+armada_resume_guard_hard_until_ms=0
+
+armada_guard_now_ms() {
+    local uptime seconds fraction
+    read -r uptime _ <"$ARMADA_UPTIME_FILE" || return 1
+    [[ $uptime =~ ^[0-9]+([.][0-9]+)?$ ]] || return 1
+    seconds=${uptime%%.*}
+    if [[ $uptime == *.* ]]; then
+        fraction=${uptime#*.}000
+        fraction=${fraction:0:3}
+    else
+        fraction=000
+    fi
+    printf '%s\n' "$((10#$seconds * 1000 + 10#$fraction))"
+}
+
+armada_read_exact_record() {
+    local path=$1 raw record sentinel=$'\034'
+    raw=$(cat "$path" && printf '%s' "$sentinel") || return 1
+    [[ $raw == *"$sentinel" ]] || return 1
+    raw=${raw%"$sentinel"}
+    [[ $raw == *$'\n' ]] || return 1
+    record=${raw%$'\n'}
+    [[ -n $record && $record != *$'\n'* ]] || return 1
+    printf '%s' "$record"
+}
+
+# Prints: generation phase phase_monotonic_ms
+armada_resume_marker_fields() {
+    local version generation boot_id phase phase_ms timestamp extra metadata owner mode current_boot record
+    [[ -f $ARMADA_RESUME_MARKER && ! -L $ARMADA_RESUME_MARKER ]] || return 1
+    metadata=$(stat -c '%u %a' "$ARMADA_RESUME_MARKER" 2>/dev/null) || return 1
+    read -r owner mode extra <<<"$metadata"
+    [[ $owner == 0 && $mode == 644 && -z $extra ]] || return 1
+    record=$(armada_read_exact_record "$ARMADA_RESUME_MARKER") || return 1
+    read -r version generation boot_id phase phase_ms timestamp extra <<<"$record"
+    [[ $version == v1 && -n $timestamp && -z $extra ]] || return 1
+    [[ $generation =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]] \
+        || return 1
+    [[ $boot_id =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]] \
+        || return 1
+    [[ $phase == prepared || $phase == resumed ]] || return 1
+    [[ $phase_ms =~ ^[0-9]+$ ]] || return 1
+    read -r current_boot <"$ARMADA_BOOT_ID_FILE" || return 1
+    [[ $boot_id == "$current_boot" ]] || return 1
+    printf '%s %s %s\n' "$generation" "$phase" "$((10#$phase_ms))"
+}
+
+armada_resume_guard_reset() {
+    armada_resume_guard_active=0
+    armada_resume_guard_seen_event=0
+    armada_resume_guard_release_seen=0
+    armada_resume_guard_until_ms=0
+    armada_resume_guard_hard_until_ms=0
+}
+
+armada_resume_guard_init() {
+    local fields generation phase phase_ms extra
+    armada_resume_identity=
+    armada_resume_generation=
+    armada_resume_phase=
+    armada_resume_guard_reset
+    # Cache any marker that predates this daemon without arming it. A daemon
+    # restart creates a fresh evdev descriptor, so it has no historical queue;
+    # treating an old prepared marker as live would instead eat a future press.
+    fields=$(armada_resume_marker_fields 2>/dev/null || true)
+    read -r generation phase phase_ms extra <<<"$fields"
+    if [[ -n $generation && -n $phase && -n $phase_ms && -z $extra ]]; then
+        armada_resume_identity=${generation}:${phase}
+        armada_resume_generation=$generation
+        armada_resume_phase=$phase
+    fi
+}
+
+# Returns success only when a new, usable root-published phase is observed.
+# A prepared phase remains usable across arbitrarily long suspend dwell. A
+# completed phase must be recent, which prevents a Steam relaunch hours later
+# from swallowing the next legitimate power press.
+armada_resume_guard_refresh() {
+    local force=${1:-0} fields generation phase phase_ms extra identity now age
+    local prepared_continuation=0
+    fields=$(armada_resume_marker_fields 2>/dev/null || true)
+    read -r generation phase phase_ms extra <<<"$fields"
+    [[ -n $generation && -n $phase && -n $phase_ms && -z $extra ]] || return 1
+    identity=${generation}:${phase}
+    if [[ $identity == "$armada_resume_identity" ]]; then
+        [[ $force == 1 && $armada_resume_guard_active == 0 ]] || return 1
+    fi
+    now=$(armada_guard_now_ms) || return 1
+    if [[ $phase == resumed && $armada_resume_phase == prepared \
+        && $armada_resume_generation == "$generation" \
+        && $armada_resume_guard_active == 1 ]]; then
+        prepared_continuation=1
+    fi
+
+    armada_resume_identity=$identity
+    armada_resume_generation=$generation
+    armada_resume_phase=$phase
+    armada_resume_guard_reset
+
+    if [[ $phase == resumed ]]; then
+        if (( prepared_continuation == 0 )) && [[ $force != 1 ]]; then
+            (( now >= phase_ms )) || return 1
+            age=$((now - phase_ms))
+            (( age < ARMADA_RESUME_GUARD_HARD_MS )) || return 1
+        fi
+    fi
+
+    armada_resume_guard_active=1
+    if [[ $phase == resumed ]]; then
+        if (( prepared_continuation == 1 )) || [[ $force == 1 ]]; then
+            armada_resume_guard_until_ms=$((now + ARMADA_RESUME_GUARD_MS))
+            armada_resume_guard_hard_until_ms=$((now + ARMADA_RESUME_GUARD_HARD_MS))
+        else
+            armada_resume_guard_until_ms=$((phase_ms + ARMADA_RESUME_GUARD_MS))
+            armada_resume_guard_hard_until_ms=$((phase_ms + ARMADA_RESUME_GUARD_HARD_MS))
+        fi
+    fi
+}
+
+# Returns 0 when pressed, 1 when released, and 2 when state cannot be proven.
+armada_power_key_pressed() {
+    local device=$1 result
+    timeout 1 evtest --query "$device" EV_KEY KEY_POWER >/dev/null 2>&1
+    result=$?
+    case $result in
+        10) return 0 ;;
+        0) return 1 ;;
+        *) return 2 ;;
+    esac
+}
+
+# Update expiry after each guarded timed read. powerbuttond replaces its evtest
+# descriptor on every new phase, so a released query is evaluated only after
+# the old descriptor and its historical queue have been discarded.
+armada_resume_guard_tick() {
+    local device=$1 now query_result
+    (( armada_resume_guard_active == 1 )) || return 1
+    # A prepared phase may be observed before kernel entry. It stays pending
+    # without timers across any suspend dwell until post publishes "resumed"
+    # or the first wake-key event establishes the boundary on the fresh fd.
+    if [[ $armada_resume_phase == prepared \
+        && $armada_resume_guard_seen_event == 0 ]]; then
+        return 0
+    fi
+    now=$(armada_guard_now_ms) || return 0
+    if (( now >= armada_resume_guard_hard_until_ms )); then
+        armada_resume_guard_active=0
+        return 1
+    fi
+    (( now >= armada_resume_guard_until_ms )) || return 0
+
+    if (( armada_resume_guard_release_seen == 1 )); then
+        armada_resume_guard_active=0
+        return 1
+    fi
+
+    if armada_power_key_pressed "$device"; then
+        armada_resume_guard_seen_event=1
+        return 0
+    else
+        query_result=$?
+    fi
+
+    if (( query_result == 1 )); then
+        armada_resume_guard_active=0
+        return 1
+    fi
+    return 0
+}
+
+# Returns success when a KEY_POWER event must be swallowed. The hard deadline
+# is checked here as well as on timer ticks so scheduler stalls cannot extend it.
+armada_resume_guard_swallow() {
+    local line=$1 now
+    (( armada_resume_guard_active == 1 )) || return 1
+    now=$(armada_guard_now_ms) || return 0
+    if [[ $armada_resume_phase == prepared \
+        && $armada_resume_guard_seen_event == 0 ]]; then
+        case $line in
+            *"(KEY_POWER), value 0"*)
+                armada_resume_guard_seen_event=1
+                armada_resume_guard_release_seen=1
+                ;;
+            *"(KEY_POWER), value 1"*|*"(KEY_POWER), value 2"*)
+                armada_resume_guard_seen_event=1
+                ;;
+            *) return 1 ;;
+        esac
+        armada_resume_guard_until_ms=$((now + ARMADA_RESUME_GUARD_MS))
+        armada_resume_guard_hard_until_ms=$((now + ARMADA_RESUME_GUARD_HARD_MS))
+        return 0
+    fi
+    if (( now >= armada_resume_guard_hard_until_ms )); then
+        armada_resume_guard_active=0
+        return 1
+    fi
+    case $line in
+        *"(KEY_POWER), value 0"*)
+            armada_resume_guard_seen_event=1
+            armada_resume_guard_release_seen=1
+            return 0
+            ;;
+        *"(KEY_POWER), value 1"*|*"(KEY_POWER), value 2"*)
+            armada_resume_guard_seen_event=1
+            return 0
+            ;;
+        *) return 1 ;;
+    esac
+}

--- a/system_files/usr/lib/systemd/system-sleep/50-armada-resume-guard
+++ b/system_files/usr/lib/systemd/system-sleep/50-armada-resume-guard
@@ -1,0 +1,175 @@
+#!/bin/bash
+# Arm before suspend and finalize after resume while user.slice is normally frozen.
+
+set -uo pipefail
+
+RUNTIME_DIR=${ARMADA_RESUME_RUNTIME_DIR:-/run/armada}
+MARKER=${ARMADA_RESUME_MARKER:-${RUNTIME_DIR}/last-resume}
+UUID_FILE=${ARMADA_RESUME_UUID_FILE:-/proc/sys/kernel/random/uuid}
+BOOT_ID_FILE=${ARMADA_RESUME_BOOT_ID_FILE:-/proc/sys/kernel/random/boot_id}
+UPTIME_FILE=${ARMADA_RESUME_UPTIME_FILE:-/proc/uptime}
+SESSION_USER=${ARMADA_SESSION_USER:-armada}
+POWERBUTTON_PATH=${ARMADA_POWERBUTTON_PATH:-/usr/libexec/armada/powerbuttond}
+PROC_ROOT=${ARMADA_PROC_ROOT:-/proc}
+resume_guard_temporary=
+
+log() {
+    logger -t armada-resume-guard -- "$*" || true
+}
+
+guard_now_ms() {
+    local uptime seconds fraction
+    read -r uptime _ <"$UPTIME_FILE" || return 1
+    [[ $uptime =~ ^[0-9]+([.][0-9]+)?$ ]] || return 1
+    seconds=${uptime%%.*}
+    if [[ $uptime == *.* ]]; then
+        fraction=${uptime#*.}000
+        fraction=${fraction:0:3}
+    else
+        fraction=000
+    fi
+    printf '%s\n' "$((10#$seconds * 1000 + 10#$fraction))"
+}
+
+cleanup_resume_generation() {
+    [[ -n $resume_guard_temporary ]] && rm -f -- "$resume_guard_temporary"
+}
+
+read_exact_record() {
+    local path=$1 raw record sentinel=$'\034'
+    raw=$(cat "$path" && printf '%s' "$sentinel") || return 1
+    [[ $raw == *"$sentinel" ]] || return 1
+    raw=${raw%"$sentinel"}
+    [[ $raw == *$'\n' ]] || return 1
+    record=${raw%$'\n'}
+    [[ -n $record && $record != *$'\n'* ]] || return 1
+    printf '%s' "$record"
+}
+
+publish_resume_phase() {
+    local phase=$1 generation=$2 boot_id=$3 phase_ms
+    phase_ms=$(guard_now_ms) || return 1
+    install -d -o root -g root -m 0755 "$RUNTIME_DIR" || return 1
+    resume_guard_temporary=$(mktemp "${RUNTIME_DIR}/.last-resume.XXXXXX") || return 1
+    trap cleanup_resume_generation EXIT
+    printf 'v1 %s %s %s %s %s\n' \
+        "$generation" "$boot_id" "$phase" "$phase_ms" "$(date --iso-8601=ns)" \
+        >"$resume_guard_temporary" || return 1
+    chown root:root "$resume_guard_temporary" || return 1
+    chmod 0644 "$resume_guard_temporary" || return 1
+    mv -f -- "$resume_guard_temporary" "$MARKER" || return 1
+    resume_guard_temporary=
+    trap - EXIT
+    log "published resume generation $generation phase=$phase"
+}
+
+prepared_generation() {
+    local expected_boot=$1 version generation boot_id phase phase_ms timestamp extra metadata owner mode record
+    [[ -f $MARKER && ! -L $MARKER ]] || return 1
+    metadata=$(stat -c '%u %a' "$MARKER" 2>/dev/null) || return 1
+    read -r owner mode extra <<<"$metadata"
+    [[ $owner == 0 && $mode == 644 && -z $extra ]] || return 1
+    record=$(read_exact_record "$MARKER") || return 1
+    read -r version generation boot_id phase phase_ms timestamp extra <<<"$record"
+    [[ $version == v1 && $boot_id == "$expected_boot" && $phase == prepared \
+        && $phase_ms =~ ^[0-9]+$ && -n $timestamp && -z $extra ]] || return 1
+    [[ $generation =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]] \
+        || return 1
+    printf '%s\n' "$generation"
+}
+
+new_generation() {
+    local generation
+    generation=$(<"$UUID_FILE") || return 1
+    [[ $generation =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]] \
+        || return 1
+    printf '%s\n' "$generation"
+}
+
+powerbuttond_pids() {
+    local session_uid proc pid ppid key real first second third fourth arg0 arg1 parent0 parent1
+    session_uid=$(id -u "$SESSION_USER" 2>/dev/null || true)
+    [[ $session_uid =~ ^[0-9]+$ ]] || return 0
+    for proc in "$PROC_ROOT"/[0-9]*; do
+        [[ -r $proc/status && -r $proc/cmdline ]] || continue
+        real=
+        first=
+        ppid=
+        while read -r key first second third fourth; do
+            case $key in
+                Uid:) real=$first ;;
+                PPid:) ppid=$first ;;
+            esac
+        done <"$proc/status"
+        [[ $real == "$session_uid" ]] || continue
+        arg0=
+        arg1=
+        exec 8<"$proc/cmdline" || continue
+        IFS= read -r -d '' -u 8 arg0 || true
+        IFS= read -r -d '' -u 8 arg1 || true
+        exec 8<&-
+        if [[ $arg0 == "$POWERBUTTON_PATH" \
+            || ( $arg0 == */bash && $arg1 == "$POWERBUTTON_PATH" ) ]]; then
+            # A lid watcher is a Bash subshell with the same argv as its main
+            # daemon. Signal only top-level owners, not their script children.
+            if [[ $ppid =~ ^[0-9]+$ && -r $PROC_ROOT/$ppid/cmdline ]]; then
+                parent0=
+                parent1=
+                exec 9<"$PROC_ROOT/$ppid/cmdline" || continue
+                IFS= read -r -d '' -u 9 parent0 || true
+                IFS= read -r -d '' -u 9 parent1 || true
+                exec 9<&-
+                if [[ $parent0 == "$POWERBUTTON_PATH" \
+                    || ( $parent0 == */bash && $parent1 == "$POWERBUTTON_PATH" ) ]]; then
+                    continue
+                fi
+            fi
+            # The daemon installs its USR1 trap before opening fd 3 for the
+            # power-key stream. A matching process without fd 3 is still
+            # starting; signaling it would invoke Bash's default USR1 action.
+            [[ -e $proc/fd/3 ]] || continue
+            pid=${proc##*/}
+            [[ $pid =~ ^[0-9]+$ ]] && printf '%s\n' "$pid"
+        fi
+    done
+}
+
+signal_powerbuttond() {
+    local pid
+    while IFS= read -r pid; do
+        kill -USR1 "$pid" 2>/dev/null || true
+    done < <(powerbuttond_pids)
+}
+
+armada_resume_guard_main() {
+    local stage=${1:-} operation=${2:-} generation boot_id
+    [[ $operation == suspend ]] || return 0
+    boot_id=$(<"$BOOT_ID_FILE") || return 1
+    [[ $boot_id =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]] \
+        || return 1
+
+    case $stage in
+        pre)
+            generation=$(new_generation) || return 1
+            publish_resume_phase prepared "$generation" "$boot_id" || {
+                log "pre-suspend wake-key guard publication failed"
+                return 1
+            }
+            ;;
+        post)
+            generation=$(prepared_generation "$boot_id" 2>/dev/null || true)
+            [[ -n $generation ]] || generation=$(new_generation) || return 1
+            publish_resume_phase resumed "$generation" "$boot_id" || {
+                log "post-resume wake-key guard publication failed"
+                return 1
+            }
+            # Wake a daemon blocked on evtest so it consumes the post marker
+            # before any queued key line, without an awake-time polling loop.
+            signal_powerbuttond
+            ;;
+    esac
+}
+
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+    armada_resume_guard_main "$@"
+fi

--- a/system_files/usr/libexec/armada/powerbuttond
+++ b/system_files/usr/libexec/armada/powerbuttond
@@ -1,72 +1,271 @@
 #!/bin/bash
 # Power button + lid -> Steam's sleep flow (steam://shortpowerpress), launched by
-# launch-steam as the user. fake-suspend owns wake.
+# launch-steam as the user. fake-suspend owns its own wake event.
 set -uo pipefail
-SESSION_USER="${ARMADA_SESSION_USER:-armada}"
+
+SESSION_USER=${ARMADA_SESSION_USER:-armada}
 STEAM_DIR="/var/home/${SESSION_USER}/.local/share/Steam/steamrtarm64"
 STEAM_BIN="${STEAM_DIR}/steam"
+LONG_MS=${ARMADA_POWERBUTTON_LONG_MS:-1000}
+GUARD_POLL_MS=${ARMADA_POWERBUTTON_GUARD_POLL_MS:-250}
+INPUT_LIB=${ARMADA_INPUT_LIB:-/usr/lib/armada/input-lib}
+GUARD_LIB=${ARMADA_POWERBUTTON_GUARD_LIB:-/usr/lib/armada/powerbutton-guard}
+
 log() { logger -t armada-powerbuttond -- "$*"; }
-source /usr/lib/armada/input-lib 2>/dev/null || true
+source "$INPUT_LIB" 2>/dev/null || true
+if ! source "$GUARD_LIB"; then
+    log "cannot load resume guard: $GUARD_LIB"
+    exit 1
+fi
 
 steam_uri() {
-    [[ -x "$STEAM_BIN" ]] || return 1
+    [[ -x $STEAM_BIN ]] || return 1
     LD_LIBRARY_PATH="$STEAM_DIR" "$STEAM_BIN" -ifrunning "steam://$1" >/dev/null 2>&1
 }
 
 power_device() {
     local dev name
     for dev in /dev/input/event*; do
-        [[ -e "$dev" ]] || continue
-        name="$(cat "/sys/class/input/$(basename "$dev")/device/name" 2>/dev/null)" || continue
-        case "$name" in *pwrkey*|*[Pp]ower\ [Bb]utton*) echo "$dev"; return 0 ;; esac
+        [[ -e $dev ]] || continue
+        name=$(cat "/sys/class/input/$(basename "$dev")/device/name" 2>/dev/null) || continue
+        case $name in
+            *pwrkey*|*[Pp]ower\ [Bb]utton*) printf '%s\n' "$dev"; return 0 ;;
+        esac
     done
     return 1
 }
 
-# Lid (clamshell only): close -> Steam sleep. Lid-open wake is fake-suspend's job.
-lidpid=""
-liddev="$(armada_find_lid_dev || true)"
-if [[ -n "$liddev" ]]; then
-    log "watching lid $liddev"
-    ( evtest "$liddev" 2>/dev/null | while read -r l; do
-        case "$l" in
-            *"(SW_LID), value 1"*) log "lid close -> shortpowerpress"; steam_uri shortpowerpress ;;
-        esac
-      done ) &
-    lidpid=$!
-fi
-trap '[[ -n "$lidpid" ]] && kill "$lidpid" 2>/dev/null' EXIT INT TERM
+state=idle
+press_ms=0
+line=
+lidpid=
+pdev=
+power_event_pid=
+resume_signal=0
 
-pdev="$(power_device || true)"
-[[ -n "$pdev" ]] || exit 0
-log "watching $pdev"
-# Long-press fires while still held, not on release.
-LONG_MS=1000
-exec 3< <(evtest "$pdev" 2>/dev/null)
-state=idle; press_ms=0
-while :; do
-    case "$state" in
+powerbutton_reset_state() {
+    state=idle
+    press_ms=0
+}
+
+powerbutton_close_stream() {
+    exec 3<&- || true
+    if [[ -n ${power_event_pid:-} ]]; then
+        kill "$power_event_pid" 2>/dev/null || true
+        wait "$power_event_pid" 2>/dev/null || true
+        power_event_pid=
+    fi
+}
+
+powerbutton_open_stream() {
+    [[ -n $pdev ]] || return 1
+    exec 3< <(evtest "$pdev" 2>/dev/null)
+    power_event_pid=$!
+}
+
+powerbutton_reopen_stream() {
+    powerbutton_close_stream
+    powerbutton_open_stream
+}
+
+powerbutton_refresh_guard() {
+    local force=${1:-0}
+    if armada_resume_guard_refresh "$force"; then
+        powerbutton_reset_state
+        # evdev queues are per open file description. Replacing the evtest
+        # process is the deterministic boundary that discards historical wake
+        # events still buffered behind the line that revealed the generation.
+        powerbutton_reopen_stream || return 1
+        log "new resume phase -> replaced power-key event stream"
+        return 0
+    fi
+    return 1
+}
+
+powerbutton_tick_guard() {
+    [[ -n $pdev ]] || return 0
+    armada_resume_guard_tick "$pdev" >/dev/null 2>&1 || true
+}
+
+# Refresh before interpreting an already-read line, then give that line to the
+# guard before evaluating expiry. Otherwise a queued wake press read at the
+# soft deadline could be mistaken for a fresh press after tick() deactivates.
+powerbutton_prepare_line() {
+    local event_line=$1
+    powerbutton_refresh_guard || true
+    if armada_resume_guard_swallow "$event_line"; then
+        powerbutton_reset_state
+        powerbutton_tick_guard
+        return 0
+    fi
+    powerbutton_tick_guard
+    return 1
+}
+
+powerbutton_handle_line() {
+    local event_line=$1
+    if powerbutton_prepare_line "$event_line"; then
+        return 0
+    fi
+
+    case $state in
         held)
-            rem=$(( LONG_MS - ( $(date +%s%3N) - press_ms ) ))
-            if (( rem <= 0 )); then
-                log "long press -> longpowerpress"; steam_uri longpowerpress; state=draining; continue
-            fi
-            if IFS= read -r -u 3 -t "$(printf '%d.%03d' $(( rem / 1000 )) $(( rem % 1000 )))" line; then
-                case "$line" in
-                    *"(KEY_POWER), value 0"*) log "short press -> shortpowerpress"; steam_uri shortpowerpress; state=idle ;;
-                esac
-            elif (( $? <= 128 )); then
-                break   # evtest ended (not a timeout); launch-steam relaunches next session
-            fi ;;
-        draining)  # long press already fired; swallow the release
-            IFS= read -r -u 3 line || break
-            case "$line" in *"(KEY_POWER), value 0"*) state=idle ;; esac ;;
-        *)  # idle: a release here is the tail of a wake press fake-suspend grabbed -> ignore
-            IFS= read -r -u 3 line || break
-            case "$line" in
+            case $event_line in
+                *"(KEY_POWER), value 0"*)
+                    powerbutton_reset_state
+                    log "short press -> shortpowerpress"
+                    steam_uri shortpowerpress || true
+                    ;;
+            esac
+            ;;
+        draining)
+            case $event_line in
+                *"(KEY_POWER), value 0"*) powerbutton_reset_state ;;
+            esac
+            ;;
+        *)
+            # A release while idle is the tail of a fake-suspend wake press.
+            case $event_line in
                 *"(KEY_POWER), value 1"*)
-                    if armada_lid_closed 2>/dev/null; then log "power w/ lid closed -> ignored"
-                    else press_ms=$(date +%s%3N); state=held; fi ;;
-            esac ;;
+                    if armada_lid_closed 2>/dev/null; then
+                        log "power w/ lid closed -> ignored"
+                    else
+                        press_ms=$(armada_guard_now_ms)
+                        state=held
+                    fi
+                    ;;
+            esac
+            ;;
     esac
-done
+}
+
+powerbutton_handle_timeout() {
+    local now
+    if (( armada_resume_guard_active == 1 )) || [[ $state == held ]]; then
+        powerbutton_refresh_guard || true
+        (( armada_resume_guard_active == 0 )) || powerbutton_tick_guard
+    fi
+    if [[ $state == held ]]; then
+        now=$(armada_guard_now_ms)
+        if (( now - press_ms >= LONG_MS )); then
+            state=draining
+            log "long press -> longpowerpress"
+            steam_uri longpowerpress || true
+        fi
+    fi
+}
+
+powerbutton_next_timeout_ms() {
+    local now remaining
+    if [[ $state == held ]]; then
+        now=$(armada_guard_now_ms)
+        remaining=$((LONG_MS - (now - press_ms)))
+        (( remaining <= 0 )) && { printf '0\n'; return; }
+        (( remaining > 100 )) && remaining=100
+        printf '%s\n' "$remaining"
+    elif (( armada_resume_guard_active == 1 )) \
+        && [[ $armada_resume_phase != prepared \
+            || $armada_resume_guard_seen_event == 1 ]]; then
+        printf '%s\n' "$GUARD_POLL_MS"
+    else
+        # Normal awake operation remains event-driven with no periodic wakeup.
+        printf '%s\n' '-1'
+    fi
+}
+
+# Returns 0 for a line, 1 for EOF/error, and 2 for a read timeout.
+read_power_line() {
+    local timeout_ms=$1 timeout_seconds result
+    if (( timeout_ms < 0 )); then
+        if IFS= read -r -u 3 line 2>/dev/null; then
+            return 0
+        else
+            result=$?
+        fi
+    else
+        printf -v timeout_seconds '%d.%03d' $((timeout_ms / 1000)) $((timeout_ms % 1000))
+        if IFS= read -r -u 3 -t "$timeout_seconds" line 2>/dev/null; then
+            return 0
+        else
+            result=$?
+        fi
+    fi
+    (( result > 128 )) && return 2
+    return 1
+}
+
+powerbutton_cleanup() {
+    powerbutton_close_stream
+    [[ -n ${lidpid:-} ]] && kill "$lidpid" 2>/dev/null || true
+}
+
+powerbutton_handle_resume_signal() {
+    resume_signal=0
+    if ! powerbutton_refresh_guard 1; then
+        # The trap already closed fd 3. Even a malformed/missing marker must
+        # leave the button owner with a fresh, usable event descriptor.
+        powerbutton_reopen_stream || true
+    fi
+}
+
+powerbutton_note_resume_signal() {
+    resume_signal=1
+    # Bash resumes a blocking read after a trapped signal. Closing the read fd
+    # makes the pending read return; the main loop then replaces the evtest
+    # process and descriptor from normal, non-trap context.
+    exec 3<&- || true
+}
+
+powerbutton_main() {
+    local liddev lid_line wait_ms read_result
+
+    liddev=$(armada_find_lid_dev 2>/dev/null || true)
+    if [[ -n $liddev ]]; then
+        log "watching lid $liddev"
+        (
+            evtest "$liddev" 2>/dev/null | while read -r lid_line; do
+                case $lid_line in
+                    *"(SW_LID), value 1"*)
+                        log "lid close -> shortpowerpress"
+                        steam_uri shortpowerpress || true
+                        ;;
+                esac
+            done
+        ) &
+        lidpid=$!
+    fi
+    trap powerbutton_cleanup EXIT
+    trap 'exit 0' INT TERM
+    trap powerbutton_note_resume_signal USR1
+
+    pdev=$(power_device || true)
+    [[ -n $pdev ]] || return 0
+    log "watching $pdev"
+    powerbutton_open_stream || return 1
+
+    powerbutton_reset_state
+    armada_resume_guard_init
+    while :; do
+        (( resume_signal == 0 )) || powerbutton_handle_resume_signal
+        powerbutton_handle_timeout
+        wait_ms=$(powerbutton_next_timeout_ms)
+        (( wait_ms == 0 )) && continue
+        read_power_line "$wait_ms"
+        read_result=$?
+        if (( resume_signal == 1 )); then
+            powerbutton_handle_resume_signal
+            # A trapped signal interrupts read. If a complete line won the
+            # race, still pass that already-read line through the fresh guard.
+            (( read_result == 0 )) || continue
+        fi
+        case $read_result in
+            0) powerbutton_handle_line "$line" ;;
+            2) powerbutton_handle_timeout ;;
+            *) log "power-button event stream ended"; return 1 ;;
+        esac
+    done
+}
+
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+    powerbutton_main "$@"
+fi

--- a/tests/powerbutton-guard-test.sh
+++ b/tests/powerbutton-guard-test.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+tmp=$(mktemp -d)
+trap 'rm -rf -- "$tmp"' EXIT
+fail() { printf 'powerbutton guard test failed at line %s: %s\n' "$1" "$2" >&2; exit 1; }
+
+export ARMADA_RESUME_MARKER="$tmp/last-resume"
+export ARMADA_RESUME_GUARD_MS=1500
+export ARMADA_RESUME_GUARD_HARD_MS=5000
+export ARMADA_UPTIME_FILE="$tmp/uptime"
+export ARMADA_BOOT_ID_FILE="$tmp/boot-id"
+boot=aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa
+printf '%s\n' "$boot" >"$ARMADA_BOOT_ID_FILE"
+printf '2147484.123 0.00\n' >"$ARMADA_UPTIME_FILE"
+source "$ROOT/system_files/usr/lib/armada/powerbutton-guard"
+
+[[ $(armada_guard_now_ms) == 2147484123 ]] || fail "$LINENO" 'monotonic conversion'
+
+test_now=1000
+key_state=released
+mock_owner=0
+mock_mode=644
+
+stat() {
+    if [[ $1 == -c && $2 == '%u %a' && $3 == "$ARMADA_RESUME_MARKER" ]]; then
+        printf '%s %s\n' "$mock_owner" "$mock_mode"
+        return 0
+    fi
+    command stat "$@"
+}
+armada_guard_now_ms() { printf '%s\n' "$test_now"; }
+armada_power_key_pressed() {
+    case $key_state in
+        pressed) return 0 ;;
+        released) return 1 ;;
+        unknown) return 2 ;;
+    esac
+}
+write_marker() {
+    local generation=$1 phase=$2 phase_ms=$3 marker_boot=${4:-$boot}
+    printf 'v1 %s %s %s %s 2026-07-14T00:00:00-04:00\n' \
+        "$generation" "$marker_boot" "$phase" "$phase_ms" >"$ARMADA_RESUME_MARKER"
+}
+
+first=11111111-1111-4111-8111-111111111111
+second=22222222-2222-4222-8222-222222222222
+third=33333333-3333-4333-8333-333333333333
+fourth=44444444-4444-4444-8444-444444444444
+fifth=55555555-5555-4555-8555-555555555555
+sixth=66666666-6666-4666-8666-666666666666
+seventh=77777777-7777-4777-8777-777777777777
+
+# Init caches a marker that predates this daemon but never arms from it. A
+# post-hook signal can explicitly force that same marker for a current resume.
+write_marker "$first" resumed 900
+armada_resume_guard_init
+[[ $armada_resume_identity == "${first}:resumed" ]] || fail "$LINENO" 'init identity'
+(( armada_resume_guard_active == 0 )) || fail "$LINENO" 'stale startup armed'
+armada_resume_guard_refresh 1 || fail "$LINENO" 'forced post signal did not arm'
+(( armada_resume_guard_until_ms == 2500 )) || fail "$LINENO" 'forced soft deadline'
+(( armada_resume_guard_hard_until_ms == 6000 )) || fail "$LINENO" 'forced hard deadline'
+
+# A normally discovered resumed phase uses absolute deadlines anchored to the
+# post marker, so observing it near five seconds cannot extend suppression.
+armada_resume_guard_reset
+test_now=5900
+write_marker "$second" resumed 1000
+armada_resume_guard_refresh || fail "$LINENO" 'fresh absolute marker rejected'
+(( armada_resume_guard_until_ms == 2500 )) || fail "$LINENO" 'soft deadline extended'
+(( armada_resume_guard_hard_until_ms == 6000 )) || fail "$LINENO" 'hard deadline extended'
+test_now=6000
+if armada_resume_guard_swallow 'Event: code 116 (KEY_POWER), value 1'; then
+    fail "$LINENO" 'event swallowed at absolute hard deadline'
+fi
+
+# The exact soft boundary still drains a queued wake sequence on a marker seen
+# promptly after post.
+test_now=3000
+write_marker "$third" resumed 3000
+armada_resume_guard_refresh || fail "$LINENO" 'prompt resumed phase rejected'
+test_now=4500
+armada_resume_guard_swallow 'Event: code 116 (KEY_POWER), value 1' \
+    || fail "$LINENO" 'soft-boundary press escaped'
+armada_resume_guard_swallow 'Event: code 116 (KEY_POWER), value 2' \
+    || fail "$LINENO" 'soft-boundary repeat escaped'
+armada_resume_guard_swallow 'Event: code 116 (KEY_POWER), value 0' \
+    || fail "$LINENO" 'soft-boundary release escaped'
+if armada_resume_guard_tick /dev/input/fake; then
+    fail "$LINENO" 'released key remained guarded after soft boundary'
+fi
+
+# A held wake key remains guarded until release is proven.
+test_now=5000
+write_marker "$fourth" resumed 5000
+armada_resume_guard_refresh || fail "$LINENO" 'held-key phase rejected'
+armada_resume_guard_swallow 'Event: code 116 (KEY_POWER), value 1' \
+    || fail "$LINENO" 'held press escaped'
+key_state=pressed
+test_now=6600
+armada_resume_guard_tick /dev/input/fake || fail "$LINENO" 'held key guard ended early'
+(( armada_resume_guard_active == 1 )) || fail "$LINENO" 'held guard inactive'
+armada_resume_guard_swallow 'Event: code 116 (KEY_POWER), value 0' \
+    || fail "$LINENO" 'held release escaped'
+key_state=released
+if armada_resume_guard_tick /dev/input/fake; then
+    fail "$LINENO" 'guard survived proven held-key release'
+fi
+
+# Unknown key state cannot extend the hard deadline.
+test_now=8000
+write_marker "$fifth" resumed 8000
+armada_resume_guard_refresh || fail "$LINENO" 'unknown-key phase rejected'
+key_state=unknown
+test_now=9600
+armada_resume_guard_tick /dev/input/fake || fail "$LINENO" 'unknown state ended before hard cap'
+test_now=13000
+if armada_resume_guard_swallow 'Event: code 116 (KEY_POWER), value 1'; then
+    fail "$LINENO" 'unknown state outlived hard cap'
+fi
+
+# A new prepared phase remains pending without deadlines across an hour-long
+# suspend; its first event on the replacement fd starts the bounded window.
+test_now=14000
+write_marker "$sixth" prepared 14000
+armada_resume_guard_refresh || fail "$LINENO" 'new prepared phase rejected'
+(( armada_resume_guard_until_ms == 0 )) || fail "$LINENO" 'prepared timer started early'
+test_now=3614000
+armada_resume_guard_tick /dev/input/fake || fail "$LINENO" 'prepared phase expired in suspend'
+armada_resume_guard_swallow 'Event: code 116 (KEY_POWER), value 1' \
+    || fail "$LINENO" 'hour-late wake press escaped'
+(( armada_resume_guard_until_ms == 3615500 )) || fail "$LINENO" 'prepared soft deadline'
+armada_resume_guard_swallow 'Event: code 116 (KEY_POWER), value 0' \
+    || fail "$LINENO" 'hour-late wake release escaped'
+
+# A stale resumed transition for the same active prepared generation remains
+# relevant even after a slow parallel post hook.
+write_marker "$sixth" resumed 14000
+armada_resume_guard_refresh || fail "$LINENO" 'prepared continuation was lost'
+[[ $armada_resume_identity == "${sixth}:resumed" ]] || fail "$LINENO" 'resumed identity'
+(( armada_resume_guard_until_ms == 3615500 )) || fail "$LINENO" 'continuation deadline'
+
+# A prepared marker already present at daemon restart is cached, not armed.
+armada_resume_guard_reset
+write_marker "$seventh" prepared 1000
+armada_resume_guard_init
+[[ $armada_resume_identity == "${seventh}:prepared" ]] || fail "$LINENO" 'prepared cache identity'
+(( armada_resume_guard_active == 0 )) || fail "$LINENO" 'abandoned prepared marker armed'
+
+# Invalid ownership, mode, boot ID, extra records/bytes, and symlinks fail closed.
+write_marker "$first" resumed 3614000
+mock_owner=501
+if armada_resume_guard_refresh; then fail "$LINENO" 'non-root marker accepted'; fi
+mock_owner=0
+mock_mode=600
+if armada_resume_guard_refresh; then fail "$LINENO" 'wrong-mode marker accepted'; fi
+mock_mode=644
+write_marker "$first" resumed 3614000 bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb
+if armada_resume_guard_refresh; then fail "$LINENO" 'wrong-boot marker accepted'; fi
+write_marker "$first" resumed 3614000
+printf ' trailing\n' >>"$ARMADA_RESUME_MARKER"
+if armada_resume_guard_refresh; then fail "$LINENO" 'trailing record accepted'; fi
+write_marker "$first" resumed 3614000
+printf 'unterminated' >>"$ARMADA_RESUME_MARKER"
+if armada_resume_guard_refresh; then fail "$LINENO" 'unterminated bytes accepted'; fi
+printf 'target\n' >"$tmp/target"
+rm -f "$ARMADA_RESUME_MARKER"
+ln -s "$tmp/target" "$ARMADA_RESUME_MARKER"
+if armada_resume_guard_refresh; then fail "$LINENO" 'symlink marker accepted'; fi
+
+printf 'powerbutton resume-guard tests passed\n'

--- a/tests/powerbutton-signal-test.sh
+++ b/tests/powerbutton-signal-test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+tmp=$(mktemp -d)
+trap 'rm -rf -- "$tmp"' EXIT
+fail() { printf 'powerbutton signal test failed at line %s: %s\n' "$1" "$2" >&2; exit 1; }
+mkfifo "$tmp/block"
+
+export ARMADA_INPUT_LIB="$ROOT/system_files/usr/lib/armada/input-lib"
+export ARMADA_POWERBUTTON_GUARD_LIB="$ROOT/system_files/usr/lib/armada/powerbutton-guard"
+source "$ROOT/system_files/usr/libexec/armada/powerbuttond"
+
+forced=0
+powerbutton_refresh_guard() {
+    [[ ${1:-0} == 1 ]] || return 1
+    forced=$((forced + 1))
+}
+trap powerbutton_note_resume_signal USR1
+exec 3<>"$tmp/block"
+
+( sleep 0.1; kill -USR1 "$$" ) &
+sender=$!
+read_result=0
+read_power_line -1 || read_result=$?
+wait "$sender"
+(( resume_signal == 1 )) || fail "$LINENO" 'USR1 did not set resume flag'
+(( read_result != 0 )) || fail "$LINENO" 'USR1 did not interrupt blocking read'
+powerbutton_handle_resume_signal
+(( forced == 1 )) || fail "$LINENO" 'signal handler did not force refresh'
+(( resume_signal == 0 )) || fail "$LINENO" 'signal handler did not clear flag'
+
+printf 'powerbutton signal tests passed\n'

--- a/tests/powerbutton-stream-test.sh
+++ b/tests/powerbutton-stream-test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+tmp=$(mktemp -d)
+trap 'powerbutton_cleanup 2>/dev/null || true; rm -rf -- "$tmp"' EXIT
+fail() { printf 'powerbutton stream test failed at line %s: %s\n' "$1" "$2" >&2; exit 1; }
+mkfifo "$tmp/block"
+
+export ARMADA_INPUT_LIB="$ROOT/system_files/usr/lib/armada/input-lib"
+export ARMADA_POWERBUTTON_GUARD_LIB="$ROOT/system_files/usr/lib/armada/powerbutton-guard"
+source "$ROOT/system_files/usr/libexec/armada/powerbuttond"
+
+# The first fake evtest fills its stdout pipe with historical backlog. The
+# replacement emits a distinct line and then both processes block without a
+# helper child, allowing powerbutton_close_stream to reap them deterministically.
+evtest() {
+    exec 9<>"$tmp/block"
+    if ( set -o noclobber; : >"$tmp/first-started" ) 2>/dev/null; then
+        printf 'old-first\nold-backlog-1\nold-backlog-2\n'
+    else
+        printf 'new-first\n'
+    fi
+    IFS= read -r -u 9 _
+}
+
+pdev=/dev/input/fake
+powerbutton_open_stream
+old_pid=$power_event_pid
+read_power_line -1
+[[ $line == old-first ]] || fail "$LINENO" 'did not read original stream'
+
+powerbutton_reopen_stream
+[[ $power_event_pid != "$old_pid" ]] || fail "$LINENO" 'stream PID did not change'
+if kill -0 "$old_pid" 2>/dev/null; then
+    fail "$LINENO" 'old evtest process survived replacement'
+fi
+read_power_line -1
+[[ $line == new-first ]] || fail "$LINENO" "old backlog crossed replacement: $line"
+
+printf 'powerbutton stream replacement tests passed\n'

--- a/tests/powerbuttond-replay-test.sh
+++ b/tests/powerbuttond-replay-test.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+fail() { printf 'powerbutton replay failed at line %s: %s\n' "$1" "$2" >&2; exit 1; }
+export ARMADA_INPUT_LIB="$ROOT/system_files/usr/lib/armada/input-lib"
+export ARMADA_POWERBUTTON_GUARD_LIB="$ROOT/system_files/usr/lib/armada/powerbutton-guard"
+source "$ROOT/system_files/usr/libexec/armada/powerbuttond"
+
+test_now=1000
+guard_pending=0
+armada_resume_guard_active=0
+armada_resume_guard_seen_event=0
+armada_resume_phase=
+actions=()
+logs=()
+reopen_count=0
+refresh_calls=0
+force_calls=0
+force_accept=1
+pdev=/dev/input/fake
+
+log() { logs+=("$*"); }
+steam_uri() { actions+=("$1"); }
+armada_lid_closed() { return 1; }
+armada_guard_now_ms() { printf '%s\n' "$test_now"; }
+armada_resume_guard_refresh() {
+    local force=${1:-0}
+    refresh_calls=$((refresh_calls + 1))
+    if [[ $force == 1 ]]; then
+        force_calls=$((force_calls + 1))
+        (( force_accept == 1 )) || return 1
+        armada_resume_guard_active=1
+        armada_resume_phase=resumed
+        return 0
+    fi
+    (( guard_pending == 1 )) || return 1
+    guard_pending=0
+    armada_resume_guard_active=1
+    armada_resume_phase=resumed
+}
+armada_resume_guard_swallow() {
+    (( armada_resume_guard_active == 1 )) || return 1
+    [[ $1 == *"(KEY_POWER), value "[012]* ]]
+}
+armada_resume_guard_tick() { return 0; }
+powerbutton_reopen_stream() { reopen_count=$((reopen_count + 1)); }
+
+press='Event: code 116 (KEY_POWER), value 1'
+repeat='Event: code 116 (KEY_POWER), value 2'
+release='Event: code 116 (KEY_POWER), value 0'
+
+# Normal short and long presses retain upstream behavior.
+powerbutton_reset_state
+powerbutton_handle_line "$press"
+test_now=1999
+powerbutton_handle_line "$release"
+[[ ${actions[*]} == shortpowerpress ]] || fail "$LINENO" 'normal short press'
+
+actions=()
+test_now=3000
+powerbutton_handle_line "$press"
+test_now=4000
+powerbutton_handle_timeout
+powerbutton_handle_line "$release"
+[[ ${actions[*]} == longpowerpress ]] || fail "$LINENO" 'normal long press'
+[[ $state == idle ]] || fail "$LINENO" 'long release did not drain'
+
+# Normal idle is blocking/event-driven; only active bounded guards poll.
+armada_resume_guard_active=0
+refresh_calls=0
+powerbutton_handle_timeout
+[[ $refresh_calls == 0 ]] || fail "$LINENO" 'idle timeout refreshed marker'
+[[ $(powerbutton_next_timeout_ms) == -1 ]] || fail "$LINENO" 'idle did not block'
+armada_resume_guard_active=1
+armada_resume_phase=resumed
+[[ $(powerbutton_next_timeout_ms) == "$GUARD_POLL_MS" ]] || fail "$LINENO" 'resumed guard did not poll'
+armada_resume_phase=prepared
+armada_resume_guard_seen_event=0
+[[ $(powerbutton_next_timeout_ms) == -1 ]] || fail "$LINENO" 'unseen prepared phase polled'
+armada_resume_guard_seen_event=1
+[[ $(powerbutton_next_timeout_ms) == "$GUARD_POLL_MS" ]] || fail "$LINENO" 'seen prepared phase did not poll'
+armada_resume_guard_active=0
+armada_resume_phase=
+armada_resume_guard_seen_event=0
+
+# A phase discovered with an already-read key-down wins the race and replaces
+# the old evtest stream before any remaining backlog can cross.
+actions=()
+guard_pending=1
+reopen_count=0
+test_now=5000
+powerbutton_handle_line "$press"
+[[ $reopen_count == 1 ]] || fail "$LINENO" 'wake phase did not replace stream'
+[[ ${#actions[@]} == 0 ]] || fail "$LINENO" 'wake press emitted Steam action'
+[[ $state == idle ]] || fail "$LINENO" 'wake press retained held state'
+
+armada_resume_guard_active=0
+powerbutton_handle_line "$press"
+powerbutton_handle_line "$release"
+[[ ${actions[*]} == shortpowerpress ]] || fail "$LINENO" 'fresh post-guard press failed'
+
+# A new phase while held must cancel state before the long deadline.
+actions=()
+test_now=6000
+powerbutton_handle_line "$press"
+[[ $state == held ]] || fail "$LINENO" 'test press did not enter held state'
+guard_pending=1
+test_now=6100
+powerbutton_handle_timeout
+[[ $state == idle ]] || fail "$LINENO" 'new phase did not cancel held state'
+[[ $reopen_count == 2 ]] || fail "$LINENO" 'held-state phase did not replace stream'
+test_now=8000
+armada_resume_guard_active=0
+powerbutton_handle_timeout
+[[ ${#actions[@]} == 0 ]] || fail "$LINENO" 'cancelled hold fired long action'
+
+# The post-hook signal forces a blocked daemon to consume even an old resumed
+# marker, and does so without any idle poll.
+armada_resume_guard_active=0
+resume_signal=1
+powerbutton_handle_resume_signal
+[[ $force_calls == 1 ]] || fail "$LINENO" 'post signal did not force refresh'
+[[ $reopen_count == 3 ]] || fail "$LINENO" 'post signal did not replace stream'
+(( resume_signal == 0 )) || fail "$LINENO" 'post signal flag not cleared'
+
+# A spurious signal or invalid marker still replaces the descriptor the trap
+# closed, so power-button handling cannot die from the recovery mechanism.
+force_accept=0
+resume_signal=1
+powerbutton_handle_resume_signal
+[[ $reopen_count == 4 ]] || fail "$LINENO" 'failed forced refresh left stream closed'
+
+printf 'powerbutton replay tests passed\n'

--- a/tests/resume-guard-hook-test.sh
+++ b/tests/resume-guard-hook-test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+tmp=$(mktemp -d)
+trap 'rm -rf -- "$tmp"' EXIT
+fail() { printf 'resume hook test failed at line %s: %s\n' "$1" "$2" >&2; exit 1; }
+
+export ARMADA_RESUME_RUNTIME_DIR="$tmp/run"
+export ARMADA_RESUME_MARKER="$tmp/run/last-resume"
+export ARMADA_RESUME_UUID_FILE="$tmp/uuid"
+export ARMADA_RESUME_BOOT_ID_FILE="$tmp/boot-id"
+export ARMADA_RESUME_UPTIME_FILE="$tmp/uptime"
+
+first=11111111-1111-4111-8111-111111111111
+second=22222222-2222-4222-8222-222222222222
+boot=aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa
+printf '%s\n' "$first" >"$ARMADA_RESUME_UUID_FILE"
+printf '%s\n' "$boot" >"$ARMADA_RESUME_BOOT_ID_FILE"
+printf '100.000 0.00\n' >"$ARMADA_RESUME_UPTIME_FILE"
+
+source "$ROOT/system_files/usr/lib/systemd/system-sleep/50-armada-resume-guard"
+
+# Keep the test unprivileged and portable across the macOS development host.
+install() { mkdir -p "${!#}"; chmod 0755 "${!#}"; }
+chown() { return 0; }
+date() { printf '2026-07-14T00:00:00.000000000-04:00\n'; }
+logger() { return 0; }
+signal_count=0
+signal_powerbuttond() { signal_count=$((signal_count + 1)); }
+stat() {
+    if [[ $1 == -c && $2 == '%u %a' && $3 == "$ARMADA_RESUME_MARKER" ]]; then
+        printf '0 644\n'
+        return 0
+    fi
+    command stat "$@"
+}
+
+armada_resume_guard_main pre hibernate
+[[ ! -e $ARMADA_RESUME_MARKER ]] || fail "$LINENO" 'non-suspend operation wrote marker'
+
+# The pre phase exists before kernel entry, then post atomically finalizes the
+# same generation. This remains ordered even if user.slice freezing is disabled.
+armada_resume_guard_main pre suspend
+read -r version generation boot_id phase phase_ms timestamp <"$ARMADA_RESUME_MARKER"
+[[ $version == v1 && $generation == "$first" && $boot_id == "$boot" ]] \
+    || fail "$LINENO" 'invalid prepared identity'
+[[ $phase == prepared && $phase_ms == 100000 ]] \
+    || fail "$LINENO" 'invalid prepared phase'
+(( signal_count == 0 )) || fail "$LINENO" 'pre phase signaled daemon'
+
+printf '200.250 0.00\n' >"$ARMADA_RESUME_UPTIME_FILE"
+armada_resume_guard_main post suspend
+read -r version generation boot_id phase phase_ms timestamp <"$ARMADA_RESUME_MARKER"
+[[ $version == v1 && $generation == "$first" && $boot_id == "$boot" ]] \
+    || fail "$LINENO" 'post changed generation'
+[[ $phase == resumed && $phase_ms == 200250 ]] \
+    || fail "$LINENO" 'invalid resumed phase'
+(( signal_count == 1 )) || fail "$LINENO" 'post did not signal daemon once'
+
+# Invalid new pre data fails without replacing the last valid generation.
+printf 'invalid\n' >"$ARMADA_RESUME_UUID_FILE"
+if armada_resume_guard_main pre suspend; then
+    printf 'invalid resume UUID unexpectedly published\n' >&2
+    exit 1
+fi
+read -r _ generation _ phase _ <"$ARMADA_RESUME_MARKER"
+[[ $generation == "$first" && $phase == resumed ]] \
+    || fail "$LINENO" 'invalid pre replaced valid marker'
+
+# Post remains a useful fallback if the pre hook was absent or failed.
+rm -f "$ARMADA_RESUME_MARKER"
+printf '%s\n' "$second" >"$ARMADA_RESUME_UUID_FILE"
+printf '300.000 0.00\n' >"$ARMADA_RESUME_UPTIME_FILE"
+armada_resume_guard_main post suspend
+read -r _ generation _ phase phase_ms _ <"$ARMADA_RESUME_MARKER"
+[[ $generation == "$second" && $phase == resumed && $phase_ms == 300000 ]] \
+    || fail "$LINENO" 'post fallback marker invalid'
+(( signal_count == 2 )) || fail "$LINENO" 'post fallback did not signal once'
+
+# PID discovery accepts only the configured user's exact script invocation.
+PROC_ROOT="$tmp/proc"
+POWERBUTTON_PATH=/usr/libexec/armada/powerbuttond
+mkdir -p "$PROC_ROOT/101/fd" "$PROC_ROOT/102" "$PROC_ROOT/103" \
+    "$PROC_ROOT/104/fd" "$PROC_ROOT/105"
+printf 'Name:\tbash\nPPid:\t1\nUid:\t501\t501\t501\t501\n' >"$PROC_ROOT/101/status"
+printf '/bin/bash\0%s\0' "$POWERBUTTON_PATH" >"$PROC_ROOT/101/cmdline"
+touch "$PROC_ROOT/101/fd/3"
+printf 'Name:\tother\nPPid:\t1\nUid:\t501\t501\t501\t501\n' >"$PROC_ROOT/102/status"
+printf '/bin/bash\0/usr/bin/not-powerbuttond\0' >"$PROC_ROOT/102/cmdline"
+printf 'Name:\tbash\nPPid:\t1\nUid:\t502\t502\t502\t502\n' >"$PROC_ROOT/103/status"
+printf '/bin/bash\0%s\0' "$POWERBUTTON_PATH" >"$PROC_ROOT/103/cmdline"
+printf 'Name:\tbash\nPPid:\t101\nUid:\t501\t501\t501\t501\n' >"$PROC_ROOT/104/status"
+printf '/bin/bash\0%s\0' "$POWERBUTTON_PATH" >"$PROC_ROOT/104/cmdline"
+touch "$PROC_ROOT/104/fd/3"
+printf 'Name:\tbash\nPPid:\t1\nUid:\t501\t501\t501\t501\n' >"$PROC_ROOT/105/status"
+printf '/bin/bash\0%s\0' "$POWERBUTTON_PATH" >"$PROC_ROOT/105/cmdline"
+id() { [[ ${1:-} == -u ]] && printf '501\n'; }
+[[ $(powerbuttond_pids) == 101 ]] \
+    || fail "$LINENO" 'exact ready powerbutton PID discovery'
+
+printf 'resume-guard hook tests passed\n'

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+
+while IFS= read -r file; do
+    case $(head -n 1 "$file") in
+        *bash*) bash -n "$file" ;;
+    esac
+done < <(find "$ROOT/system_files" "$ROOT/tests" -type f -print)
+
+"$ROOT/tests/powerbutton-guard-test.sh"
+"$ROOT/tests/resume-guard-hook-test.sh"
+"$ROOT/tests/powerbuttond-replay-test.sh"
+"$ROOT/tests/powerbutton-stream-test.sh"
+"$ROOT/tests/powerbutton-signal-test.sh"
+
+printf 'wake-guard test suite passed\n'


### PR DESCRIPTION
## Summary

Armada already ships `mem` suspend for the Odin 3. This PR does not enable, select, or replace that suspend path; it prevents the physical power-key input used to wake the kernel from being interpreted after resume as a new `steam://shortpowerpress`.

The guard establishes an explicit input boundary around suspend:

- a `systemd-sleep` hook atomically publishes one root-owned generation as `prepared` before suspend and the same generation as `resumed` afterward;
- post-resume locates only the configured session user's exact, ready, top-level `powerbuttond` invocation and sends `SIGUSR1`;
- the signal closes Bash's blocked read fd, then normal (non-trap) code terminates and reaps the old `evtest` process and opens a new descriptor;
- because evdev queues belong to the open file description, replacing that descriptor discards historical wake-key backlog; and
- a line that wins the signal/read race is still passed through the fresh guard before normal short/long-press handling.

Normal awake operation remains blocking and event-driven—there is no idle polling loop. Existing short press, long press, lid, and fake-suspend behavior is preserved.

## Guard lifetime and failure behavior

- A `prepared` generation can remain pending across an arbitrarily long suspend dwell; its bounded window begins only at the matching `resumed` phase or the first guarded key event.
- A normally discovered `resumed` marker uses absolute monotonic deadlines anchored to publication. A forced post-signal refresh uses fresh bounded deadlines. Both use a 1.5-second soft window and an unconditional 5-second hard limit, checked on timer and event paths.
- A valid marker that predates a newly started daemon is cached but does not arm the guard. The new daemon already owns a fresh evdev descriptor, so swallowing a later legitimate press would be incorrect.
- Markers must be one exact record, current-boot, root-owned mode `0644`, and not a symlink. Invalid or stale data is ignored.
- Startup candidates without the daemon's fd 3 and same-script child/subshell processes are not signaled.
- If the pre phase is missing, post publishes a fallback generation. If signaling is missed, `powerbuttond` still refreshes the marker before interpreting an input line.
- If a signal arrives with a missing or malformed marker, the descriptor is still reopened so power-button handling remains usable.
- A missing guard library is treated as a partial installation: `powerbuttond` logs and exits instead of running a half-installed path.

## Why

On a physical Odin 3 running Armada Preview's existing `mem` implementation, local instrumentation captured the wake press being translated into another Steam short-power action within milliseconds of resume. One user-visible wake-then-immediate-sleep loop was reproduced.

An earlier live guard prototype then published a resume generation before session thaw and prevented the second Steam action in guarded cycles. Those observations establish the race and the value of a wake boundary, but they are local hardware evidence—not CI—and this redesigned descriptor-replacement implementation still needs installed-image qualification on the Odin 3. It does not claim to fix unrelated kernel, controller, audio, fan, or power-consumption behavior.

## Scope and attribution

The underlying Odin 3 suspend enablement and Armada's ROCKNIX-derived kernel/GPU work are pre-existing and unchanged; this PR contains no kernel code and claims no credit for making `mem` work. PR #34 concerns suspend-mode selection/fallback and is orthogonal to this post-resume input race.

Development and analysis used substantial AI assistance, disclosed in the spirit of #27. AI helped inspect logs, refine the state machine, implement the patch, and build the tests. A human directed the scope, performed the physical device actions, and evaluated the observed behavior. The change is presented as a scoped, independently reviewable userspace patch.

## Tests

- `git diff --check`
- `bash tests/run.sh` (also wired into `just check`), covering:
  1. Bash syntax for shipped and test scripts
  2. marker validation, stale-cache behavior, phase continuation, and absolute/forced deadlines
  3. pre/post publication, post fallback, and exact ready-PID matching
  4. normal short/long presses plus resume-boundary state-machine replay
  5. deterministic `evtest` process/descriptor replacement with backlog rejection
  6. `SIGUSR1` interruption of a blocking Bash read and forced refresh
