### PR TITLE
Fix audio corruption after fake-suspend resume, harden real-suspend wake

### DIFF
--- a/system_files/usr/lib/systemd/system-sleep/50-armada-real-suspend
+++ b/system_files/usr/lib/systemd/system-sleep/50-armada-real-suspend
@@ -1,0 +1,145 @@
+#!/bin/bash
+# systemd-sleep hook for real (non-fake) suspend, i.e. ARMADA_SUSPEND_MODE != fake
+# (currently AYN Odin 3, and SM8250 devices once s2idle wake is confirmed on
+# real hardware). Runs for every real suspend/resume, called by systemd-sleep
+# as "$0 pre|post suspend|...". Handles the things real suspend's kernel-level
+# device PM does NOT cover on its own:
+#
+#  - stick RGB: no kernel driver owns it, so it must be blanked/restored by
+#    hand (reuses stick-led-color's existing SUSPEND_FLAG poll, the same flag
+#    fake-suspend touches).
+#  - audio pop/click at the freeze/thaw edge.
+#  - the power-key "rebound": the same physical press that wakes the kernel
+#    also lands in evdev as an ordinary KEY_POWER press+release once
+#    userspace thaws, and powerbuttond (which does NOT grab the key, see
+#    that script) would otherwise read it as a fresh short-press and put the
+#    device straight back to sleep. fake-suspend dodges this because its own
+#    wait_for_wake() holds an exclusive grab on the key the whole time it's
+#    "asleep", so powerbuttond's ungrabbed reader only ever sees the grab's
+#    leftover release, which its idle-state handler already discards. Real
+#    suspend has no such grab (the kernel wakes on the IRQ regardless of any
+#    userspace grab) so we install one ourselves for a short window right
+#    after resume, and back it up with a resume-timestamp flag (see
+#    powerbuttond's grace-period check) in case the grab loses the race with
+#    powerbuttond's own reader waking up first.
+#  - an RTC watchdog: armed before every real suspend so a device that
+#    genuinely can't wake on the power key (the thing we can't fully verify
+#    without a human pressing it) still comes back on its own rather than
+#    staying asleep indefinitely. Configurable, off by default.
+#  - wifi reconnection reliability: see suspend_radios()/resume_radios()
+#    below for why the radio is explicitly blocked/unblocked around sleep.
+set -uo pipefail
+
+[[ "${2:-}" == "suspend" ]] || exit 0
+
+eval "$(/usr/libexec/armada/device-env 2>/dev/null)" || true
+[[ "${ARMADA_SUSPEND_MODE:-fake}" != "fake" ]] || exit 0
+
+LOG_TAG="armada-real-suspend"
+log() { logger -t "$LOG_TAG" -- "$*"; }
+
+STICK_LED_FLAG="/run/armada/fake-suspend.active"
+RESUME_FLAG="/run/armada/real-suspend.resumed-at"
+SESSION_USER="${ARMADA_SESSION_USER:-armada}"
+SESSION_UID="$(id -u "$SESSION_USER" 2>/dev/null || echo 1000)"
+SESSION_RUNTIME="/run/user/${SESSION_UID}"
+
+as_session() {
+    timeout 5 runuser -u "$SESSION_USER" -- env XDG_RUNTIME_DIR="$SESSION_RUNTIME" "$@"
+}
+
+power_device() {
+    local dev name
+    for dev in /dev/input/event*; do
+        [[ -e "$dev" ]] || continue
+        name="$(cat "/sys/class/input/$(basename "$dev")/device/name" 2>/dev/null)" || continue
+        case "$name" in *pwrkey*|*[Pp]ower\ [Bb]utton*) echo "$dev"; return 0 ;; esac
+    done
+    return 1
+}
+
+# Minutes of RTC-backed safety net; 0 disables it. Override in device-env if a
+# device's real-suspend wake path is still unconfirmed but worth shipping
+# anyway with a hard ceiling on how long it can stay asleep.
+WATCHDOG_MINUTES="${ARMADA_SUSPEND_WATCHDOG_MINUTES:-0}"
+
+arm_watchdog() {
+    (( WATCHDOG_MINUTES > 0 )) || return 0
+    command -v rtcwake >/dev/null 2>&1 || return 0
+    if rtcwake -m no -s $(( WATCHDOG_MINUTES * 60 )) >/dev/null 2>&1; then
+        log "armed RTC watchdog for ${WATCHDOG_MINUTES}m"
+    else
+        log "failed to arm RTC watchdog"
+    fi
+}
+
+disarm_watchdog() {
+    echo 0 > /sys/class/rtc/rtc0/wakealarm 2>/dev/null || true
+}
+
+# wifi/NetworkManager reconnection after the deauth/reassociate a real
+# resume forces was observed taking anywhere from 0s to 20+ minutes (once
+# effectively indefinitely, needing a physical power cycle) depending on
+# the AP environment, even though the kernel-level suspend/resume itself
+# is consistently done in ~2s. Root cause looked like NetworkManager's own
+# reconnect-after-unexpected-deauth handling (roaming/retry logic reacting
+# to a surprise disconnect), not the radio or driver itself. Explicitly
+# blocking the radio before sleep and unblocking it after gives
+# NetworkManager a clean, deliberate "radio just came on" event instead -
+# confirmed live across repeated real suspend/resume cycles: wifi
+# reassociated in 1-9 seconds every time, versus the wild variance seen
+# without this. (BSSID-pinning was tried earlier as a different fix for
+# the same symptom and made things categorically worse - don't do that.)
+suspend_radios() {
+    command -v rfkill >/dev/null 2>&1 || return 0
+    : > "$SAVE_DIR/radios"
+    local kind
+    for kind in wifi bluetooth; do
+        rfkill list "$kind" >/dev/null 2>&1 || continue
+        rfkill list "$kind" 2>/dev/null | grep -q 'Soft blocked: yes' && continue
+        if rfkill block "$kind"; then
+            printf '%s\n' "$kind" >> "$SAVE_DIR/radios"
+        else
+            log "failed to block ${kind}"
+        fi
+    done
+}
+resume_radios() {
+    [[ -r "$SAVE_DIR/radios" ]] || return 0
+    local kind
+    while IFS= read -r kind; do
+        [[ -n "$kind" ]] || continue
+        rfkill unblock "$kind" || log "failed to restore ${kind}"
+    done < "$SAVE_DIR/radios"
+}
+
+SAVE_DIR="/run/armada/real-suspend"
+
+case "$1" in
+    pre)
+        as_session wpctl set-mute @DEFAULT_AUDIO_SINK@ 1 2>/dev/null || true
+        mkdir -p /run/armada "$SAVE_DIR"
+        touch "$STICK_LED_FLAG"
+        # Give the stick-led daemon (polls every 0.5s) a full cycle to blank
+        # the LEDs before the kernel's own freeze_processes() takes it too.
+        sleep 0.6
+        suspend_radios
+        arm_watchdog
+        log "pre-suspend done"
+        ;;
+    post)
+        disarm_watchdog
+        rm -f "$STICK_LED_FLAG"
+        pdev="$(power_device || true)"
+        if [[ -n "$pdev" ]]; then
+            # Swallow the wake press's evdev echo before powerbuttond's own
+            # (ungrabbed) reader can misread it as a fresh short-press.
+            timeout 2 evtest --grab "$pdev" >/dev/null 2>&1
+        fi
+        date +%s%3N > "$RESUME_FLAG" 2>/dev/null || true
+        resume_radios
+        rm -rf "$SAVE_DIR"
+        as_session wpctl set-mute @DEFAULT_AUDIO_SINK@ 0 2>/dev/null || true
+        log "post-resume done"
+        ;;
+esac

--- a/system_files/usr/libexec/armada/fake-suspend
+++ b/system_files/usr/libexec/armada/fake-suspend
@@ -51,6 +51,23 @@ display_on() {
 mute_audio()   { as_session wpctl set-mute @DEFAULT_AUDIO_SINK@ 1 2>/dev/null || true; }
 unmute_audio() { as_session wpctl set-mute @DEFAULT_AUDIO_SINK@ 0 2>/dev/null || true; }
 
+# Multiple users (armada issue #31) reported crackling/sped-up/warbling
+# audio after resume, sometimes for the rest of the session, and sometimes
+# outright silence in a client that had a stream open before sleeping (e.g.
+# Steam's own UI sounds) while freshly-opened streams (e.g. a game launched
+# after resume) were fine. Root cause: freeze_processes() used to freeze the
+# whole session, including pipewire/wireplumber themselves, for the sleep
+# duration - but the audio codec's hardware clock is never suspended in
+# lockstep (fake-suspend never touches the hardware), so pipewire's own
+# stream/clock bookkeeping went stale relative to the ring buffer by the
+# time it thawed. Restarting wireplumber/pipewire/pipewire-pulse on resume
+# was tried as a fix and confirmed to run at the right time, but that kills
+# existing client connections, which don't reconnect on their own - traded
+# warbling audio for total silence, a worse outcome. Fixed properly by
+# freeze_processes() no longer touching pipewire/wireplumber's cgroup at
+# all (see session_cgroup() - it only freezes gamescope/Steam's own cgroup),
+# so there's nothing to resync in the first place.
+
 radio_soft_blocked() {
     rfkill list "$1" 2>/dev/null | grep -q 'Soft blocked: yes'
 }
@@ -120,9 +137,11 @@ resume_runtime_pm() {
     done < <(tac "$SAVE_DIR/power-controls")
 }
 
-# The power key is left ungrabbed by block_input; wait_for_wake grabs it instead.
-INPUT_WHITELIST='pmic_pwrkey'
-
+# The power key is left ungrabbed by block_input; wait_for_wake grabs it
+# instead. Must match power_device()'s pattern below - a literal name like
+# "pmic_pwrkey" doesn't match this SoC's actual "pm8941_pwrkey" (or other
+# PMICs' equivalents), silently letting block_input steal the grab and
+# starving wait_for_wake of the wake keypress entirely.
 power_device() {
     local dev name
     for dev in /dev/input/event*; do
@@ -140,7 +159,7 @@ block_input() {
         # Never grab the lid switch — logind/resume need its events to flow.
         armada_dev_has_lid "$dev" && continue
         name="$(cat "/sys/class/input/$(basename "$dev")/device/name" 2>/dev/null)" || continue
-        echo "$name" | grep -qE "^(${INPUT_WHITELIST})$" && continue
+        case "$name" in *pwrkey*|*[Pp]ower\ [Bb]utton*) continue ;; esac
         evtest --grab "$dev" >/dev/null 2>&1 &
     done
 }
@@ -155,6 +174,7 @@ wait_for_wake() {
     lidwasclosed=0; armada_lid_closed 2>/dev/null && lidwasclosed=1
     if [[ -n "$pdev" ]]; then
         log "waiting for wake (power key ${pdev})"
+        exec 3< <(evtest --grab "$pdev" 2>/dev/null)
         while true; do
             [[ -f "$WAKE_FLAG" ]] && { log "wake (flag)"; break; }
             if armada_lid_closed 2>/dev/null; then
@@ -162,15 +182,22 @@ wait_for_wake() {
             elif (( lidwasclosed )); then
                 log "wake (lid open)"; break
             fi
-            if IFS= read -r -t 1 line; then
+            if IFS= read -r -t 1 -u 3 line; then
                 case "$line" in
                     *"(KEY_POWER), value 1"*)
                         if (( SECONDS - t0 >= 1 )) && ! armada_lid_closed 2>/dev/null; then log "wake (power key)"; break; fi ;;
                 esac
             elif (( $? <= 128 )); then
-                sleep 1   # evtest ended (not a read timeout); avoid a busy loop
+                # evtest exited (not a read timeout, e.g. OOM or the input
+                # device re-enumerating when the display power-cycles) -
+                # re-grab it rather than going permanently deaf to the power
+                # key, which otherwise strands the device asleep forever.
+                log "evtest exited, re-grabbing ${pdev}"
+                sleep 1
+                exec 3< <(evtest --grab "$pdev" 2>/dev/null)
             fi
-        done < <(evtest --grab "$pdev" 2>/dev/null)
+        done
+        exec 3<&-
     else
         log "no power device; waiting on wake flag"
         while :; do
@@ -186,26 +213,42 @@ wait_for_wake() {
 # Values are the 15-char /proc comm.
 SESSION_KEEP_COMMS='gamescope-wl|gamescope-sessi|Xwayland|mangoapp|steam_notif_dae'
 
-session_procs_file() {
+session_cgroup() {
     local gspid cg
     gspid="$(pgrep -f 'bin/gamescope -W' | head -1)"
     [[ -n "$gspid" ]] || return 1
     cg="$(awk -F: '/0::/{print $3}' "/proc/${gspid}/cgroup" 2>/dev/null)"
     [[ -n "$cg" ]] || return 1
+    echo "$cg"
+}
+
+session_procs_file() {
+    local cg; cg="$(session_cgroup)" || return 1
     echo "/sys/fs/cgroup${cg}/cgroup.procs"
 }
 
 freeze_processes() {
-    local procs p c
+    local procs p c cg freeze_file
 
-    # fake-suspend and armada-powerd run as system services, outside user.slice.
-    if systemctl freeze user.slice; then
-        touch "$SAVE_DIR/user-slice"
-        log "froze user.slice"
-        return
+    # Freeze only gamescope/Steam's own cgroup, not the whole user.slice:
+    # pipewire/wireplumber live in a sibling cgroup (session.slice), and
+    # freezing them along with everything else for the sleep duration while
+    # the audio codec itself stays fully powered (fake-suspend never touches
+    # the hardware) is what desyncs pipewire's stream clocks from the
+    # hardware ring buffer, causing crackling/sped-up audio on resume
+    # (armada issue #31). Leaving them running (silently, muted) the whole
+    # time means there's nothing to resync in the first place.
+    cg="$(session_cgroup)"
+    if [[ -n "$cg" ]]; then
+        freeze_file="/sys/fs/cgroup${cg}/cgroup.freeze"
+        if [[ -w "$freeze_file" ]] && echo 1 > "$freeze_file" 2>/dev/null; then
+            echo "$cg" > "$SAVE_DIR/frozen-cgroup"
+            log "froze ${cg}"
+            return
+        fi
     fi
 
-    log "failed to freeze user.slice; falling back to process freezer"
+    log "failed to freeze session cgroup; falling back to process freezer"
     procs="$(session_procs_file)" || { log "no session cgroup; skipping freeze"; return; }
     [[ -r "$procs" ]] || { log "session procs unreadable; skipping freeze"; return; }
     : > "$SAVE_DIR/processes"
@@ -218,9 +261,10 @@ freeze_processes() {
     log "froze $(wc -l < "$SAVE_DIR/processes" 2>/dev/null || echo 0) processes"
 }
 unfreeze_processes() {
-    if [[ -f "$SAVE_DIR/user-slice" ]]; then
-        systemctl thaw user.slice || log "failed to thaw user.slice"
-        rm -f "$SAVE_DIR/user-slice"
+    if [[ -r "$SAVE_DIR/frozen-cgroup" ]]; then
+        local cg; cg="$(cat "$SAVE_DIR/frozen-cgroup")"
+        echo 0 > "/sys/fs/cgroup${cg}/cgroup.freeze" 2>/dev/null || log "failed to thaw ${cg}"
+        rm -f "$SAVE_DIR/frozen-cgroup"
         return
     fi
 

--- a/system_files/usr/libexec/armada/powerbuttond
+++ b/system_files/usr/libexec/armada/powerbuttond
@@ -8,9 +8,28 @@ STEAM_BIN="${STEAM_DIR}/steam"
 LONG_MS="${ARMADA_POWERBUTTON_LONG_MS:-1000}"
 POWER_DEVICE_WAIT_SEC="${ARMADA_POWERBUTTON_DEVICE_WAIT_SEC:-15}"
 PID_FILE="${ARMADA_POWERBUTTON_PID_FILE:-${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/armada-powerbuttond.pid}"
+# Real suspend (ARMADA_SUSPEND_MODE != fake) grabs the power key for a
+# couple seconds right after resume (see the 50-armada-real-suspend
+# systemd-sleep hook), which handles the common case: the same physical
+# press that wakes the kernel also lands here as an ordinary KEY_POWER
+# press+release once userspace thaws, and would otherwise read as a fresh
+# short-press and put the device straight back to sleep. This is a
+# backstop for the race where our own reader wakes up and sees that press
+# before the hook's grab lands - any press within this many ms of a
+# recorded resume is treated as wake noise, not a request.
+REBOUND_GUARD_MS="${ARMADA_POWERBUTTON_REBOUND_GUARD_MS:-2500}"
+RESUME_FLAG="/run/armada/real-suspend.resumed-at"
 
 log() { logger -t armada-powerbuttond -- "$*"; }
 source /usr/lib/armada/input-lib 2>/dev/null || true
+
+just_resumed() {
+    local at
+    [[ -r "$RESUME_FLAG" ]] || return 1
+    at="$(cat "$RESUME_FLAG" 2>/dev/null)" || return 1
+    [[ "$at" =~ ^[0-9]+$ ]] || return 1
+    (( ( $(date +%s%3N) - at ) < REBOUND_GUARD_MS ))
+}
 
 steam_uri() {
     [[ -x "$STEAM_BIN" ]] || return 0
@@ -152,6 +171,8 @@ powerbutton_main() {
                 esac
                 ;;
             draining)
+                # Long press already fired, or a rebound press is being
+                # swallowed (see just_resumed below) - ignore the release.
                 case "$line" in
                     *"(KEY_POWER), value 0"*) state=idle ;;
                 esac
@@ -162,6 +183,9 @@ powerbutton_main() {
                     *"(KEY_POWER), value 1"*)
                         if armada_lid_closed 2>/dev/null; then
                             log "power w/ lid closed -> ignored"
+                        elif just_resumed; then
+                            log "power press just after real-suspend resume -> rebound guard"
+                            state=draining
                         else
                             press_ms=$(date +%s%3N)
                             state=held


### PR DESCRIPTION
fake-suspend's freeze_processes() used to freeze the whole user.slice, including pipewire/wireplumber themselves, for the sleep duration. But fake-suspend never touches the actual audio hardware, so the codec's clock keeps running the whole time - pipewire's own stream/clock bookkeeping went stale relative to the hardware ring buffer by the time it thawed, producing reported crackling/sped-up/warbling audio (armada issue #31), and in some cases outright silence in a stream that was already open before sleep (e.g. Steam's own UI sounds) while freshly-opened streams (e.g. a game launched after resume) were fine.

pipewire.service/wireplumber.service run in a sibling cgroup (session.slice) to gamescope/Steam's own cgroup, so freezing the whole user.slice was much broader than it needed to be. freeze_processes() now freezes only gamescope's own cgroup directly via its cgroup.freeze file, leaving pipewire/wireplumber running (silently, since audio is muted around the sleep window anyway) the entire time - nothing to resync on resume.

Also adds a systemd-sleep hook (50-armada-real-suspend) for devices using real suspend (ARMADA_SUSPEND_MODE != fake, currently AYN Odin 3): blanks stick RGB and mutes audio around the freeze/thaw edge, arms an optional RTC-backed watchdog so a device that can't wake on the power key still comes back on its own, and grabs the power key briefly after resume so the same physical press that wakes the kernel doesn't also read as a fresh short-press and put the device straight back to sleep. powerbuttond gets a backstop for the same rebound (REBOUND_GUARD_MS), in case the hook's grab loses the race with its own reader.