### PR TITLE
Feat: add lsfg-vk decky

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,5 @@
 ARG FEX_PKG=ghcr.io/virtudude/armada-packages/fex@sha256:5ac08826823c1228e5d25681c0508b79b01ff301e8c32d2cd5bbe72687615e7a
+ARG LSFG_VK_PKG=ghcr.io/virtudude/armada-packages/lsfg-vk@sha256:3912b6e8d5c98b973df85746ca58aa5c2188e33e3f8abc7e7618bfe284f4ad70
 ARG MESA_PKG=ghcr.io/virtudude/armada-packages/mesa@sha256:1b5bb7dec2d5cbcdbd3f895d3cdb6751c6a3a508b1fcc40e30cf83ad72229bcb
 ARG MANGOHUD_PKG=ghcr.io/virtudude/armada-packages/mangohud@sha256:583278eb4f9b55f6ee25bc1040ad8066d897e75b947ec8f2c73e01a360368e0c
 ARG GAMESCOPE_PKG=ghcr.io/virtudude/armada-packages/gamescope@sha256:d5f2b5ab57ef94e86b58dfbbe9b5ed6e92c20db1732d9a79b466f82dd31fde92
@@ -9,6 +10,7 @@ ARG NETWORKMANAGER_PKG=ghcr.io/virtudude/armada-packages/networkmanager@sha256:1
 ARG JUPITER_HW_SUPPORT_PKG=ghcr.io/virtudude/armada-packages/jupiter-hw-support@sha256:ff4e36a762e3488e1510b45aed1b0ba800962f3d4f9a5c143b483a6530fc27f3
 
 FROM ${FEX_PKG} AS fex
+FROM ${LSFG_VK_PKG} AS lsfg-vk
 FROM ${MESA_PKG} AS mesa
 FROM ${MANGOHUD_PKG} AS mangohud
 FROM ${GAMESCOPE_PKG} AS gamescope
@@ -36,6 +38,7 @@ LABEL org.opencontainers.image.version="${ARMADA_VERSION}"
 
 RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
     --mount=type=bind,from=fex,source=/rpms,target=/packages/fex \
+    --mount=type=bind,from=lsfg-vk,source=/,target=/packages/lsfg-vk \
     --mount=type=bind,from=mesa,source=/rpms,target=/packages/mesa \
     --mount=type=bind,from=mangohud,source=/rpms,target=/packages/mangohud \
     --mount=type=bind,from=gamescope,source=/rpms,target=/packages/gamescope \

--- a/build_files/10-base-packages.sh
+++ b/build_files/10-base-packages.sh
@@ -31,6 +31,7 @@ dnf5 -y install --setopt=install_weak_deps=False \
     rsync \
     curl \
     jq \
+    patch \
     htop \
     lsof \
     scx-scheds \

--- a/build_files/45-install-decky-plugins.sh
+++ b/build_files/45-install-decky-plugins.sh
@@ -11,6 +11,26 @@ rm -f /usr/share/decky-plugins/armada-control/dist/*.map
 find /usr/share/decky-plugins/armada-control -name __pycache__ -type d -prune -exec rm -rf {} +
 chmod 0755 /usr/lib/decky-loader/armada-decky-sync
 
+lsfg_version=0.12.5
+lsfg_url=https://github.com/xXJSONDeruloXx/decky-lsfg-vk/releases/download/v${lsfg_version}/Decky.LSFG-VK.zip
+lsfg_sha256=13b8c8de5744a4fcf300e85971cb0c110f0734cb2db508c8de6309bbf8298a07
+lsfg_archive="$(mktemp)"
+lsfg_extract="$(mktemp -d)"
+
+curl --retry 3 --retry-delay 2 -fL -o "${lsfg_archive}" "${lsfg_url}"
+printf '%s  %s\n' "${lsfg_sha256}" "${lsfg_archive}" | sha256sum -c -
+unzip -q "${lsfg_archive}" -d "${lsfg_extract}"
+
+lsfg_src="${lsfg_extract}/Decky LSFG-VK"
+patch --directory="${lsfg_src}" --strip=1 \
+    < /ctx/decky/decky-lsfg-vk/patches/0001-Adapt-Decky-LSFG-VK-for-Armada.patch
+install -d -m 0755 /usr/share/decky-plugins/decky-lsfg-vk
+cp -a "${lsfg_src}/." /usr/share/decky-plugins/decky-lsfg-vk/
+install -m 0755 /packages/lsfg-vk/liblsfg-vk.so \
+    /usr/share/decky-plugins/decky-lsfg-vk/bin/liblsfg-vk-arm64.so
+rm -rf "${lsfg_extract}"
+rm -f "${lsfg_archive}"
+
 decky_release="$(
     curl --retry 3 --retry-delay 2 -fsSL \
         https://api.github.com/repos/SteamDeckHomebrew/decky-loader/releases |

--- a/build_files/45-install-decky-plugins.sh
+++ b/build_files/45-install-decky-plugins.sh
@@ -24,6 +24,7 @@ unzip -q "${lsfg_archive}" -d "${lsfg_extract}"
 lsfg_src="${lsfg_extract}/Decky LSFG-VK"
 patch --directory="${lsfg_src}" --strip=1 \
     < /ctx/decky/decky-lsfg-vk/patches/0001-Adapt-Decky-LSFG-VK-for-Armada.patch
+sed -i 's/Decky LSFG-VK/Decky LSFG-VK (Armada)/g' "${lsfg_src}/dist/index.js"
 install -d -m 0755 /usr/share/decky-plugins/decky-lsfg-vk
 cp -a "${lsfg_src}/." /usr/share/decky-plugins/decky-lsfg-vk/
 install -m 0755 /packages/lsfg-vk/liblsfg-vk.so \

--- a/decky/decky-lsfg-vk/patches/0001-Adapt-Decky-LSFG-VK-for-Armada.patch
+++ b/decky/decky-lsfg-vk/patches/0001-Adapt-Decky-LSFG-VK-for-Armada.patch
@@ -1,0 +1,69 @@
+From 057881764028bdfacb00e817bafc2249cde74800 Mon Sep 17 00:00:00 2001
+From: JPyke3 <github@pyk.ee>
+Date: Sun, 26 Jul 2026 17:34:22 +1000
+Subject: [PATCH] Adapt Decky LSFG-VK for Armada
+
+---
+ py_modules/lsfg_vk/config_schema.py | 4 ++--
+ py_modules/lsfg_vk/installation.py  | 6 +++---
+ py_modules/lsfg_vk/plugin.py        | 1 +
+ 3 files changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/py_modules/lsfg_vk/config_schema.py b/py_modules/lsfg_vk/config_schema.py
+index 4ab2dcb..ace7f03 100755
+--- a/py_modules/lsfg_vk/config_schema.py
++++ b/py_modules/lsfg_vk/config_schema.py
+@@ -130,8 +130,8 @@ class ConfigurationManager:
+                 logging.getLogger(__name__).debug(f"DLL detection failed: {e}")
+         
+         # If DLL path is still empty, use a reasonable fallback
+-        if not defaults["dll"]:
+-            defaults["dll"] = "/home/deck/.local/share/Steam/steamapps/common/Lossless Scaling/Lossless.dll"
++        if not defaults["dll"] or defaults["dll"] == "/games/Lossless Scaling/Lossless.dll":
++            defaults["dll"] = str(Path.home() / ".local/share/Steam/steamapps/common/Lossless Scaling/Lossless.dll")
+         
+         return defaults
+     
+diff --git a/py_modules/lsfg_vk/installation.py b/py_modules/lsfg_vk/installation.py
+index 4f01be1..3dcfc28 100755
+--- a/py_modules/lsfg_vk/installation.py
++++ b/py_modules/lsfg_vk/installation.py
+@@ -53,7 +53,7 @@ class InstallationService(BaseService):
+             if self._is_arm_architecture():
+                 self.log.info("Detected ARM architecture, using ARM binary")
+                 arm_so_path = plugin_dir / BIN_DIR / ARM_LIB_FILENAME
+-                shutil.copy2(arm_so_path, self.lib_file)
++                shutil.copyfile(arm_so_path, self.lib_file)
+                 self.log.info(f"Overwrote with ARM binary: {self.lib_file}")
+             
+             self._create_config_file()
+@@ -78,7 +78,7 @@ class InstallationService(BaseService):
+         Returns:
+             True if running on ARM (aarch64), False otherwise
+         """
+-        return platform.machine().lower() == 'aarch64'
++        return True
+     
+     def _extract_and_install_files(self, zip_path: Path) -> None:
+         """Extract zip file and install files to appropriate locations
+@@ -117,7 +117,7 @@ class InstallationService(BaseService):
+                             if file_path.suffix == JSON_EXT and file == JSON_FILENAME:
+                                 self._copy_and_fix_json_file(src_file, dst_file)
+                             else:
+-                                shutil.copy2(src_file, dst_file)
++                                shutil.copyfile(src_file, dst_file)
+                             
+                             self.log.info(f"Copied {file} to {dst_file}")
+     
+diff --git a/py_modules/lsfg_vk/plugin.py b/py_modules/lsfg_vk/plugin.py
+index cb59b4f..14c5900 100755
+--- a/py_modules/lsfg_vk/plugin.py
++++ b/py_modules/lsfg_vk/plugin.py
+@@ -418,6 +418,7 @@ class Plugin:
+         Any initialization code should go here.
+         """
+         decky.logger.info("decky-lsfg-vk plugin loaded")
++        self.installation_service.install()
+ 
+     async def _unload(self):
+         """

--- a/decky/decky-lsfg-vk/patches/0001-Adapt-Decky-LSFG-VK-for-Armada.patch
+++ b/decky/decky-lsfg-vk/patches/0001-Adapt-Decky-LSFG-VK-for-Armada.patch
@@ -1,16 +1,28 @@
-From 057881764028bdfacb00e817bafc2249cde74800 Mon Sep 17 00:00:00 2001
+From 8ba24834a871394ac1308dd8ad575d248a2ee7a2 Mon Sep 17 00:00:00 2001
 From: JPyke3 <github@pyk.ee>
-Date: Sun, 26 Jul 2026 17:34:22 +1000
+Date: Mon, 27 Jul 2026 08:49:34 +1000
 Subject: [PATCH] Adapt Decky LSFG-VK for Armada
 
 ---
+ plugin.json                         | 2 +-
  py_modules/lsfg_vk/config_schema.py | 4 ++--
  py_modules/lsfg_vk/installation.py  | 6 +++---
  py_modules/lsfg_vk/plugin.py        | 1 +
- 3 files changed, 6 insertions(+), 5 deletions(-)
+ 4 files changed, 7 insertions(+), 6 deletions(-)
 
+diff --git a/plugin.json b/plugin.json
+index ea49519..1f59aec 100644
+--- a/plugin.json
++++ b/plugin.json
+@@ -1,5 +1,5 @@
+ {
+-  "name": "Decky LSFG-VK",
++  "name": "Decky LSFG-VK (Armada)",
+   "author": "Kurt Himebauch (xXJSONDeruloXx)",
+   "flags": [],
+   "api_version": 1,
 diff --git a/py_modules/lsfg_vk/config_schema.py b/py_modules/lsfg_vk/config_schema.py
-index 4ab2dcb..ace7f03 100755
+index 4ab2dcb..ace7f03 100644
 --- a/py_modules/lsfg_vk/config_schema.py
 +++ b/py_modules/lsfg_vk/config_schema.py
 @@ -130,8 +130,8 @@ class ConfigurationManager:
@@ -25,7 +37,7 @@ index 4ab2dcb..ace7f03 100755
          return defaults
      
 diff --git a/py_modules/lsfg_vk/installation.py b/py_modules/lsfg_vk/installation.py
-index 4f01be1..3dcfc28 100755
+index 4f01be1..3dcfc28 100644
 --- a/py_modules/lsfg_vk/installation.py
 +++ b/py_modules/lsfg_vk/installation.py
 @@ -53,7 +53,7 @@ class InstallationService(BaseService):
@@ -56,7 +68,7 @@ index 4f01be1..3dcfc28 100755
                              self.log.info(f"Copied {file} to {dst_file}")
      
 diff --git a/py_modules/lsfg_vk/plugin.py b/py_modules/lsfg_vk/plugin.py
-index cb59b4f..14c5900 100755
+index cb59b4f..14c5900 100644
 --- a/py_modules/lsfg_vk/plugin.py
 +++ b/py_modules/lsfg_vk/plugin.py
 @@ -418,6 +418,7 @@ class Plugin:


### PR DESCRIPTION
**Note:** Depends on https://github.com/virtudude/armada-packages/pull/11 being merged first!

Adds Decky Lsfg-vk and adds it to the image. 

PR Notes:
* Bundles the official 0.12.5 release.
* Replaces the ARM build with Armada's own Package (Fixes issues with upstream compiling with GCC instead of Clang)
* Tested on AYN thor, everything validated working including frame gen on Outer Wilds