### PR TITLE
Start the ADSP when its boot-time firmware load loses the race

### DIFF
--- a/build_files/40-vendor-system-files.sh
+++ b/build_files/40-vendor-system-files.sh
@@ -29,6 +29,7 @@ systemctl enable armada-input-calibration.service
 systemctl enable armada-controller-type.service
 systemctl enable inputplumber.service
 systemctl enable armada-device-quirks.service
+systemctl enable armada-adsp-recover.service
 systemctl enable armada-fixups.service
 systemctl enable armada-installer-visibility.service
 systemctl enable armada-steamapps.service

--- a/system_files/usr/lib/systemd/system/armada-adsp-recover.service
+++ b/system_files/usr/lib/systemd/system/armada-adsp-recover.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=armada ADSP recovery
+# remoteproc requests the ADSP firmware early and does not retry on failure, so
+# run once the rootfs is definitely mounted. Ordered before the battery and
+# session consumers so they do not read an empty power supply.
+After=sysinit.target local-fs.target
+Before=armada-powerd.service display-manager.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/libexec/armada/adsp-recover
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/system_files/usr/libexec/armada/adsp-recover
+++ b/system_files/usr/libexec/armada/adsp-recover
@@ -1,0 +1,40 @@
+#!/bin/bash
+# The ADSP hosts the battery manager firmware behind pmic_glink. Its firmware
+# request can fire before the rootfs holding /usr/lib/firmware is reachable;
+# remoteproc logs "request_firmware failed: -2" and never retries, so the ADSP
+# stays offline for the whole boot. Every power_supply attribute then reads back
+# empty and the battery looks absent (Steam shows 0%). Losing the race is
+# intermittent, so start it here once the filesystem is definitely up.
+set -uo pipefail
+
+log() { echo "adsp-recover: $*"; }
+
+found=0
+for rp in /sys/class/remoteproc/remoteproc*; do
+    [[ -r "${rp}/name" && -w "${rp}/state" ]] || continue
+    [[ "$(cat "${rp}/name" 2>/dev/null)" == "adsp" ]] || continue
+    found=1
+
+    state="$(cat "${rp}/state" 2>/dev/null)" || continue
+    if [[ "$state" == "running" ]]; then
+        log "adsp already running"
+        exit 0
+    fi
+
+    log "adsp is ${state}; starting it"
+    for attempt in 1 2 3; do
+        echo start > "${rp}/state" 2>/dev/null || true
+        sleep 2
+        if [[ "$(cat "${rp}/state" 2>/dev/null)" == "running" ]]; then
+            log "adsp started (attempt ${attempt})"
+            exit 0
+        fi
+    done
+
+    # Non-fatal: a device without working audio/battery still boots to Steam.
+    log "failed to start adsp after 3 attempts"
+    exit 0
+done
+
+(( found )) || log "no adsp remoteproc present; nothing to do"
+exit 0


### PR DESCRIPTION
## Problem

`remoteproc` requests the ADSP firmware at **~3s into boot, inside the initramfs** — about 4s before `/boot` mounts:

```
[    3.197727] remoteproc remoteproc0: Direct firmware load for qcom/sm8550/ayaneo/adsp.mdt failed with error -2
[    3.199251] remoteproc remoteproc0: request_firmware failed: -2
```

dracut ships `qcom_q6v5_pas.ko` in the initramfs but **no qcom firmware** (`lsinitrd | grep -c lib/firmware/qcom` → 0), so the probe fails and remoteproc never retries after switch-root. The ADSP hosts the battery manager behind `pmic_glink`, so every `power_supply` attribute then reads back empty and Steam shows 0% on a charged device.

Not a race — it fails on every boot I have logs for. What varies is whether anything starts the ADSP afterwards. Full timing data across four boots is in the comment below.

## Fix

Oneshot that writes `start` once the filesystem is up, ordered before `armada-powerd` and the session. No-op if already running, 3 retries, never fails the boot.

## Testing

Pocket EVO, reproduced on a losing boot and recovered first try:
```
adsp-recover: adsp is offline; starting it
adsp-recover: adsp started (attempt 1)
→ cap=78 status=Discharging
```

## Alternative worth considering

Fixing it in dracut instead — omit `qcom_q6v5_pas` from the initramfs so it loads from the rootfs where the firmware exists, or include `/usr/lib/firmware/qcom`. That prevents the failed probe rather than repairing it. This PR is the more robust option (recovers regardless of cause); happy to do either or both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)