### PR TITLE
External display support patch

### DIFF
--- a/system_files/etc/gamescope-session-plus/sessions.d/steam
+++ b/system_files/etc/gamescope-session-plus/sessions.d/steam
@@ -30,4 +30,4 @@ fi
 
 export STEAM_EXTRA_COMPAT_TOOLS_PATHS="/usr/share/steam/compatibilitytools.d:${HOME}/.local/share/Steam/compatibilitytools.d"
 
-CLIENTCMD='/usr/libexec/armada/launch-steam -gamepadui -steamos3 -steampal -steamdeck -noverifyfiles'
+CLIENTCMD='/usr/libexec/armada/launch-steam -gamepadui -steamos3 -steampal -steamdeck -noverifyfiles -noshaders'

--- a/system_files/etc/gamescope-session-plus/sessions.d/steam
+++ b/system_files/etc/gamescope-session-plus/sessions.d/steam
@@ -1,10 +1,13 @@
 eval "$(/usr/libexec/armada/device-env)"
 
-[[ -n "${ARMADA_PRIMARY_CONNECTOR:-}" ]] && OUTPUT_CONNECTOR="$ARMADA_PRIMARY_CONNECTOR"
+# These variables are not needed.
+# Gamescope determines the settings automatically.
+# In this case, it automatically produces successful results for both DSI-1 and DP-1.
+#[[ -n "${ARMADA_PRIMARY_CONNECTOR:-}" ]] && OUTPUT_CONNECTOR="$ARMADA_PRIMARY_CONNECTOR"
 [[ -n "${ARMADA_PANEL_TYPE:-}" ]] && PANEL_TYPE="$ARMADA_PANEL_TYPE"
-[[ -n "${ARMADA_PANEL_ORIENTATION:-}" ]] && ORIENTATION="$ARMADA_PANEL_ORIENTATION"
-[[ -n "${ARMADA_PANEL_NATIVE_WIDTH:-}" ]] && SCREEN_WIDTH="$ARMADA_PANEL_NATIVE_WIDTH"
-[[ -n "${ARMADA_PANEL_NATIVE_HEIGHT:-}" ]] && SCREEN_HEIGHT="$ARMADA_PANEL_NATIVE_HEIGHT"
+#[[ -n "${ARMADA_PANEL_ORIENTATION:-}" ]] && ORIENTATION="$ARMADA_PANEL_ORIENTATION"
+#[[ -n "${ARMADA_PANEL_NATIVE_WIDTH:-}" ]] && SCREEN_WIDTH="$ARMADA_PANEL_NATIVE_WIDTH"
+#[[ -n "${ARMADA_PANEL_NATIVE_HEIGHT:-}" ]] && SCREEN_HEIGHT="$ARMADA_PANEL_NATIVE_HEIGHT"
 if [[ -n "${ARMADA_PANEL_REFRESH_RATES:-}" ]]; then
     CUSTOM_REFRESH_RATES="$ARMADA_PANEL_REFRESH_RATES"
     IFS=',' read -r -a ARMADA_REFRESH_RATE_LIST <<< "$ARMADA_PANEL_REFRESH_RATES"
@@ -27,4 +30,4 @@ fi
 
 export STEAM_EXTRA_COMPAT_TOOLS_PATHS="/usr/share/steam/compatibilitytools.d:${HOME}/.local/share/Steam/compatibilitytools.d"
 
-CLIENTCMD='/usr/libexec/armada/launch-steam -gamepadui -steamos3 -steampal -steamdeck -noverifyfiles -noshaders'
+CLIENTCMD='/usr/libexec/armada/launch-steam -gamepadui -steamos3 -steampal -steamdeck -noverifyfiles'

--- a/system_files/usr/lib/bootc/kargs.d/10-armada.toml
+++ b/system_files/usr/lib/bootc/kargs.d/10-armada.toml
@@ -8,8 +8,6 @@ kargs = [
     "quiet",
     "loglevel=3",
 
-    "enforcing=0",
-
     "allow_mismatched_32bit_el0",
     "fw_devlink.strict=1",
     "pcie_ports=compat",


### PR DESCRIPTION
I commented out the forced screen output settings, and Gamescope started working perfectly with both the external display and internal screen.
If you wanna test it, check https://github.com/virtudude/armada/issues/29#issuecomment-5058788605, I’ve prepared a test build in my fork, along with a script to switch to the fork and back.

Tested on my Retroid Pocket 6.