### PR TITLE
Switch the Pocket EVO to real suspend to RAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,10 +176,15 @@ desktop. The **Bazaar** app store and the **Armada Installer**
 
 ### Power button and sleep
 
-Pressing the power button does a "fake suspend" (inspired by ROCKNIX) rather than
-real S3 sleep: it blanks the screen and freezes the session, and the same press
-wakes it. Because the device does not truly sleep, idle battery drain is higher
-than it would be with real suspend.
+What the power button does depends on the device.
+
+On the **AYN Odin 3** and **AYANEO Pocket EVO** it is a real suspend to RAM: the
+device genuinely powers down and the same press wakes it. Standby drain is much
+lower — measured at roughly a fifth of fake suspend on the Pocket EVO.
+
+Everywhere else it is a "fake suspend" (inspired by ROCKNIX): the screen blanks
+and the session freezes, but the device stays powered, so idle battery drain is
+higher than it would be with real suspend.
 
 ## Updating
 

--- a/system_files/usr/lib/armada/devices/ayaneo-pocket-evo.conf
+++ b/system_files/usr/lib/armada/devices/ayaneo-pocket-evo.conf
@@ -9,3 +9,7 @@ ARMADA_PANEL_NATIVE_HEIGHT=1920
 ARMADA_PANEL_REFRESH_RATES=60,120
 ARMADA_GAMESCOPE_USE_ROTATION_SHADER=1
 ARMADA_GAMEPAD_QUIRK=ayaneo-xbox
+# Requires the SM8550 suspend patches and the fan tacho DTS override from
+# armada-packages. Without them this device wakes itself within seconds and
+# hard-hangs on resume with a Steam session running.
+ARMADA_SUSPEND_MODE=mem

--- a/system_files/usr/lib/systemd/sleep.conf.d/10-armada-suspend-state.conf
+++ b/system_files/usr/lib/systemd/sleep.conf.d/10-armada-suspend-state.conf
@@ -1,0 +1,6 @@
+[Sleep]
+# Only try suspend-to-RAM. systemd's default is "mem standby freeze", so a
+# failed deep suspend falls through to s2idle -- which has been observed to
+# wedge SM8550 devices hard enough to need a power-button reset. A failed deep
+# should no-op instead. Matches what ROCKNIX pins for the same SoC.
+SuspendState=mem


### PR DESCRIPTION
> [!IMPORTANT]
> **Do not merge before [armada-packages#23](https://github.com/armada-os/armada-packages/pull/23).** On a kernel without those patches, `mem` is the configuration that hangs the EVO on resume with a Steam session running — recoverable only by holding the power button.

## What changed

- `ayaneo-pocket-evo.conf`: `ARMADA_SUSPEND_MODE=mem`
- New `sleep.conf.d` drop-in pinning `SuspendState=mem` — systemd's default `mem standby freeze` falls through to s2idle on a failed deep suspend, which wedges SM8550 hard enough to need a power-button reset (we hit this during bring-up). ROCKNIX pins the same for this SoC.
- README: sleep section still described fake suspend as universal, stale since the Odin 3 moved to `mem`

## Results

Pocket EVO, on battery, Steam running: **27.8 mA vs 161.8 mA** standby — ~2 days to ~12. 1202s of uninterrupted deep suspend woken only by the RTC alarm, `success=3 fail=0`, session intact on resume.

## Gaps

Headline numbers are from a 7.0.11 build; packages has since moved to 7.1.5, confirmed working but only over a ~4 minute run. No multi-hour soak, single drain sample per mode, one device. The 5.8× gap is well beyond sampling error, but holding this until there's a longer soak on 7.1.5 is a reasonable call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)