### PR TITLE
Fix duplicate Odin 3 headphones UCM section

### DIFF
--- a/system_files/usr/share/alsa/ucm2/AYN/Odin3/HiFi.conf
+++ b/system_files/usr/share/alsa/ucm2/AYN/Odin3/HiFi.conf
@@ -44,22 +44,3 @@ SectionDevice."Headphones" {
 		JackHWMute "Speaker"
 	}
 }
-
-SectionDevice."Headphones" {
-	Comment "Headphones playback"
-
-	Include.wcdhpe.File "/codecs/wcd939x/HeadphoneEnableSeq.conf"
-	Include.wcdhpd.File "/codecs/wcd939x/HeadphoneDisableSeq.conf"
-	Include.rxmhpe.File "/codecs/qcom-lpass/rx-macro/HeadphoneEnableSeq.conf"
-	Include.rxmhpd.File "/codecs/qcom-lpass/rx-macro/HeadphoneDisableSeq.conf"
-
-	Value {
-		PlaybackChannels 2
-		PlaybackPriority 200
-		PlaybackPCM "hw:${CardId},0"
-		PlaybackMixer "default:${CardId}"
-		PlaybackMixerElem "HP Digital"
-		JackControl "Headphone Jack"
-		JackHWMute "Speaker"
-	}
-}

--- a/tests/alsa-ucm-duplicates-test.sh
+++ b/tests/alsa-ucm-duplicates-test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+UCM_ROOT="$ROOT/system_files/usr/share/alsa/ucm2"
+SECTION_PATTERN='^[[:space:]]*(Section(Device|UseCase|Modifier))\."([^"]+)"[[:space:]]*\{'
+failed=0
+config_count=0
+section_count=0
+
+while IFS= read -r -d '' config; do
+	declare -A seen=()
+	line_number=0
+	config_count=$((config_count + 1))
+
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		line_number=$((line_number + 1))
+		if [[ $line =~ $SECTION_PATTERN ]]; then
+			section_type="${BASH_REMATCH[1]}"
+			section_name="${BASH_REMATCH[3]}"
+			section_key="$section_type/$section_name"
+			section_count=$((section_count + 1))
+
+			if [[ -n "${seen[$section_key]+x}" ]]; then
+				printf 'duplicate %s."%s" in %s:%d (first declared on line %s)\n' \
+					"$section_type" "$section_name" "${config#"$ROOT"/}" \
+					"$line_number" "${seen[$section_key]}" >&2
+				failed=1
+			else
+				seen[$section_key]="$line_number"
+			fi
+		fi
+	done <"$config"
+done < <(find "$UCM_ROOT" -type f -name '*.conf' -print0 | sort -z)
+
+if ((config_count == 0 || section_count == 0)); then
+	printf 'no ALSA UCM sections found under %s\n' "$UCM_ROOT" >&2
+	exit 1
+fi
+
+if ((failed)); then
+	exit 1
+fi
+
+printf 'ALSA UCM duplicate section test passed (%d sections in %d files)\n' \
+	"$section_count" "$config_count"


### PR DESCRIPTION
## Summary

- remove the second duplicate `SectionDevice."Headphones"` block from the Odin 3 UCM profile
- retain the headphone definition routed to `hw:${CardId},1`; the removed copy incorrectly reused speaker PCM `hw:${CardId},0`
- add a regression test that rejects duplicate named device, use-case, and modifier sections in shipped UCM files

## Context

The duplicate was inherited from [AYN's SM8750 UCM contribution](https://github.com/AYNTechnologies/alsa-ucm-conf/commit/52b6ae98b7cd01e35ab6d193f953394dcefe5c0e). Both blocks declare the same UCM device identifier, but point at different PCMs.

This malformed profile may contribute to #120. I have Odin 3 hardware, but it is not currently running Armada, so I could not verify jack detection or routing with this change. This PR therefore references rather than closes that issue; insertion/removal, automatic speaker mute, and headphone playback still need validation on-device under Armada.

## Testing

- regression test failed on the original profile and identified lines 29/48
- `bash tests/alsa-ucm-duplicates-test.sh`
- complete `tests/*-test.sh` loop
- `shfmt --diff tests/alsa-ucm-duplicates-test.sh`
- `git diff --check`

`just` and `shellcheck` were not available in the local environment.