### PR TITLE
Map Pocket EVO AYA SPACE, =, LC and RC buttons

### DIFF
--- a/system_files/usr/share/inputplumber/capability_maps/ayaneo_pocket_evo_keys.yaml
+++ b/system_files/usr/share/inputplumber/capability_maps/ayaneo_pocket_evo_keys.yaml
@@ -1,0 +1,65 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/capability_map_v2.json
+# Schema version number
+version: 2
+
+# The type of configuration schema
+kind: CapabilityMap
+
+# Name for the device event map
+name: AYANEO Pocket EVO GPIO Keys
+
+# Unique identifier of the capability mapping
+id: ayaneo_pocket_evo_keys
+
+# The Pocket EVO wires AYA SPACE, =, LC and RC directly to SoC GPIOs instead of
+# the controller MCU, so they arrive on their own gpio-keys node rather than on
+# the fake-Xbox-360 pad. The F13-F16 codes come from armada's aya-keys device
+# tree node; AYANEO's stock codes (KEY_A, KEY_EQUAL, KEY_LEFT, KEY_RIGHTSHIFT)
+# are deliberately not reused, since those type text if they ever reach a
+# compositor with InputPlumber stopped.
+#
+# Only AYA SPACE is hardcoded: QuickAccess is the one action Steam Input cannot
+# bind. The rest become paddles so they stay remappable per game.
+mapping:
+  - name: AYA SPACE
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: KEY_F13
+          value_type: button
+    target_event:
+      gamepad:
+        button: QuickAccess
+
+  - name: Menu (=)
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: KEY_F14
+          value_type: button
+    target_event:
+      gamepad:
+        button: LeftPaddle2
+
+  - name: LC
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: KEY_F15
+          value_type: button
+    target_event:
+      gamepad:
+        button: LeftPaddle1
+
+  - name: RC
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: KEY_F16
+          value_type: button
+    target_event:
+      gamepad:
+        button: RightPaddle1
+
+# List of events to filter from the source devices
+filtered_events: []

--- a/system_files/usr/share/inputplumber/devices/01-ayaneo-controller.yaml
+++ b/system_files/usr/share/inputplumber/devices/01-ayaneo-controller.yaml
@@ -46,6 +46,15 @@ source_devices:
       product_id: "028e"
       handler: event*
     capability_map_id: ayaneo_mcu_xbox
+  # Pocket EVO only: AYA SPACE, =, LC and RC hang off SoC GPIOs, not the MCU, so
+  # they arrive on the separate aya-keys gpio-keys node. Kept out of the main
+  # gpio-keys node on purpose - InputPlumber grabs its source devices, which
+  # would otherwise swallow volume up.
+  - group: keyboard
+    evdev:
+      name: aya-keys
+      handler: event*
+    capability_map_id: ayaneo_pocket_evo_keys
 
 # Optional configuration for the composite device
 options:


### PR DESCRIPTION
These four buttons are wired to SoC GPIOs rather than to the controller MCU, so they never appear on the fake-Xbox-360 pad and were unmapped. They arrive instead on their own gpio-keys node, which the kernel only creates once the device tree declares it.

Kept out of the existing gpio-keys node deliberately: InputPlumber grabs the source devices it manages, so sharing that node would swallow volume up.

The device tree emits F13-F16 rather than AYANEO's stock KEY_A, KEY_EQUAL, KEY_LEFT and KEY_RIGHTSHIFT. Those type real characters, so any moment InputPlumber is not grabbing the node - desktop mode, a service restart - they would leak into whatever has focus.

Only AYA SPACE is bound to a fixed action, since QuickAccess is the one thing Steam Input cannot bind. The other three become paddles so they stay remappable per game.

Needs the matching aya-keys node in qcs8550-ayaneo-pocketevo.dts; until that lands nothing matches "aya-keys" and this config is inert.

Verified on hardware by patching the DTB in place and reading the emulated Steam Controller's HID reports: AYA SPACE opens QAM, and =, LC and RC report as L5, L4 and R4.