### PR TITLE
Speed up DNF during image builds

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -43,6 +43,7 @@ COPY system_files /system_files/
 
 FROM quay.io/fedora/fedora-bootc:44
 ARG ARMADA_VERSION=unknown
+ARG ARMADA_FEDORA_MIRROR=
 LABEL org.opencontainers.image.version="${ARMADA_VERSION}"
 
 RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
@@ -66,6 +67,7 @@ RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
     --mount=type=tmpfs,dst=/tmp \
     mkdir -p /usr/lib/armada && \
     printf '%s\n' "${ARMADA_VERSION}" >/usr/lib/armada/version && \
+    export ARMADA_FEDORA_MIRROR="${ARMADA_FEDORA_MIRROR}" && \
     /ctx/build_files/build.sh
 
 RUN bootc container lint

--- a/Justfile
+++ b/Justfile
@@ -82,6 +82,9 @@ build $target_image=image_name $tag=default_tag:
     BUILD_ARGS=()
     ARMADA_VERSION="$(TZ=America/New_York date +%Y%m%d).$(git rev-parse --short HEAD)"
     BUILD_ARGS+=("--build-arg" "ARMADA_VERSION=${ARMADA_VERSION}")
+    if [[ -n "${ARMADA_FEDORA_MIRROR:-}" ]]; then
+        BUILD_ARGS+=("--build-arg" "ARMADA_FEDORA_MIRROR=${ARMADA_FEDORA_MIRROR}")
+    fi
 
     # Allow local armada-packages images to override pinned package images.
     mapfile -t PKG_VARS < <(sed -n 's/^ARG \([A-Z0-9_]*_PKG\)=.*/\1/p' Containerfile)

--- a/build_files/05-configure-dnf.sh
+++ b/build_files/05-configure-dnf.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euxo pipefail
 
+BUILD_DNF_STATE_DIR=/tmp/armada-build-dnf
+
 mkdir -p /etc/dnf/libdnf5.conf.d
 cat >/etc/dnf/libdnf5.conf.d/10-armada-build.conf <<'EOF'
 [main]
@@ -12,10 +14,12 @@ EOF
 
 if [[ -n "${ARMADA_FEDORA_MIRROR:-}" ]]; then
     fedora_mirror="${ARMADA_FEDORA_MIRROR%/}"
+    mkdir -p "${BUILD_DNF_STATE_DIR}/yum.repos.d"
 
     for repo in /etc/yum.repos.d/fedora*.repo; do
         [[ -e "${repo}" ]] || continue
         grep -q '^#baseurl=http://download.example/pub/fedora/linux' "${repo}" || continue
+        cp -a "${repo}" "${BUILD_DNF_STATE_DIR}/yum.repos.d/${repo##*/}"
         sed -i \
             -e 's|^metalink=|#metalink=|' \
             -e "s|^#baseurl=http://download.example/pub/fedora/linux|baseurl=${fedora_mirror}|" \

--- a/build_files/05-configure-dnf.sh
+++ b/build_files/05-configure-dnf.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euxo pipefail
+
+mkdir -p /etc/dnf/libdnf5.conf.d
+cat >/etc/dnf/libdnf5.conf.d/10-armada-build.conf <<'EOF'
+[main]
+fastestmirror=True
+max_parallel_downloads=10
+minrate=200k
+timeout=20
+EOF
+
+if [[ -n "${ARMADA_FEDORA_MIRROR:-}" ]]; then
+    fedora_mirror="${ARMADA_FEDORA_MIRROR%/}"
+
+    for repo in /etc/yum.repos.d/fedora*.repo; do
+        [[ -e "${repo}" ]] || continue
+        grep -q '^#baseurl=http://download.example/pub/fedora/linux' "${repo}" || continue
+        sed -i \
+            -e 's|^metalink=|#metalink=|' \
+            -e "s|^#baseurl=http://download.example/pub/fedora/linux|baseurl=${fedora_mirror}|" \
+            "${repo}"
+    done
+fi

--- a/build_files/75-restore-build-dnf.sh
+++ b/build_files/75-restore-build-dnf.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euxo pipefail
+
+BUILD_DNF_STATE_DIR=/tmp/armada-build-dnf
+
+rm -f /etc/dnf/libdnf5.conf.d/10-armada-build.conf
+
+if [[ -d "${BUILD_DNF_STATE_DIR}/yum.repos.d" ]]; then
+    for repo in "${BUILD_DNF_STATE_DIR}"/yum.repos.d/*.repo; do
+        [[ -e "${repo}" ]] || continue
+        cp -a "${repo}" "/etc/yum.repos.d/${repo##*/}"
+    done
+fi
+
+rm -rf "${BUILD_DNF_STATE_DIR}"

--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -13,4 +13,5 @@ cd /ctx/build_files
 ./55-generate-initramfs.sh
 ./60-set-default-target.sh
 ./70-cleanup.sh
+./75-restore-build-dnf.sh
 ./80-finalize-update-state.sh

--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -3,6 +3,7 @@ set -euxo pipefail
 
 cd /ctx/build_files
 
+./05-configure-dnf.sh
 ./10-base-packages.sh
 ./20-install-kernel.sh
 ./30-install-steam-session.sh


### PR DESCRIPTION
## Summary

This adds an early build step that configures libdnf5 for faster and more resilient package downloads during image builds:

- enables `fastestmirror`
- raises `max_parallel_downloads` to 10
- sets a minimum transfer rate and timeout so very slow mirrors fail over sooner
- adds an optional `ARMADA_FEDORA_MIRROR` build arg for builders who know a nearby Fedora mirror

By default this does not hard-code a regional mirror. The explicit mirror override is only applied when `ARMADA_FEDORA_MIRROR` is set, and it only rewrites Fedora repo files that use Fedora standard commented `baseurl` template.


The build now writes the libdnf5 speed-up config at the start of the container build, optionally rewrites Fedora repo files when `ARMADA_FEDORA_MIRROR` is set, and then runs a late restore step after the final DNF operations. That restore step removes `/etc/dnf/libdnf5.conf.d/10-armada-build.conf` and restores any Fedora repo files it temporarily changed before the image is finalized.

So the installed OS should keep Fedora's normal repository configuration, while local/CI image builds can still use faster parallel downloads and an operator-selected nearby mirror.

## Speed-up observed

Tested from the western US while building in a Fedora Lima VM on macOS. With an explicit nearby mirror, DNF download phases that had previously selected slow mirrors or stalled in the hundreds of KiB/s range were observed around 6-8 MiB/s on representative transactions. One later DNF transaction in the successful image build downloaded 43 MiB at about 7.8 MiB/s.

The total build-time improvement depends heavily on cache state and non-DNF work, especially package/image assembly, but the DNF download portions were roughly an order of magnitude faster in this test environment.

## Usage

The general build path gets the libdnf5 tuning automatically. Builders who want to pin a known-good mirror can run, for example:

```bash
ARMADA_FEDORA_MIRROR=https://mirrors.kernel.org/fedora just build localhost/armada test
```

Builders elsewhere can use a geographically appropriate Fedora mirror, or leave `ARMADA_FEDORA_MIRROR` unset and rely on Fedora mirror selection with `fastestmirror` enabled.

## Validation

- `bash -n build_files/05-configure-dnf.sh build_files/build.sh`
- `just --fmt --check`
- completed a local image build in a Fedora Lima VM from the western US using `ARMADA_FEDORA_MIRROR=https://mirrors.kernel.org/fedora`