### PR TITLE
feat: pin Pocket DS virtual keyboard to lower display

### DIFF
--- a/system_files/usr/lib/armada/devices/ayaneo-pocket-ds.conf
+++ b/system_files/usr/lib/armada/devices/ayaneo-pocket-ds.conf
@@ -1,7 +1,11 @@
 ARMADA_DEVICE_ID=ayaneo-pocket-ds
 ARMADA_DEVICE_NAME='AYANEO Pocket DS'
-ARMADA_SOC_CLASS=SM8550
 
+# Plasma's virtual keyboard belongs on the lower Pocket DS display. Consumed
+# by the optional patched-KWin path proposed in armada-os/armada#194.
+ARMADA_VIRTUAL_KEYBOARD_CONNECTOR=DSI-2
+
+ARMADA_SOC_CLASS=SM8550
 ARMADA_PRIMARY_CONNECTOR=DSI-1
 ARMADA_PANEL_ORIENTATION=left
 ARMADA_PANEL_NATIVE_WIDTH=1080

--- a/tests/pocket-ds-virtual-keyboard-test.sh
+++ b/tests/pocket-ds-virtual-keyboard-test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+config="$ROOT/system_files/usr/lib/armada/devices/ayaneo-pocket-ds.conf"
+
+grep -q '^ARMADA_VIRTUAL_KEYBOARD_CONNECTOR=DSI-2$' "$config"
+printf 'Pocket DS virtual-keyboard connector check passed\n'


### PR DESCRIPTION
## Summary
- Configure the AYANEO Pocket DS virtual keyboard output as its lower physical display: `DSI-2`.
- Add a regression test for this device mapping.

## Related pull requests
- Depends on [#160](https://github.com/armada-os/armada/pull/160) for the Pocket DS dual-screen desktop policy and its established `DSI-1` (top) / `DSI-2` (bottom) mapping.
- Requires [#194](https://github.com/armada-os/armada/pull/194), which adds the optional patched-KWin implementation that reads `ARMADA_VIRTUAL_KEYBOARD_CONNECTOR`.

After #160 and #194 are included in an image built with #194’s `build_patched_kwin` option, Plasma will pin Pocket DS’s virtual keyboard to the bottom `DSI-2` display instead of following the active-output heuristic.

## Test plan
- `bash tests/pocket-ds-virtual-keyboard-test.sh`
- `for test_file in tests/*-test.sh; do bash "$test_file"; done`
- `git diff --check`
