### PR TITLE
feat: add CPU turbo boost toggle

### DIFF
--- a/decky/armada-control/main.py
+++ b/decky/armada-control/main.py
@@ -9,7 +9,7 @@ from armada_control.calibration import (
 )
 from armada_control.config import build_config
 from armada_control.controller import set_controller_type
-from armada_control.power import save_power_config
+from armada_control.power import save_power_config, set_cpu_boost_enabled
 from armada_control.steam import installed_games
 from armada_control.system import set_ssh_enabled
 from armada_control.tweaks import load_compat_applied, save_compat_applied, save_tweaks
@@ -25,6 +25,10 @@ class Plugin:
 
     async def save_power_config(self, data):
         await asyncio.to_thread(save_power_config, data)
+        return await self.get_config()
+
+    async def set_cpu_boost_enabled(self, enabled):
+        await asyncio.to_thread(set_cpu_boost_enabled, enabled)
         return await self.get_config()
 
     async def save_tweaks(self, data):

--- a/decky/armada-control/py_modules/armada_control/config.py
+++ b/decky/armada-control/py_modules/armada_control/config.py
@@ -1,5 +1,5 @@
 from .controller import CONTROLLER_TYPES, controller_type
-from .power import factory_power_defaults, parse_power
+from .power import cpu_boost_state, factory_power_defaults, parse_power
 from .steam import installed_games
 from .system import cpu_device_class, os_version, ssh_enabled
 from .tweaks import fex_profile_labels, load_fex_contract, load_tweaks
@@ -14,6 +14,7 @@ def build_config(include_games=True):
         "installedGames": installed_games() if include_games else [],
         "fexProfiles": fex_profile_labels(fex_contract),
         "cpuDeviceClass": cpu_device_class(),
+        "cpuBoost": cpu_boost_state(),
         "osVersion": os_version(),
         "sshEnabled": ssh_enabled(),
         "controllerType": controller_type(),

--- a/decky/armada-control/py_modules/armada_control/power.py
+++ b/decky/armada-control/py_modules/armada_control/power.py
@@ -1,4 +1,5 @@
 import configparser
+import subprocess
 import shutil
 import tempfile
 import time
@@ -9,10 +10,51 @@ from .privileged import call
 POWER_CONFIG = Path("/etc/armada/power-profiles.conf")
 FACTORY_POWER_CONFIG = Path("/usr/share/armada/power-profiles.conf")
 PROFILES = ("eco", "balanced", "performance")
+POWER_CLI = "/usr/bin/armada-power"
 
 
 def default_label(name):
     return name.replace("_", " ").title()
+
+
+def power_status():
+    try:
+        proc = subprocess.run(
+            [POWER_CLI, "status"],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return {}
+    data = {}
+    for line in proc.stdout.splitlines():
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        data[key] = value
+    return data
+
+
+def cpu_boost_state():
+    status = power_status()
+    return {
+        "available": status.get("cpu_boost_available") == "True",
+        "enabled": status.get("cpu_boost_enabled") == "True",
+    }
+
+
+def set_cpu_boost_enabled(enabled):
+    subprocess.run(
+        [POWER_CLI, "boost", "on" if enabled else "off"],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=10,
+    )
+    return cpu_boost_state()
 
 
 def restore_factory_power_config(reason):

--- a/decky/armada-control/src/backend.ts
+++ b/decky/armada-control/src/backend.ts
@@ -4,6 +4,7 @@ import type { CalibrationState, Capture, Config, InstalledGame, PowerConfig, Twe
 export const getConfig = () => call<[], Config>("get_config");
 export const getInstalledGames = () => call<[], InstalledGame[]>("get_installed_games");
 export const savePowerConfig = (data: PowerConfig) => call<[PowerConfig], Config>("save_power_config", data);
+export const setCpuBoostEnabled = (enabled: boolean) => call<[boolean], Config>("set_cpu_boost_enabled", enabled);
 export const saveTweaks = (data: Tweaks) => call<[Tweaks], Config>("save_tweaks", data);
 export const getCompatApplied = () => call<[], string[]>("get_compat_applied");
 let compatAppliedSaveChain = Promise.resolve<unknown>(undefined);

--- a/decky/armada-control/src/tabs/Power.tsx
+++ b/decky/armada-control/src/tabs/Power.tsx
@@ -1,7 +1,8 @@
 import { ButtonItem, PanelSection } from "@decky/ui";
 import { useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
-import { SelectEdit, SliderEdit } from "../components/widgets";
+import { setCpuBoostEnabled as applyCpuBoostEnabled } from "../backend";
+import { SelectEdit, SliderEdit, ToggleRow } from "../components/widgets";
 import { clone, titleCase, update } from "../lib/util";
 import type { Config, PowerProfile } from "../types";
 
@@ -46,6 +47,17 @@ export function Power({ config, setConfig }: { config: Config; setConfig: Dispat
     if (!defaults) return;
     setConfig((current) => (current ? update(current, ["power", "profiles", profile], defaults) : current));
   };
+  const setCpuBoostEnabled = async (enabled: boolean) => {
+    const previous = !!config.cpuBoost?.enabled;
+    if (enabled === previous) return;
+    setConfig((current) => (current ? update(current, ["cpuBoost", "enabled"], enabled) : current));
+    try {
+      const next = await applyCpuBoostEnabled(enabled);
+      setConfig(next);
+    } catch (error) {
+      setConfig((current) => (current ? update(current, ["cpuBoost", "enabled"], previous) : current));
+    }
+  };
   const underclockLevel = p.cpu_underclock || "";
   const supportsUnderclockPresets = !!config.power.underclocks?.[config.cpuDeviceClass];
   return (
@@ -54,6 +66,13 @@ export function Power({ config, setConfig }: { config: Config; setConfig: Dispat
         <SelectEdit value={profile} options={profiles} onChange={setProfile} />
       </PanelSection>
       <PanelSection title="PROFILE SETTINGS">
+        <ToggleRow
+          label="CPU Turbo Boost"
+          value={!!config.cpuBoost?.enabled}
+          disabled={!config.cpuBoost?.available}
+          description={config.cpuBoost?.available ? "Allow the CPU to use boost frequencies." : "CPU boost control is not available on this device."}
+          onChange={setCpuBoostEnabled}
+        />
         <SelectEdit label="Fan Curve" value={p.fan_curve} options={fanCurves} onChange={(v) => setProfileValue("fan_curve", v)} />
         {supportsUnderclockPresets ? (
           <SelectEdit label="CPU Underclock" value={underclockLevel} options={underclocks} onChange={(v) => setProfileValue("cpu_underclock", v)} />

--- a/decky/armada-control/src/types.ts
+++ b/decky/armada-control/src/types.ts
@@ -70,6 +70,11 @@ export interface GameRef {
   name: string;
 }
 
+export interface CpuBoostState {
+  available: boolean;
+  enabled: boolean;
+}
+
 export interface Config {
   power: PowerConfig;
   powerDefaults: PowerConfig;
@@ -77,6 +82,7 @@ export interface Config {
   installedGames: InstalledGame[];
   fexProfiles: Record<string, FexProfile>;
   cpuDeviceClass: string;
+  cpuBoost: CpuBoostState;
   osVersion: string;
   sshEnabled: boolean;
   controllerType: string;

--- a/system_files/usr/bin/armada-power
+++ b/system_files/usr/bin/armada-power
@@ -80,6 +80,8 @@ def status():
         "fan_rpm",
         "temperature",
         "suspended",
+        "cpu_boost_available",
+        "cpu_boost_enabled",
     ):
         value = data[key].unpack() if hasattr(data[key], "unpack") else data[key]
         print(f"{key}={value}")
@@ -91,7 +93,7 @@ def call_method(name):
 
 def usage():
     print(
-        "Usage: armada-power status|reload|profile [name]|gpu-auto|gpu-manual <mhz>|suspend|resume",
+        "Usage: armada-power status|reload|profile [name]|gpu-auto|gpu-manual <mhz>|boost [on|off]|suspend|resume",
         file=sys.stderr,
     )
     return 2
@@ -118,6 +120,18 @@ def main():
         set_prop("GpuPerformanceLevel", GLib.Variant("s", "manual"))
         set_prop("ManualGpuClock", GLib.Variant("u", int(sys.argv[2])))
         return 0
+    if cmd == "boost":
+        if len(sys.argv) == 2:
+            print("on" if get_prop("CpuBoostEnabled") else "off")
+            return 0
+        value = sys.argv[2].strip().lower()
+        if value in ("1", "on", "true", "yes", "enable", "enabled"):
+            set_prop("CpuBoostEnabled", GLib.Variant("b", True))
+            return 0
+        if value in ("0", "off", "false", "no", "disable", "disabled"):
+            set_prop("CpuBoostEnabled", GLib.Variant("b", False))
+            return 0
+        return usage()
     if cmd == "suspend":
         call_method("Suspend")
         return 0

--- a/system_files/usr/libexec/armada/armada-powerd
+++ b/system_files/usr/libexec/armada/armada-powerd
@@ -48,6 +48,8 @@ XML = f"""
     <property name="ManualGpuClock" type="u" access="readwrite"/>
     <property name="ManualGpuClockMin" type="u" access="read"/>
     <property name="ManualGpuClockMax" type="u" access="read"/>
+    <property name="CpuBoostAvailable" type="b" access="read"/>
+    <property name="CpuBoostEnabled" type="b" access="readwrite"/>
     <property name="FanMode" type="s" access="read"/>
     <property name="FanPwm" type="u" access="read"/>
     <property name="FanRpm" type="u" access="read"/>
@@ -184,6 +186,7 @@ class ArmadaPower:
         self.profile = ""
         self.gpu_level = "auto"
         self.manual_gpu_clock = 0
+        self.cpu_boost_enabled = None
         self.smoothed_temp = 0.0
         self.last_pwm = 0
         self.suspended = False
@@ -198,6 +201,8 @@ class ArmadaPower:
             current = read_text(self.fan_pwm)
             self.last_pwm = int(current) if current.isdigit() else self.fan_config["min_pwm"]
         self.apply_profile()
+        if self.cpu_boost_enabled is not None:
+            self.set_cpu_boost(self.cpu_boost_enabled)
         if self.gpu_level == "manual" and self.manual_gpu_clock:
             self.set_gpu_manual_clock(self.manual_gpu_clock)
         self.fan_tick()
@@ -397,6 +402,8 @@ class ArmadaPower:
                 self.gpu_level = value
             elif key == "manual_gpu_clock" and value.isdigit():
                 self.manual_gpu_clock = int(value)
+            elif key == "cpu_boost_enabled" and value in ("0", "1"):
+                self.cpu_boost_enabled = value == "1"
 
     def save_state(self):
         STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
@@ -404,6 +411,7 @@ class ArmadaPower:
             f"profile={self.profile}\n"
             f"gpu_level={self.gpu_level}\n"
             f"manual_gpu_clock={self.manual_gpu_clock}\n"
+            f"cpu_boost_enabled={1 if self.cpu_boost_current() else 0}\n"
         )
 
     def gpu_freqs(self):
@@ -420,6 +428,41 @@ class ArmadaPower:
         if low.isdigit() and high.isdigit():
             return [int(low), int(high)]
         return []
+
+    def cpu_boost_paths(self):
+        global_boost = Path("/sys/devices/system/cpu/cpufreq/boost")
+        if global_boost.exists():
+            # On Qualcomm/Pocket DS, the global node is the authoritative control;
+            # writing per-policy boost nodes can return EINVAL for clusters that do
+            # not support boost independently.
+            return [global_boost]
+        paths = []
+        for policy in self.cpu_policies:
+            boost = policy / "boost"
+            if boost.exists():
+                paths.append(boost)
+        # Preserve order while removing duplicates from policy symlinks.
+        return list(dict.fromkeys(paths))
+
+    def cpu_boost_available(self):
+        return bool(self.cpu_boost_paths())
+
+    def cpu_boost_current(self):
+        paths = self.cpu_boost_paths()
+        if not paths:
+            return False
+        # If any boost control is still enabled, report boost as enabled.
+        return any(read_text(path) not in ("", "0") for path in paths)
+
+    def set_cpu_boost(self, enabled):
+        paths = self.cpu_boost_paths()
+        if not paths:
+            raise RuntimeError("CPU boost control is not available")
+        value = "1" if enabled else "0"
+        for path in paths:
+            write_text(path, value)
+        self.cpu_boost_enabled = enabled
+        return self.cpu_boost_current()
 
     def closest(self, freqs, target):
         return min(freqs, key=lambda freq: abs(freq - target)) if freqs else 0
@@ -718,6 +761,10 @@ class ArmadaPower:
             return GLib.Variant("u", freqs[0] // 1000000 if freqs else 0)
         if prop == "ManualGpuClockMax":
             return GLib.Variant("u", freqs[-1] // 1000000 if freqs else 0)
+        if prop == "CpuBoostAvailable":
+            return GLib.Variant("b", self.cpu_boost_available())
+        if prop == "CpuBoostEnabled":
+            return GLib.Variant("b", self.cpu_boost_current())
         if prop == "FanMode":
             return GLib.Variant("s", "managed" if self.fan_pwm else "unavailable")
         if prop == "FanPwm":
@@ -756,6 +803,10 @@ class ArmadaPower:
             if self.gpu_level == "manual":
                 mhz = self.set_gpu_manual_clock(mhz)
             changed["ManualGpuClock"] = GLib.Variant("u", mhz)
+        elif prop == "CpuBoostEnabled":
+            enabled = value.get_boolean()
+            applied = self.set_cpu_boost(enabled)
+            changed["CpuBoostEnabled"] = GLib.Variant("b", applied)
         else:
             raise KeyError(prop)
         self.save_state()
@@ -774,6 +825,8 @@ class ArmadaPower:
             "manual_gpu_clock": self.get_property("ManualGpuClock"),
             "manual_gpu_clock_min": self.get_property("ManualGpuClockMin"),
             "manual_gpu_clock_max": self.get_property("ManualGpuClockMax"),
+            "cpu_boost_available": self.get_property("CpuBoostAvailable"),
+            "cpu_boost_enabled": self.get_property("CpuBoostEnabled"),
             "fan_mode": self.get_property("FanMode"),
             "fan_pwm": self.get_property("FanPwm"),
             "fan_rpm": self.get_property("FanRpm"),
@@ -800,6 +853,8 @@ class ArmadaPower:
                 self.discover()
                 self.apply_underclock_refs()
                 self.apply_profile()
+                if self.cpu_boost_enabled is not None:
+                    self.set_cpu_boost(self.cpu_boost_enabled)
                 if self.gpu_level == "manual" and self.manual_gpu_clock:
                     self.set_gpu_manual_clock(self.manual_gpu_clock)
             except Exception as exc:


### PR DESCRIPTION
## Summary
- Add CPU boost/turbo controls to `armada-powerd` and expose them via D-Bus status/properties
- Add `armada-power boost [on|off]` CLI support
- Surface a Decky Power tab toggle that disables itself when the device has no CPU boost sysfs control

## Test Plan
- `python3 -m py_compile system_files/usr/libexec/armada/armada-powerd system_files/usr/bin/armada-power decky/armada-control/main.py decky/armada-control/py_modules/armada_control/*.py`
- `cd decky/armada-control && npm install && npm run build`
- Direct shell equivalent of `just test` because `just` is not installed on this VM:
  ```bash
  shopt -s nullglob
  for test_file in tests/*-test.sh; do
    bash "$test_file"
  done
  ```
