### PR TITLE
Prototype touchscreen trackpad mode

### DIFF
--- a/build_files/10-base-packages.sh
+++ b/build_files/10-base-packages.sh
@@ -24,6 +24,7 @@ dnf5 -y install --setopt=install_weak_deps=False \
     bluez \
     dbus-broker \
     python3-gobject \
+    python3-evdev \
     python3-websocket-client \
     polkit \
     upower \

--- a/build_files/40-vendor-system-files.sh
+++ b/build_files/40-vendor-system-files.sh
@@ -35,6 +35,7 @@ systemctl enable sddm.service
 systemctl enable armada-session-default.service
 systemctl enable seatd.service
 systemctl enable armada-input-calibration.service
+systemctl enable armada-touchscreen-trackpad.service
 systemctl enable armada-controller-type.service
 systemctl enable inputplumber.service
 systemctl enable armada-device-quirks.service

--- a/decky/armada-control/main.py
+++ b/decky/armada-control/main.py
@@ -12,6 +12,7 @@ from armada_control.controller import set_controller_type
 from armada_control.power import save_power_config
 from armada_control.steam import installed_games
 from armada_control.system import set_ssh_enabled
+from armada_control.touchscreen import set_touchscreen_mode
 from armada_control.tweaks import load_compat_applied, save_compat_applied, save_tweaks
 
 
@@ -42,6 +43,9 @@ class Plugin:
 
     async def set_controller_type(self, value):
         return await asyncio.to_thread(set_controller_type, value)
+
+    async def set_touchscreen_mode(self, value):
+        return await asyncio.to_thread(set_touchscreen_mode, value)
 
     async def get_controller_state(self):
         return await asyncio.to_thread(controller_state)

--- a/decky/armada-control/py_modules/armada_control/config.py
+++ b/decky/armada-control/py_modules/armada_control/config.py
@@ -2,6 +2,7 @@ from .controller import CONTROLLER_TYPES, controller_type
 from .power import factory_power_defaults, parse_power
 from .steam import installed_games
 from .system import cpu_device_class, os_version, ssh_enabled
+from .touchscreen import touchscreen_mode
 from .tweaks import fex_profile_labels, load_fex_contract, load_tweaks
 
 
@@ -18,4 +19,5 @@ def build_config(include_games=True):
         "sshEnabled": ssh_enabled(),
         "controllerType": controller_type(),
         "controllerTypes": [{"data": key, "label": label} for key, label in CONTROLLER_TYPES.items()],
+        "touchscreenMode": touchscreen_mode(),
     }

--- a/decky/armada-control/py_modules/armada_control/touchscreen.py
+++ b/decky/armada-control/py_modules/armada_control/touchscreen.py
@@ -1,0 +1,20 @@
+from .privileged import call
+
+DEFAULT_MODE = "direct"
+TOUCHSCREEN_MODES = {"direct", "trackpad"}
+
+
+def touchscreen_mode():
+    try:
+        value = str(call("get_touchscreen_mode").get("value") or "")
+    except Exception:
+        return DEFAULT_MODE
+    return value if value in TOUCHSCREEN_MODES else DEFAULT_MODE
+
+
+def set_touchscreen_mode(value):
+    if value not in TOUCHSCREEN_MODES:
+        raise ValueError("invalid touchscreen mode")
+    return str(
+        call("set_touchscreen_mode", value=value).get("value") or touchscreen_mode()
+    )

--- a/decky/armada-control/src/backend.ts
+++ b/decky/armada-control/src/backend.ts
@@ -17,6 +17,8 @@ export const saveCompatApplied = (appids: string[]) => {
 };
 export const setSshEnabled = (enabled: boolean) => call<[boolean], boolean>("set_ssh_enabled", enabled);
 export const setControllerType = (value: string) => call<[string], string>("set_controller_type", value);
+export const setTouchscreenMode = (value: string) =>
+  call<[string], string>("set_touchscreen_mode", value);
 export const getControllerState = () => call<[], CalibrationState>("get_controller_state");
 export const saveCalibration = (capture: Capture) => call<[Capture], CalibrationState>("save_calibration", capture);
 export const resetCalibration = () => call<[], CalibrationState>("reset_calibration");

--- a/decky/armada-control/src/tabs/Settings.tsx
+++ b/decky/armada-control/src/tabs/Settings.tsx
@@ -1,6 +1,10 @@
 import { ButtonItem, Field, PanelSection } from "@decky/ui";
 import type { Dispatch, SetStateAction } from "react";
-import { setControllerType as applyControllerType, setSshEnabled as applySshEnabled } from "../backend";
+import {
+  setControllerType as applyControllerType,
+  setSshEnabled as applySshEnabled,
+  setTouchscreenMode as applyTouchscreenMode,
+} from "../backend";
 import { openCalibration } from "../components/Calibration";
 import { SelectEdit, ToggleRow } from "../components/widgets";
 import type { Config } from "../types";
@@ -31,8 +35,27 @@ export function Settings({ config, setConfig }: {
       setConfig((current) => (current ? { ...current, controllerType: previous } : current));
     }
   };
+  const setTouchscreenMode = async (enabled: boolean) => {
+    const previous = config.touchscreenMode || "direct";
+    const value = enabled ? "trackpad" : "direct";
+    setConfig((current) => (current ? { ...current, touchscreenMode: value } : current));
+    try {
+      const applied = await applyTouchscreenMode(value);
+      setConfig((current) => (current ? { ...current, touchscreenMode: applied } : current));
+    } catch (error) {
+      setConfig((current) => (current ? { ...current, touchscreenMode: previous } : current));
+    }
+  };
   return (
     <>
+      <PanelSection title="Input">
+        <ToggleRow
+          label="Touchscreen Trackpad"
+          description="Move with one finger, tap to left-click, or tap with two fingers to right-click."
+          value={config.touchscreenMode === "trackpad"}
+          onChange={setTouchscreenMode}
+        />
+      </PanelSection>
       <PanelSection title="Controller">
         <SelectEdit
           label="Emulation"

--- a/decky/armada-control/src/types.ts
+++ b/decky/armada-control/src/types.ts
@@ -81,6 +81,7 @@ export interface Config {
   sshEnabled: boolean;
   controllerType: string;
   controllerTypes: DropdownChoice[];
+  touchscreenMode: string;
   calibration?: CalibrationState;
   game?: GameRef | null;
   selectedGame?: GameRef | null;

--- a/system_files/usr/lib/armada/touchscreen_trackpad.py
+++ b/system_files/usr/lib/armada/touchscreen_trackpad.py
@@ -1,0 +1,134 @@
+"""Gesture state machine for Armada's touchscreen trackpad mode."""
+
+from dataclasses import dataclass
+import math
+
+
+def orient_coordinates(x, y, orientation):
+    """Rotate native-panel coordinates into the displayed orientation."""
+    if orientation == "left":
+        return y, 1.0 - x
+    if orientation == "right":
+        return 1.0 - y, x
+    if orientation == "inverted":
+        return 1.0 - x, 1.0 - y
+    return x, y
+
+
+@dataclass
+class Contact:
+    start_x: float
+    start_y: float
+    x: float
+    y: float
+
+
+class TouchpadGestureEngine:
+    """Translate normalized touch contacts into relative mouse gestures.
+
+    The sink must provide ``move(dx, dy)`` and ``button(name, pressed)``.
+    Coordinates passed to this class are normalized to the range 0..1.
+    """
+
+    def __init__(
+        self,
+        sink,
+        *,
+        motion_counts=1400,
+        tap_seconds=0.25,
+        double_tap_seconds=0.35,
+        tap_move_threshold=0.018,
+    ):
+        self.sink = sink
+        self.motion_counts = motion_counts
+        self.tap_seconds = tap_seconds
+        self.double_tap_seconds = double_tap_seconds
+        self.tap_move_threshold = tap_move_threshold
+        self.contacts = {}
+        self.session_started = None
+        self.session_max_contacts = 0
+        self.session_moved = False
+        self.last_single_tap = None
+        self.dragging = False
+        self.x_remainder = 0.0
+        self.y_remainder = 0.0
+
+    def touch_down(self, slot, x, y, timestamp):
+        if slot in self.contacts:
+            return
+        if not self.contacts:
+            self.session_started = timestamp
+            self.session_max_contacts = 0
+            self.session_moved = False
+            if (
+                self.last_single_tap is not None
+                and timestamp - self.last_single_tap <= self.double_tap_seconds
+            ):
+                self.dragging = True
+                self.last_single_tap = None
+                self.sink.button("left", True)
+            elif self.last_single_tap is not None:
+                self.last_single_tap = None
+        self.contacts[slot] = Contact(x, y, x, y)
+        self.session_max_contacts = max(self.session_max_contacts, len(self.contacts))
+
+    def touch_move(self, slot, x, y, timestamp):
+        del timestamp
+        contact = self.contacts.get(slot)
+        if contact is None:
+            return
+        dx = x - contact.x
+        dy = y - contact.y
+        contact.x = x
+        contact.y = y
+        if math.hypot(x - contact.start_x, y - contact.start_y) > self.tap_move_threshold:
+            self.session_moved = True
+        if len(self.contacts) != 1:
+            return
+        self.x_remainder += dx * self.motion_counts
+        self.y_remainder += dy * self.motion_counts
+        move_x = math.trunc(self.x_remainder)
+        move_y = math.trunc(self.y_remainder)
+        self.x_remainder -= move_x
+        self.y_remainder -= move_y
+        if move_x or move_y:
+            self.sink.move(move_x, move_y)
+
+    def touch_up(self, slot, timestamp):
+        if self.contacts.pop(slot, None) is None or self.contacts:
+            return
+        if self.dragging:
+            self.sink.button("left", False)
+            self.dragging = False
+            self._finish_session()
+            return
+        duration = timestamp - self.session_started if self.session_started is not None else 0
+        if duration <= self.tap_seconds and not self.session_moved:
+            if self.session_max_contacts == 1:
+                self._click("left")
+                self.last_single_tap = timestamp
+            elif self.session_max_contacts >= 2:
+                self._click("right")
+                self.last_single_tap = None
+        else:
+            self.last_single_tap = None
+        self._finish_session()
+
+    def reset(self):
+        if self.dragging:
+            self.sink.button("left", False)
+        self.contacts.clear()
+        self.dragging = False
+        self.last_single_tap = None
+        self.x_remainder = 0.0
+        self.y_remainder = 0.0
+        self._finish_session()
+
+    def _click(self, name):
+        self.sink.button(name, True)
+        self.sink.button(name, False)
+
+    def _finish_session(self):
+        self.session_started = None
+        self.session_max_contacts = 0
+        self.session_moved = False

--- a/system_files/usr/lib/systemd/system/armada-touchscreen-trackpad.service
+++ b/system_files/usr/lib/systemd/system/armada-touchscreen-trackpad.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Armada touchscreen trackpad emulator
+After=systemd-udevd.service
+
+[Service]
+Type=simple
+ExecStart=/usr/libexec/armada/touchscreen-trackpad
+Restart=on-failure
+RestartSec=2
+TimeoutStopSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/system_files/usr/libexec/armada/armada-control
+++ b/system_files/usr/libexec/armada/armada-control
@@ -11,6 +11,7 @@ SOCKET = Path("/run/armada/control.sock")
 MAX_REQUEST = 1024 * 1024
 CLIENT_TIMEOUT = 5
 CONTROLLER_TYPES = {"deck-uhid", "xb360", "ds5"}
+TOUCHSCREEN_MODES = {"direct", "trackpad"}
 INTERCEPT_MODES = {"overlay", "reset"}
 CONFIG_PATHS = {
     "power": Path("/etc/armada/power-profiles.conf"),
@@ -18,6 +19,7 @@ CONFIG_PATHS = {
     "calibration": Path("/etc/armada/input-calibration.json"),
     "compat-applied": Path("/var/lib/armada/compat-applied.json"),
 }
+TOUCHSCREEN_MODE_PATH = Path("/etc/armada/touchscreen-mode.conf")
 CALIBRATION_PARAMS = (
     "axis_leftx_min",
     "axis_leftx_center",
@@ -107,6 +109,27 @@ def action_get_controller_type(request):
     return {"value": result}
 
 
+def touchscreen_mode():
+    try:
+        value = TOUCHSCREEN_MODE_PATH.read_text(encoding="utf-8").strip()
+    except OSError:
+        return "direct"
+    return value if value in TOUCHSCREEN_MODES else "direct"
+
+
+def action_set_touchscreen_mode(request):
+    value = str(request.get("value", ""))
+    if value not in TOUCHSCREEN_MODES:
+        raise ValueError("invalid touchscreen mode")
+    atomic_write(TOUCHSCREEN_MODE_PATH, value + "\n")
+    run(["/usr/bin/systemctl", "restart", "armada-touchscreen-trackpad.service"])
+    return {"value": touchscreen_mode()}
+
+
+def action_get_touchscreen_mode(request):
+    return {"value": touchscreen_mode()}
+
+
 def action_set_ssh_enabled(request):
     enabled = bool(request.get("enabled"))
     action = "enable" if enabled else "disable"
@@ -155,6 +178,8 @@ def action_write_config(request):
 ACTIONS = {
     "set_controller_type": action_set_controller_type,
     "get_controller_type": action_get_controller_type,
+    "set_touchscreen_mode": action_set_touchscreen_mode,
+    "get_touchscreen_mode": action_get_touchscreen_mode,
     "get_device_env": action_get_device_env,
     "get_ssh_enabled": action_get_ssh_enabled,
     "inputplumber_intercept": action_inputplumber_intercept,

--- a/system_files/usr/libexec/armada/touchscreen-trackpad
+++ b/system_files/usr/libexec/armada/touchscreen-trackpad
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Turn the primary touchscreen into a relative virtual mouse when enabled."""
+
+import shlex
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from evdev import InputDevice, UInput, ecodes, list_devices
+
+sys.path.insert(0, "/usr/lib/armada")
+from touchscreen_trackpad import TouchpadGestureEngine, orient_coordinates  # noqa: E402
+
+
+MODE_FILE = Path("/etc/armada/touchscreen-mode.conf")
+VIRTUAL_DEVICE_NAME = "Armada Touchscreen Trackpad"
+
+
+def configured_mode():
+    try:
+        mode = MODE_FILE.read_text(encoding="utf-8").strip()
+    except OSError:
+        return "direct"
+    return mode if mode in {"direct", "trackpad"} else "direct"
+
+
+def device_environment():
+    try:
+        output = subprocess.check_output(
+            ["/usr/libexec/armada/device-env"], text=True, timeout=3
+        )
+    except (OSError, subprocess.SubprocessError):
+        return {}
+    environment = {}
+    for line in output.splitlines():
+        if "=" not in line:
+            continue
+        name, value = line.split("=", 1)
+        try:
+            parsed = shlex.split(value)
+        except ValueError:
+            environment[name] = value
+        else:
+            environment[name] = parsed[0] if parsed else ""
+    return environment
+
+
+def is_touchscreen(path):
+    try:
+        result = subprocess.run(
+            ["udevadm", "info", "--query=property", "--name", path],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=3,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    properties = dict(
+        line.split("=", 1) for line in result.stdout.splitlines() if "=" in line
+    )
+    return properties.get("ID_INPUT_TOUCHSCREEN") == "1"
+
+
+def find_touchscreen(preferred_name=""):
+    fallback = None
+    for path in sorted(list_devices()):
+        try:
+            device = InputDevice(path)
+        except OSError:
+            continue
+        if device.name == VIRTUAL_DEVICE_NAME or not is_touchscreen(path):
+            device.close()
+            continue
+        capabilities = device.capabilities(absinfo=False)
+        abs_codes = capabilities.get(ecodes.EV_ABS, [])
+        if not {
+            ecodes.ABS_MT_SLOT,
+            ecodes.ABS_MT_TRACKING_ID,
+            ecodes.ABS_MT_POSITION_X,
+            ecodes.ABS_MT_POSITION_Y,
+        }.issubset(abs_codes):
+            device.close()
+            continue
+        if preferred_name and device.name == preferred_name:
+            if fallback is not None:
+                fallback.close()
+            return device
+        if fallback is None:
+            fallback = device
+        else:
+            device.close()
+    if preferred_name and fallback is not None:
+        fallback.close()
+        return None
+    return fallback
+
+
+class MouseSink:
+    def __init__(self, device):
+        self.device = device
+
+    def move(self, dx, dy):
+        if dx:
+            self.device.write(ecodes.EV_REL, ecodes.REL_X, dx)
+        if dy:
+            self.device.write(ecodes.EV_REL, ecodes.REL_Y, dy)
+        self.device.syn()
+
+    def button(self, name, pressed):
+        code = ecodes.BTN_LEFT if name == "left" else ecodes.BTN_RIGHT
+        self.device.write(ecodes.EV_KEY, code, int(pressed))
+        self.device.syn()
+
+
+def normalize(value, info):
+    size = info.max - info.min
+    if size <= 0:
+        return 0.0
+    return min(1.0, max(0.0, (value - info.min) / size))
+
+
+def run_trackpad(device, orientation):
+    x_info = device.absinfo(ecodes.ABS_MT_POSITION_X)
+    y_info = device.absinfo(ecodes.ABS_MT_POSITION_Y)
+    virtual_mouse = UInput(
+        {
+            ecodes.EV_KEY: [ecodes.BTN_LEFT, ecodes.BTN_RIGHT],
+            ecodes.EV_REL: [ecodes.REL_X, ecodes.REL_Y],
+        },
+        name=VIRTUAL_DEVICE_NAME,
+        bustype=ecodes.BUS_VIRTUAL,
+        vendor=0x0001,
+        product=0x0001,
+        version=1,
+    )
+    sink = MouseSink(virtual_mouse)
+    engine = TouchpadGestureEngine(sink)
+    slots = {}
+    active_slots = set()
+    current_slot = 0
+    dropping = False
+    grabbed = False
+    try:
+        device.grab()
+        grabbed = True
+        print(f"using {device.path}: {device.name}", flush=True)
+        for event in device.read_loop():
+            if dropping:
+                if event.type == ecodes.EV_SYN and event.code == ecodes.SYN_REPORT:
+                    dropping = False
+                continue
+            if event.type == ecodes.EV_ABS:
+                if event.code == ecodes.ABS_MT_SLOT:
+                    current_slot = event.value
+                    slots.setdefault(
+                        current_slot,
+                        {"tracking": False, "x": None, "y": None, "dirty": False},
+                    )
+                else:
+                    slot = slots.setdefault(
+                        current_slot,
+                        {"tracking": False, "x": None, "y": None, "dirty": False},
+                    )
+                    if event.code == ecodes.ABS_MT_TRACKING_ID:
+                        slot["tracking"] = event.value >= 0
+                        if event.value >= 0:
+                            slot["x"] = None
+                            slot["y"] = None
+                        slot["dirty"] = True
+                    elif event.code == ecodes.ABS_MT_POSITION_X:
+                        slot["x"] = normalize(event.value, x_info)
+                        slot["dirty"] = True
+                    elif event.code == ecodes.ABS_MT_POSITION_Y:
+                        slot["y"] = normalize(event.value, y_info)
+                        slot["dirty"] = True
+            elif event.type == ecodes.EV_SYN and event.code == ecodes.SYN_DROPPED:
+                engine.reset()
+                slots.clear()
+                active_slots.clear()
+                current_slot = 0
+                dropping = True
+            elif event.type == ecodes.EV_SYN and event.code == ecodes.SYN_REPORT:
+                timestamp = time.monotonic()
+                for slot_id, slot in slots.items():
+                    if not slot["dirty"]:
+                        continue
+                    slot["dirty"] = False
+                    if (
+                        slot["tracking"]
+                        and slot["x"] is not None
+                        and slot["y"] is not None
+                    ):
+                        x, y = orient_coordinates(slot["x"], slot["y"], orientation)
+                        if slot_id in active_slots:
+                            engine.touch_move(slot_id, x, y, timestamp)
+                        else:
+                            active_slots.add(slot_id)
+                            engine.touch_down(slot_id, x, y, timestamp)
+                    elif slot_id in active_slots:
+                        active_slots.remove(slot_id)
+                        engine.touch_up(slot_id, timestamp)
+    finally:
+        engine.reset()
+        if grabbed:
+            try:
+                device.ungrab()
+            except OSError:
+                pass
+        virtual_mouse.close()
+
+
+def main():
+    if configured_mode() != "trackpad":
+        print("direct touchscreen mode; waiting", flush=True)
+        while True:
+            time.sleep(3600)
+    environment = device_environment()
+    preferred_name = environment.get("ARMADA_PRIMARY_TOUCHSCREEN", "")
+    orientation = environment.get("ARMADA_PANEL_ORIENTATION", "normal")
+    while True:
+        device = find_touchscreen(preferred_name)
+        if device is None:
+            print("no multi-touch touchscreen found; retrying", flush=True)
+            time.sleep(2)
+            continue
+        try:
+            run_trackpad(device, orientation)
+        except OSError as exc:
+            print(f"touchscreen unavailable: {exc}; retrying", flush=True)
+            time.sleep(2)
+        finally:
+            device.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/touchscreen-trackpad-test.py
+++ b/tests/touchscreen-trackpad-test.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import sys
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "system_files/usr/lib/armada"))
+from touchscreen_trackpad import TouchpadGestureEngine, orient_coordinates
+
+
+class Sink:
+    def __init__(self):
+        self.events = []
+
+    def move(self, dx, dy):
+        self.events.append(("move", dx, dy))
+
+    def button(self, name, pressed):
+        self.events.append(("button", name, pressed))
+
+
+class TouchpadGestureEngineTest(unittest.TestCase):
+    def setUp(self):
+        self.sink = Sink()
+        self.engine = TouchpadGestureEngine(self.sink, motion_counts=1000)
+
+    def test_single_finger_tap_left_clicks(self):
+        self.engine.touch_down(0, 0.5, 0.5, 1.0)
+        self.engine.touch_up(0, 1.1)
+        self.assertEqual(
+            self.sink.events,
+            [("button", "left", True), ("button", "left", False)],
+        )
+
+    def test_two_finger_tap_right_clicks(self):
+        self.engine.touch_down(0, 0.4, 0.5, 1.0)
+        self.engine.touch_down(1, 0.6, 0.5, 1.02)
+        self.engine.touch_up(0, 1.1)
+        self.engine.touch_up(1, 1.12)
+        self.assertEqual(
+            self.sink.events,
+            [("button", "right", True), ("button", "right", False)],
+        )
+
+    def test_dragging_moves_relatively_without_clicking(self):
+        self.engine.touch_down(0, 0.2, 0.2, 1.0)
+        self.engine.touch_move(0, 0.3, 0.25, 1.1)
+        self.engine.touch_up(0, 1.4)
+        self.assertEqual(self.sink.events, [("move", 99, 49)])
+
+    def test_double_tap_and_hold_drags(self):
+        self.engine.touch_down(0, 0.2, 0.2, 1.0)
+        self.engine.touch_up(0, 1.1)
+        self.engine.touch_down(0, 0.2, 0.2, 1.25)
+        self.engine.touch_move(0, 0.3, 0.2, 1.35)
+        self.engine.touch_up(0, 1.5)
+        self.assertEqual(
+            self.sink.events,
+            [
+                ("button", "left", True),
+                ("button", "left", False),
+                ("button", "left", True),
+                ("move", 99, 0),
+                ("button", "left", False),
+            ],
+        )
+
+    def test_reset_releases_a_held_drag(self):
+        self.engine.touch_down(0, 0.2, 0.2, 1.0)
+        self.engine.touch_up(0, 1.1)
+        self.engine.touch_down(0, 0.2, 0.2, 1.2)
+        self.engine.reset()
+        self.assertEqual(self.sink.events[-1], ("button", "left", False))
+
+    def test_panel_orientation_matches_display_rotation(self):
+        expected = {
+            "normal": (0.2, 0.7),
+            "left": (0.7, 0.8),
+            "right": (0.3, 0.2),
+            "inverted": (0.8, 0.3),
+        }
+        for orientation, coordinates in expected.items():
+            actual = orient_coordinates(0.2, 0.7, orientation)
+            self.assertAlmostEqual(actual[0], coordinates[0])
+            self.assertAlmostEqual(actual[1], coordinates[1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/touchscreen-trackpad-test.sh
+++ b/tests/touchscreen-trackpad-test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+python3 - \
+    "$ROOT/system_files/usr/lib/armada/touchscreen_trackpad.py" \
+    "$ROOT/system_files/usr/libexec/armada/touchscreen-trackpad" \
+    "$ROOT/system_files/usr/libexec/armada/armada-control" \
+    "$ROOT/decky/armada-control/py_modules/armada_control/touchscreen.py" <<'PY'
+from pathlib import Path
+import sys
+
+for name in sys.argv[1:]:
+    source = Path(name).read_text(encoding="utf-8")
+    compile(source, name, "exec")
+PY
+PYTHONDONTWRITEBYTECODE=1 python3 "$ROOT/tests/touchscreen-trackpad-test.py"
+
+grep -q 'python3-evdev' "$ROOT/build_files/10-base-packages.sh"
+grep -q 'enable armada-touchscreen-trackpad.service' "$ROOT/build_files/40-vendor-system-files.sh"
+
+printf 'touchscreen trackpad tests passed\n'


### PR DESCRIPTION
## What changed

- add a fail-safe system service that grabs the primary touchscreen only when trackpad mode is enabled and emits a standard relative virtual mouse
- support one-finger pointer movement, single-tap left click, two-finger-tap right click, and double-tap-and-hold dragging
- rotate raw touch coordinates using Armada's per-device panel orientation, including the portrait-native Retroid panels
- add a persisted `Touchscreen Trackpad` toggle under Armada Control's Advanced > Input section
- add focused gesture, orientation, syntax, package, and service-installation tests

## Why

Steam Input does not expose a handheld's physical touchscreen as a configurable trackpad, and InputPlumber's touchscreen-to-mouse translation is not implemented in the pinned package. A small Armada-owned prototype lets us validate the interaction model without first coordinating an InputPlumber package change.

Direct touch remains the default. In trackpad mode the service uses an exclusive evdev grab, so Gamescope does not also receive absolute touches. If the service exits or crashes, the kernel releases the grab and direct touch becomes available again.

## User impact

Users can switch modes from the controller-accessible Decky quick-access menu. Trackpad mode works as a conventional system mouse in Steam, games, and Desktop Mode rather than relying on a per-game Steam Input layout.

## Validation

- all repository shell tests passed in a disposable Fedora 44 ARM64 container
- six focused gesture and panel-orientation unit tests passed
- Decky production bundle built successfully with the locked dependencies
- Python and shell syntax checks passed
- `git diff --check` passed
- Fedora 44's official repositories provide `python3-evdev`

A full Armada image was not built locally. The pull-request container build should provide that integration check.

## Hardware validation still needed

- verify pointer direction and speed on a left-rotated Retroid and a right-rotated handheld
- verify direct/trackpad switching in Gaming Mode and Desktop Mode
- verify tap, two-finger tap, double-click, and double-tap drag behavior
- verify stopping the service immediately restores direct touch
- check interaction with Steam overlays, suspend/resume, and device reconnects

This is intentionally a prototype. Sensitivity, scrolling, and per-game overrides can be added after the basic interaction is tested on hardware.
