### PR TITLE
fix(fan_curves): reduce heat SM8550 issue #175

### DIFF
--- a/system_files/usr/share/armada/power-profiles.conf
+++ b/system_files/usr/share/armada/power-profiles.conf
@@ -13,11 +13,11 @@ fan_curve=relaxed
 [profile.balanced]
 label=Balanced
 cpu_governor=schedutil
-cpu_max=0.65
+cpu_max=0.85
 cpu_underclock=medium
 gpu_max=1.0
-gpu_min=0.60
-fan_curve=moderate
+gpu_min=0.5
+fan_curve=aggressive
 
 [profile.performance]
 label=Performance
@@ -38,7 +38,7 @@ curve=96:255,90:204,84:153,78:102,72:77,55:51,0:51
 
 [fan_curve.aggressive]
 label=Aggressive
-curve=90:255,85:204,80:153,74:102,66:77,45:51,0:51
+curve=90:255,85:255,80:255,70:255,65:150,60:100,50:75,30:51,0:51
 
 [fan]
 min_pwm=51
@@ -59,9 +59,9 @@ cpu_max_policy3=2323200
 cpu_max_policy7=2476800
 
 [underclock.SM8550.medium]
-cpu_max_policy0=1555200
+cpu_max_policy0=1655200
 cpu_max_policy3=2054400
-cpu_max_policy7=2092800
+cpu_max_policy7=2192800
 
 [underclock.SM8550.large]
 cpu_max_policy0=1459200


### PR DESCRIPTION
This fix improves aggressive fan curves to be really aggressive. Additionally changes balanced profile definitions and increases a little SM8550 clocks under medium underclock. Tested on AYN Thor and reduced around 10 degrees even under load (max 70-75 degrees). Battery life was not affected by the changes.