### PR TITLE
Fire wedged-controller repair when an unrelated pad left WINEXINPUT keys

### DIFF
--- a/system_files/usr/libexec/armada/armada-game-launch
+++ b/system_files/usr/libexec/armada/armada-game-launch
@@ -155,7 +155,9 @@ def repair_wedged_controller():
         return
     lines = text.splitlines(keepends=True)
     pad_sections = sum(1 for line in lines if line.startswith("[") and "VID_28DE" in line)
-    if not pad_sections or any("WINEXINPUT" in line for line in lines):
+    # Only a WINEXINPUT key for this same pad proves promotion; an old target's keys outlive it.
+    promoted = any("WINEXINPUT" in line and "VID_28DE" in line for line in lines)
+    if not pad_sections or promoted:
         return  # no pad registered, or it promoted fine - leave the prefix alone
     reg.with_name("system.reg.armada-bak").write_text(
         text, encoding="utf-8", errors="surrogateescape")


### PR DESCRIPTION
## Problem

`repair_wedged_controller()` never fires on the prefixes it exists to repair.

On an AYANEO Pocket EVO, several titles (Crash N-Sane Trilogy, DOOM 2016) launch fine but receive no controller input, while Big Picture and other games work normally. `PROTON_LOG` shows the pad reaching the prefix correctly and then failing to register:

```
hid:lnxev_device_create node "/dev/input/event8", desc {vid 28de, pid 11ff, is_gamepad 1}
hid:bus_create_hid_device desc {vid 28de, pid 11ff, is_gamepad 1}
err:plugplay:enumerate_new_device Failed to create or open device
  L"USB\VID_28DE&PID_11FF&MI_00\0&00000000000011ff28de&0&0&1", error 0xe000020b
```

This is exactly the x86 ↔ arm64ec prefix corruption the fixup targets, but it never ran — no `system.reg.armada-bak` was ever written.

## Cause

```python
if not pad_sections or any("WINEXINPUT" in line for line in lines):
    return
```

The guard accepts *any* `WINEXINPUT` key in the hive as proof the pad promoted. In the affected prefixes every such key belongs to `VID_045E&PID_028E`:

```
[System\ControlSet001\Enum\WINEXINPUT\VID_045E&PID_028E&IG_00\...]
[System\ControlSet001\Enum\WINEXINPUT\VID_045E&PID_028E&XI_00\...]
```

Those are residue from an `xb360` target and outlive the device that created them, so `any(...)` returns `True` and the repair short-circuits on precisely the corrupted prefixes it is meant to clean. Since the instance ID is derived from VID/PID, the collision is deterministic and the prefix can never self-heal — games poll `XInputGetState` on indices 0–3 indefinitely and get nothing.

This looks reachable on AYANEO devices specifically: InputPlumber builds the composite as `xb360` (per `01-ayaneo-controller.yaml`), then `armada-controller-type` re-targets it to `deck-uhid` at boot, seeding the `VID_045E` keys into every prefix created afterwards. AYN devices default straight to `deck-uhid` and never seed them, which would explain why this hasn't shown up elsewhere.

```
Setting target devices: [xb360, keyboard]
Setting target devices: [deck-uhid, keyboard]
```

## Fix

Require the `WINEXINPUT` key to belong to the same pad being repaired. Two-line change, no behaviour change for prefixes that are genuinely healthy.

## Verification

Manually stripping the `VID_28DE` sections restored input immediately on both Crash N-Sane Trilogy and DOOM 2016 on a Pocket EVO. With this patch the repair fires on its own and does the same thing at launch.

## Notes for review

- The silent early-return made this hard to find — worth considering a stderr line when the repair *declines* to run, not just when it fires. Happy to add it here if you want.
- Separately, and out of scope: `controller-type`'s hardcoded `DEFAULT_TYPE = "deck-uhid"` overrides the per-device YAML target, which silently undoes 147ed20 ("Revert AYANEO controller default to xb360") on AYANEO hardware. That is the mechanism seeding the stale `VID_045E` keys. Whether the AYANEO default should be `xb360` is your call, but the config precedence looks unintentional.
