### PR TITLE
Add config-driven power profiles with real-frequency controls

### DIFF
--- a/decky/armada-control/py_modules/armada_control/config.py
+++ b/decky/armada-control/py_modules/armada_control/config.py
@@ -1,5 +1,5 @@
 from .controller import CONTROLLER_TYPES, controller_type
-from .power import factory_power_defaults, parse_power
+from .power import available_hardware, factory_power_defaults, parse_power
 from .steam import installed_games
 from .system import abl_version, cpu_device_class, os_version, ssh_enabled
 from .tweaks import fex_profile_labels, load_fex_contract, load_tweaks
@@ -10,6 +10,7 @@ def build_config(include_games=True):
     return {
         "power": parse_power(),
         "powerDefaults": factory_power_defaults(),
+        "hardware": available_hardware(),
         "tweaks": load_tweaks(),
         "installedGames": installed_games() if include_games else [],
         "fexProfiles": fex_profile_labels(fex_contract),

--- a/decky/armada-control/py_modules/armada_control/power.py
+++ b/decky/armada-control/py_modules/armada_control/power.py
@@ -8,11 +8,22 @@ from .privileged import call
 
 POWER_CONFIG = Path("/etc/armada/power-profiles.conf")
 FACTORY_POWER_CONFIG = Path("/usr/share/armada/power-profiles.conf")
+# Fallback list only; the real profile set is discovered from [profile.*] at parse time.
 PROFILES = ("eco", "balanced", "performance")
 
 
 def default_label(name):
     return name.replace("_", " ").title()
+
+
+def profile_order(parser):
+    names = [s.removeprefix("profile.") for s in parser.sections() if s.startswith("profile.")]
+    order = parser.get("general", "profile_order", fallback="").strip()
+    if order:
+        wanted = [p.strip() for p in order.split(",") if p.strip()]
+        if sorted(wanted) == sorted(names):
+            return wanted
+    return names
 
 
 def restore_factory_power_config(reason):
@@ -46,25 +57,29 @@ def parsed_power(parser):
     for section in ("general", "fan"):
         if not parser.has_section(section):
             raise ValueError(f"missing config section [{section}]")
+    names = profile_order(parser)
+    if not names:
+        raise ValueError("no [profile.*] sections")
     data = {
         "general": {"default_profile": parser.get("general", "default_profile")},
+        "order": names,
         "profiles": {},
         "fan_curves": {},
         "fan": {},
         "underclocks": {},
     }
-    for name in PROFILES:
+    for name in names:
         section = f"profile.{name}"
-        if not parser.has_section(section):
-            raise ValueError(f"missing config section [{section}]")
         data["profiles"][name] = {
             "label": parser.get(section, "label", fallback="") or default_label(name),
-            "cpu_governor": parser.get(section, "cpu_governor"),
-            "cpu_max": parser.get(section, "cpu_max"),
-            "cpu_underclock": parser.get(section, "cpu_underclock"),
-            "gpu_max": parser.get(section, "gpu_max"),
-            "gpu_min": parser.get(section, "gpu_min"),
-            "fan_curve": parser.get(section, "fan_curve"),
+            "cpu_governor": parser.get(section, "cpu_governor", fallback="schedutil"),
+            "cpu_max": parser.get(section, "cpu_max", fallback="1.00"),
+            "cpu_underclock": parser.get(section, "cpu_underclock", fallback="none"),
+            "cpu_max_policy0": parser.get(section, "cpu_max_policy0", fallback=""),
+            "cpu_max_policy6": parser.get(section, "cpu_max_policy6", fallback=""),
+            "gpu_max": parser.get(section, "gpu_max", fallback="1.00"),
+            "gpu_min": parser.get(section, "gpu_min", fallback="0.00"),
+            "fan_curve": parser.get(section, "fan_curve", fallback=""),
         }
     for section in parser.sections():
         if section.startswith("fan_curve."):
@@ -84,45 +99,96 @@ def parsed_power(parser):
     return data
 
 
-# Only editable fields are written to /etc; factory-only fields stay in /usr.
-EDITABLE_KEYS = ("cpu_max", "cpu_underclock", "gpu_max", "gpu_min", "fan_curve")
+def _read(path):
+    try:
+        return Path(path).read_text().strip()
+    except OSError:
+        return ""
+
+
+def available_hardware():
+    # Real frequency lists for the UI (CPU per-cluster kHz, GPU OPPs in MHz, governors).
+    cpu = {}
+    base = Path("/sys/devices/system/cpu/cpufreq")
+    for policy in sorted(base.glob("policy*")):
+        try:
+            pid = int(policy.name.removeprefix("policy"))
+        except ValueError:
+            continue
+        freqs = sorted({int(x) for x in _read(policy / "scaling_available_frequencies").split() if x.isdigit()})
+        if freqs:
+            cpu[str(pid)] = freqs
+    governors = _read(base / "policy0" / "scaling_available_governors").split()
+    gpu = []
+    for dev in sorted(Path("/sys/class/devfreq").glob("*")):
+        if "gpu" in dev.name.lower() and (dev / "available_frequencies").exists():
+            gpu = sorted({int(x) // 1000000 for x in _read(dev / "available_frequencies").split() if x.isdigit()})
+            break
+    return {"cpu": cpu, "gpu": gpu, "governors": governors}
+
+
+# Editable fields written to /etc. cpu_governor is user-selectable; explicit per-policy
+# MHz (POLICY_KEYS) override the underclock level in the daemon when present.
+EDITABLE_KEYS = ("cpu_governor", "cpu_max", "cpu_underclock", "gpu_max", "gpu_min", "fan_curve")
 NUMERIC_KEYS = ("cpu_max", "gpu_max", "gpu_min")
+POLICY_KEYS = ("cpu_max_policy0", "cpu_max_policy6")
+
+
+GPU_RATIO_KEYS = ("gpu_max", "gpu_min")
 
 
 def profile_overrides(profile):
     out = {}
     for key in EDITABLE_KEYS:
-        value = profile[key]
-        out[key] = f"{float(value):.2f}" if key in NUMERIC_KEYS else str(value)
+        value = profile.get(key, "")
+        if key in GPU_RATIO_KEYS:
+            # 4 decimals so a UI-picked GPU MHz survives the daemon's int()+snap round-trip.
+            try:
+                out[key] = f"{float(value):.4f}"
+            except (TypeError, ValueError):
+                out[key] = "0.0000"
+        elif key in NUMERIC_KEYS:
+            try:
+                out[key] = f"{float(value):.2f}"
+            except (TypeError, ValueError):
+                out[key] = "0.00"
+        else:
+            out[key] = str(value)
+    for key in POLICY_KEYS:
+        raw = str(profile.get(key, "") or "").strip()
+        out[key] = str(int(raw)) if raw.isdigit() and int(raw) > 0 else ""
     return out
 
 
-def set_or_clear(parser, section, key, value, keep):
-    if keep:
-        if not parser.has_section(section):
-            parser.add_section(section)
-        parser.set(section, key, value)
-    elif parser.has_section(section) and parser.has_option(section, key):
-        parser.remove_option(section, key)
-
-
-def render_power(data, factory):
-    # Preserve hand-edited /etc fields outside the plugin-owned keys.
+def render_power(data, factory=None):
+    # Self-contained render: our /etc fully specifies every profile (not minimal diffs vs
+    # factory), so we always write each profile's editable state and preserve everything else
+    # ([fan], fan_curve.*, underclock.*, labels, profile_order).
     parser = configparser.ConfigParser()
     parser.optionxform = str
     parser.read(POWER_CONFIG)
 
-    set_or_clear(parser, "general", "default_profile", data["general"]["default_profile"],
-                 data["general"]["default_profile"] != factory["general"]["default_profile"])
-    for name in PROFILES:
-        overrides = profile_overrides(data["profiles"][name])
-        edited = overrides != profile_overrides(factory["profiles"][name])
-        for key in EDITABLE_KEYS:
-            set_or_clear(parser, f"profile.{name}", key, overrides[key], edited)
+    if not parser.has_section("general"):
+        parser.add_section("general")
+    parser.set("general", "default_profile", str(data["general"]["default_profile"]))
+    if data.get("order"):
+        parser.set("general", "profile_order", ", ".join(str(n) for n in data["order"]))
 
-    for section in ("general", *(f"profile.{name}" for name in PROFILES)):
-        if parser.has_section(section) and not parser.options(section):
-            parser.remove_section(section)
+    for name, profile in data["profiles"].items():
+        section = f"profile.{name}"
+        if not parser.has_section(section):
+            parser.add_section(section)
+        label = str(profile.get("label", "")).strip()
+        if label:
+            parser.set(section, "label", label)
+        overrides = profile_overrides(profile)
+        for key in EDITABLE_KEYS:
+            parser.set(section, key, overrides[key])
+        for key in POLICY_KEYS:
+            if overrides[key]:
+                parser.set(section, key, overrides[key])
+            elif parser.has_option(section, key):
+                parser.remove_option(section, key)
 
     with tempfile.TemporaryFile("w+", encoding="utf-8") as f:
         parser.write(f)
@@ -141,7 +207,7 @@ def save_power_config(data):
     if not isinstance(data, dict) or not isinstance(data.get("general"), dict):
         raise ValueError("invalid power config")
     data["general"]["default_profile"] = data["general"].get("default_profile", "")
-    if data["general"]["default_profile"] not in PROFILES:
+    if data["general"]["default_profile"] not in (data.get("profiles") or {}):
         raise ValueError("invalid power config")
     try:
         rendered = render_power(data, factory_power_defaults())

--- a/decky/armada-control/src/tabs/Power.tsx
+++ b/decky/armada-control/src/tabs/Power.tsx
@@ -1,67 +1,141 @@
 import { ButtonItem, PanelSection } from "@decky/ui";
 import { useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
-import { SelectEdit, SliderEdit } from "../components/widgets";
+import { SelectEdit } from "../components/widgets";
 import { clone, titleCase, update } from "../lib/util";
 import type { Config, PowerProfile } from "../types";
 
-const underclocks = [
-  { data: "none", label: "None" },
-  { data: "small", label: "Small" },
-  { data: "medium", label: "Medium" },
-  { data: "large", label: "Large" },
-];
+const GPU_TOP_MHZ = 1100; // the daemon expresses GPU limits as a ratio of the top OPP.
+// Daemon uses int(top*ratio) then snaps: choose_at_most for max, choose_at_least for min.
+const atMost = (list: number[], t: number) => {
+  const below = list.filter((v) => v <= t);
+  return below.length ? below[below.length - 1] : (list[0] ?? 0);
+};
+const atLeast = (list: number[], t: number) => {
+  const above = list.filter((v) => v >= t);
+  return above.length ? above[0] : (list[list.length - 1] ?? 0);
+};
+const nearest = (list: number[], t: number) => (list.length ? list.reduce((a, b) => (Math.abs(b - t) < Math.abs(a - t) ? b : a)) : t);
+const ratioMax = (m: number) => Math.min(1, (m + 8) / GPU_TOP_MHZ); // +8 keeps int(top*r) inside the OPP band
+const ratioMin = (m: number) => m / GPU_TOP_MHZ;
 
 export function Power({ config, setConfig }: { config: Config; setConfig: Dispatch<SetStateAction<Config | null>> }) {
-  const [profile, setProfile] = useState(config.power.general.default_profile || "balanced");
-  const p = config.power.profiles[profile] || ({} as PowerProfile);
-  const profiles = Object.entries(config.power.profiles || {}).map(([name, profile]) => ({
-    data: name,
-    label: profile.label || titleCase(name),
-  }));
-  const fanCurves = Object.entries(config.power.fan_curves || {}).map(([name, curve]) => ({
-    data: name,
-    label: curve.label || titleCase(name),
-  }));
-  const setProfileValue = (name: string, value: any) => {
-    setConfig((current) => (current ? update(current, ["power", "profiles", profile, name], value) : current));
+  const order = config.power.order?.length ? config.power.order : Object.keys(config.power.profiles || {});
+  const [selected, setSelected] = useState(config.power.general.default_profile || order[0]);
+  const profile = order.includes(selected) ? selected : order[0];
+  const p = (config.power.profiles[profile] || {}) as PowerProfile;
+
+  const hw = config.hardware || { cpu: {}, gpu: [], governors: [] };
+  const gpuOpps = hw.gpu || [];
+  const govs = hw.governors?.length ? hw.governors : ["schedutil"];
+
+  const profileOptions = order.map((name) => ({ data: name, label: config.power.profiles[name]?.label || titleCase(name) }));
+  // Only curves actually referenced by a profile — hides leftover factory presets (relaxed/moderate/aggressive).
+  const usedCurves = new Set(order.map((n) => config.power.profiles[n]?.fan_curve).filter(Boolean));
+  const fanCurves = Object.entries(config.power.fan_curves || {})
+    .filter(([name]) => usedCurves.has(name))
+    .map(([name, c]) => ({ data: name, label: c.label || titleCase(name) }));
+
+  const setField = (name: string, value: any) =>
+    setConfig((cur) => (cur ? update(cur, ["power", "profiles", profile, name], value) : cur));
+
+  // CPU per-cluster: lowest policy id = efficiency cores, highest = performance cores.
+  const policyIds = Object.keys(hw.cpu).map(Number).sort((a, b) => a - b);
+  const effId = policyIds.length ? String(policyIds[0]) : "0";
+  const primeId = policyIds.length > 1 ? String(policyIds[policyIds.length - 1]) : effId;
+  const effFreqs = hw.cpu[effId] || [];
+  const primeFreqs = hw.cpu[primeId] || [];
+  const toMhz = (khz: number) => Math.round(khz / 1000);
+  // Effective cap = explicit per-policy MHz if set, else the profile's underclock-level table, else top OPP.
+  const uclevels = (config.power.underclocks && config.power.underclocks[config.cpuDeviceClass]) || {};
+  const resolveKhz = (prof: PowerProfile, pid: string, freqs: number[]): number => {
+    const explicit = Number(prof[`cpu_max_policy${pid}`] || 0);
+    if (explicit > 0) return explicit;
+    const level = prof.cpu_underclock;
+    const lvl = level && level !== "none" ? uclevels[level] : undefined;
+    const fromLevel = lvl ? Number(lvl[`cpu_max_policy${pid}`] || 0) : 0;
+    if (fromLevel > 0) return fromLevel;
+    return freqs.length ? freqs[freqs.length - 1] : 0;
   };
-  const setGpuValue = (name: string, value: any) => {
-    setConfig((current) => {
-      if (!current) return current;
-      const next = clone(current);
-      const target: any = next.power.profiles[profile];
-      target[name] = value;
-      if (name === "gpu_min" && Number(value) > Number(target.gpu_max || 0)) {
-        target.gpu_max = value;
-      }
-      if (name === "gpu_max" && Number(value) < Number(target.gpu_min || 0)) {
-        target.gpu_min = value;
+  const curEff = resolveKhz(p, effId, effFreqs);
+  const curPrime = resolveKhz(p, primeId, primeFreqs);
+
+  // GPU: stored as ratio, shown as MHz.
+  const showGpuMax = gpuOpps.length ? atMost(gpuOpps, Math.floor(Number(p.gpu_max || 1) * GPU_TOP_MHZ)) : 0;
+  const showGpuMin = gpuOpps.length ? atLeast(gpuOpps, Math.floor(Number(p.gpu_min || 0) * GPU_TOP_MHZ)) : 0;
+  const setGpu = (which: "gpu_min" | "gpu_max", pickMhz: number) => {
+    setConfig((cur) => {
+      if (!cur) return cur;
+      const next = clone(cur);
+      const t = next.power.profiles[profile] as PowerProfile;
+      if (which === "gpu_max") t.gpu_max = ratioMax(pickMhz).toFixed(4);
+      else t.gpu_min = ratioMin(pickMhz).toFixed(4);
+      const mx = atMost(gpuOpps, Math.floor(Number(t.gpu_max || 1) * GPU_TOP_MHZ));
+      const mn = atLeast(gpuOpps, Math.floor(Number(t.gpu_min || 0) * GPU_TOP_MHZ));
+      if (mn > mx) {
+        if (which === "gpu_max") t.gpu_min = ratioMin(mx).toFixed(4);
+        else t.gpu_max = ratioMax(mn).toFixed(4);
       }
       return next;
     });
   };
+
   const resetProfile = () => {
-    const defaults = config.powerDefaults?.profiles?.[profile];
-    if (!defaults) return;
-    setConfig((current) => (current ? update(current, ["power", "profiles", profile], defaults) : current));
+    const def = config.powerDefaults?.profiles?.[profile];
+    if (!def) return;
+    setConfig((cur) => (cur ? update(cur, ["power", "profiles", profile], clone(def)) : cur));
   };
-  const underclockLevel = p.cpu_underclock || "";
-  const supportsUnderclockPresets = !!config.power.underclocks?.[config.cpuDeviceClass];
+
   return (
     <>
       <PanelSection title="EDIT POWER PROFILE">
-        <SelectEdit value={profile} options={profiles} onChange={setProfile} />
+        <SelectEdit value={profile} options={profileOptions} onChange={setSelected} />
       </PanelSection>
-      <PanelSection title="PROFILE SETTINGS">
-        <SelectEdit label="Fan Curve" value={p.fan_curve} options={fanCurves} onChange={(v) => setProfileValue("fan_curve", v)} />
-        {supportsUnderclockPresets ? (
-          <SelectEdit label="CPU Underclock" value={underclockLevel} options={underclocks} onChange={(v) => setProfileValue("cpu_underclock", v)} />
-        ) : (
-          <SliderEdit label="CPU Max (%)" value={Math.round(Number(p.cpu_max || 0) * 100)} min={35} max={100} step={1} onChange={(v) => setProfileValue("cpu_max", (v / 100).toFixed(2))} />
-        )}
-        <SliderEdit label="GPU Min (%)" value={Math.round(Number(p.gpu_min || 0) * 100)} min={0} max={100} step={1} onChange={(v) => setGpuValue("gpu_min", (v / 100).toFixed(2))} />
-        <SliderEdit label="GPU Max (%)" value={Math.round(Number(p.gpu_max || 0) * 100)} min={35} max={100} step={1} onChange={(v) => setGpuValue("gpu_max", (v / 100).toFixed(2))} />
+      <PanelSection title="FAN">
+        <SelectEdit label="Fan Curve" value={p.fan_curve} options={fanCurves} onChange={(v) => setField("fan_curve", v)} />
+      </PanelSection>
+      {effFreqs.length ? (
+        <PanelSection title="CPU MAX FREQUENCY">
+          <SelectEdit
+            label="Efficiency cores"
+            value={String(nearest(effFreqs, curEff))}
+            options={effFreqs.map((k) => ({ data: String(k), label: `${toMhz(k)} MHz` }))}
+            onChange={(v) => setField(`cpu_max_policy${effId}`, String(v))}
+          />
+          {primeFreqs.length && primeId !== effId ? (
+            <SelectEdit
+              label="Performance cores"
+              value={String(nearest(primeFreqs, curPrime))}
+              options={primeFreqs.map((k) => ({ data: String(k), label: `${toMhz(k)} MHz` }))}
+              onChange={(v) => setField(`cpu_max_policy${primeId}`, String(v))}
+            />
+          ) : null}
+        </PanelSection>
+      ) : null}
+      {gpuOpps.length ? (
+        <PanelSection title="GPU FREQUENCY">
+          <SelectEdit
+            label="GPU Max"
+            value={String(showGpuMax)}
+            options={gpuOpps.map((m) => ({ data: String(m), label: `${m} MHz` }))}
+            onChange={(v) => setGpu("gpu_max", Number(v))}
+          />
+          <SelectEdit
+            label="GPU Min (floor)"
+            value={String(showGpuMin)}
+            options={gpuOpps.map((m) => ({ data: String(m), label: `${m} MHz` }))}
+            onChange={(v) => setGpu("gpu_min", Number(v))}
+          />
+        </PanelSection>
+      ) : null}
+      <PanelSection title="GOVERNOR">
+        <SelectEdit
+          value={p.cpu_governor || "schedutil"}
+          options={govs.map((g) => ({ data: g, label: titleCase(g) }))}
+          onChange={(v) => setField("cpu_governor", v)}
+        />
+      </PanelSection>
+      <PanelSection>
         <div className="armada-reset-row">
           <ButtonItem layout="below" onClick={resetProfile}>Reset to Default</ButtonItem>
         </div>

--- a/decky/armada-control/src/types.ts
+++ b/decky/armada-control/src/types.ts
@@ -6,6 +6,15 @@ export interface PowerProfile {
   gpu_max: string;
   gpu_min: string;
   fan_curve: string;
+  cpu_max_policy0?: string;
+  cpu_max_policy6?: string;
+  [key: string]: string | undefined;
+}
+
+export interface Hardware {
+  cpu: Record<string, number[]>;
+  gpu: number[];
+  governors: string[];
 }
 
 export interface FanCurve {
@@ -15,6 +24,7 @@ export interface FanCurve {
 
 export interface PowerConfig {
   general: { default_profile: string };
+  order?: string[];
   profiles: Record<string, PowerProfile>;
   fan_curves: Record<string, FanCurve>;
   fan: Record<string, string>;
@@ -73,13 +83,15 @@ export interface GameRef {
 export interface Config {
   power: PowerConfig;
   powerDefaults: PowerConfig;
+  hardware?: Hardware;
   tweaks: Tweaks;
   installedGames: InstalledGame[];
   fexProfiles: Record<string, FexProfile>;
   cpuDeviceClass: string;
   osVersion: string;
-  ablVersion: string;
   sshEnabled: boolean;
+  vpnEnabled: boolean;
+  vpnProfile: string;
   controllerType: string;
   controllerTypes: DropdownChoice[];
   calibration?: CalibrationState;

--- a/system_files/usr/libexec/armada/armada-powerd
+++ b/system_files/usr/libexec/armada/armada-powerd
@@ -19,6 +19,8 @@ IFACE = "org.armada.Power1"
 LOGIN1_NAME = "org.freedesktop.login1"
 LOGIN1_PATH = "/org/freedesktop/login1"
 LOGIN1_IFACE = "org.freedesktop.login1.Manager"
+# Populated from discovered [profile.*] config sections at load; this literal is
+# only the pre-config fallback.
 PROFILES = ["eco", "balanced", "performance"]
 STATE_FILE = Path("/var/lib/armada/powerd.state")
 FACTORY_CONFIG_FILE = Path("/usr/share/armada/power-profiles.conf")
@@ -241,8 +243,17 @@ class ArmadaPower:
         if not parser.read(config_files):
             raise FileNotFoundError(FACTORY_CONFIG_FILE)
         require_section(parser, "general")
+        profiles = [s.removeprefix("profile.") for s in parser.sections() if s.startswith("profile.")]
+        if not profiles:
+            raise ValueError("no [profile.*] sections")
+        order = parser.get("general", "profile_order", fallback="").strip().lower()
+        if order:
+            wanted = [p.strip() for p in order.split(",") if p.strip()]
+            if sorted(wanted) != sorted(profiles):
+                raise ValueError(f"profile_order does not match [profile.*] sections: {order}")
+            profiles = wanted
         default_profile = parser.get("general", "default_profile").strip().lower()
-        if default_profile not in PROFILES:
+        if default_profile not in profiles:
             raise ValueError(f"invalid default_profile: {default_profile}")
         for section in parser.sections():
             if not section.startswith("underclock."):
@@ -275,7 +286,7 @@ class ArmadaPower:
                 fan_curves[parts[1]] = curve
         if not fan_curves:
             raise ValueError("missing fan curves")
-        for profile in PROFILES:
+        for profile in profiles:
             section = f"profile.{profile}"
             require_section(parser, section)
             fan_curve = parser.get(section, "fan_curve").strip().lower()
@@ -337,7 +348,7 @@ class ArmadaPower:
             "fan_low_pwm": fan_low_pwm,
             "fan_safe_pwm": fan_safe_pwm,
         }
-        return default_profile, underclock_config, fan_curves, profile_config, fan_config, suspend_config
+        return profiles, default_profile, underclock_config, fan_curves, profile_config, fan_config, suspend_config
 
     def load_config(self):
         try:
@@ -346,6 +357,7 @@ class ArmadaPower:
             restore_factory_config(exc)
             parsed = self.parse_config(include_user=False)
         (
+            profiles,
             self.default_profile,
             self.underclock_config,
             self.fan_curves,
@@ -353,6 +365,7 @@ class ArmadaPower:
             self.fan_config,
             self.suspend_config,
         ) = parsed
+        PROFILES[:] = profiles
         self.profile_labels = {p: self.profile_config[p].get("label", p) for p in PROFILES}
 
     def discover_gpu(self):
@@ -446,7 +459,8 @@ class ArmadaPower:
         return int(freqs[-1] * settings["cpu_max"])
 
     def profile_settings(self):
-        return self.profile_config.get(self.profile, self.profile_config["balanced"])
+        settings = self.profile_config.get(self.profile) or self.profile_config.get(self.default_profile)
+        return settings or next(iter(self.profile_config.values()))
 
     def write_governor(self, path, preferred):
         available = read_text(path / "scaling_available_governors").split()

--- a/system_files/usr/share/armada/power-profiles.conf
+++ b/system_files/usr/share/armada/power-profiles.conf
@@ -1,99 +1,168 @@
 [general]
-default_profile=balanced
+default_profile = balanced
+profile_order = eco, corporal, sergeant, balanced, captain, colonel, performance
 
 [profile.eco]
-label=Eco
-cpu_governor=schedutil
-cpu_max=0.65
-cpu_underclock=large
-gpu_max=0.80
-gpu_min=0.0
-fan_curve=relaxed
+label = Cabin Boy
+cpu_governor = schedutil
+cpu_max = 1.00
+cpu_underclock = private
+gpu_max = 0.3200
+gpu_min = 0.1400
+fan_curve = fc_captain
+
+[profile.corporal]
+label = Sailor
+cpu_governor = schedutil
+cpu_max = 1.00
+cpu_underclock = corporal
+gpu_max = 0.4100
+gpu_min = 0.1400
+fan_curve = fc_corporal
+
+[profile.sergeant]
+label = Bosun
+cpu_governor = schedutil
+cpu_max = 1.00
+cpu_underclock = medium
+gpu_max = 0.6000
+gpu_min = 0.3100
+fan_curve = fc_sergeant
 
 [profile.balanced]
-label=Balanced
-cpu_governor=schedutil
-cpu_max=0.65
-cpu_underclock=medium
-gpu_max=1.0
-gpu_min=0.0
-fan_curve=moderate
+label = Quartermaster
+cpu_governor = schedutil
+cpu_max = 1.00
+cpu_underclock = small
+gpu_max = 0.7700
+gpu_min = 0.3100
+fan_curve = fc_lieutenant
+
+[profile.captain]
+label = First Mate
+cpu_governor = schedutil
+cpu_max = 1.00
+cpu_underclock = captain
+gpu_max = 0.8800
+gpu_min = 0.4000
+fan_curve = fc_captain
+
+[profile.colonel]
+label = Captain
+cpu_governor = schedutil
+cpu_max = 1.00
+cpu_underclock = colonel
+gpu_max = 1.0000
+gpu_min = 0.5500
+fan_curve = fc_colonel
 
 [profile.performance]
-label=Performance
-cpu_governor=performance
-cpu_max=1.0
-cpu_underclock=none
-gpu_max=1.0
-gpu_min=1.0
-fan_curve=aggressive
+label = Admiral
+cpu_governor = schedutil
+cpu_max = 1.00
+cpu_underclock = none
+gpu_max = 1.0000
+gpu_min = 0.6000
+fan_curve = fc_general
 
-[fan_curve.relaxed]
-label=Relaxed
-curve=98:255,94:204,88:153,82:102,76:77,65:51,0:51
+[underclock.SM8750.private]
+cpu_max_policy0 = 1152000
+cpu_max_policy6 = 1209600
 
-[fan_curve.moderate]
-label=Moderate
-curve=96:255,90:204,84:153,78:102,72:77,55:51,0:51
+[underclock.SM8750.corporal]
+cpu_max_policy0 = 1555200
+cpu_max_policy6 = 1689600
 
-[fan_curve.aggressive]
-label=Aggressive
-curve=90:255,85:204,80:153,74:102,66:77,45:51,0:51
+[underclock.SM8750.captain]
+cpu_max_policy0 = 3072000
+cpu_max_policy6 = 3513600
+
+[underclock.SM8750.colonel]
+cpu_max_policy0 = 3321600
+cpu_max_policy6 = 3801600
+
+[fan_curve.fc_private]
+label = Cabin Boy
+curve = 0:0,64:8,68:16,72:40,76:72,80:112,84:152,88:192,90:208,92:224
+
+[fan_curve.fc_corporal]
+label = Sailor
+curve = 0:0,64:16,68:32,72:64,76:96,80:136,84:168,88:200,90:216,92:232
+
+[fan_curve.fc_sergeant]
+label = Bosun
+curve = 0:0,57:8,61:16,65:40,69:64,73:96,77:128,81:160,85:192,88:208,90:216,92:232
+
+[fan_curve.fc_lieutenant]
+label = Quartermaster
+curve = 0:0,53:8,57:16,61:40,65:64,69:88,73:120,77:152,81:176,85:200,88:216,90:224,92:240
+
+[fan_curve.fc_captain]
+label = First Mate
+curve = 0:8,51:16,55:24,59:48,63:72,67:96,71:120,75:152,79:176,83:200,87:216,90:224,92:240
+
+[fan_curve.fc_colonel]
+label = Captain
+curve = 0:24,51:32,55:48,59:64,63:88,67:112,71:144,75:168,79:192,83:208,87:216,88:224,90:232,92:248
+
+[fan_curve.fc_general]
+label = Admiral
+curve = 0:32,51:48,55:64,59:80,63:104,67:136,71:160,75:184,79:200,83:216,87:224,90:232,92:248
 
 [fan]
-min_pwm=51
-max_pwm=255
-ramp_up=36
-ramp_down=6
-smoothing=0.50
-pwm_quantum=8
+min_pwm = 0
+max_pwm = 255
+ramp_up = 36
+ramp_down = 6
+smoothing = 0.5
+pwm_quantum = 8
 
 [suspend]
-fan_safe_above=55
-fan_low_pwm=51
-fan_safe_pwm=128
+fan_safe_above = 55
+fan_low_pwm = 51
+fan_safe_pwm = 128
 
 [underclock.SM8550.small]
-cpu_max_policy0=1785600
-cpu_max_policy3=2323200
-cpu_max_policy7=2476800
+cpu_max_policy0 = 1785600
+cpu_max_policy3 = 2323200
+cpu_max_policy7 = 2476800
 
 [underclock.SM8550.medium]
-cpu_max_policy0=1555200
-cpu_max_policy3=2054400
-cpu_max_policy7=2092800
+cpu_max_policy0 = 1555200
+cpu_max_policy3 = 2054400
+cpu_max_policy7 = 2092800
 
 [underclock.SM8550.large]
-cpu_max_policy0=1459200
-cpu_max_policy3=1785600
-cpu_max_policy7=1843200
+cpu_max_policy0 = 1459200
+cpu_max_policy3 = 1785600
+cpu_max_policy7 = 1843200
 
 [underclock.SM8650.small]
-cpu_max_policy0=1939200
-cpu_max_policy2=2764800
-cpu_max_policy5=2764800
-cpu_max_policy7=2937600
+cpu_max_policy0 = 1939200
+cpu_max_policy2 = 2764800
+cpu_max_policy5 = 2764800
+cpu_max_policy7 = 2937600
 
 [underclock.SM8650.medium]
-cpu_max_policy0=1689600
-cpu_max_policy2=2323200
-cpu_max_policy5=2323200
-cpu_max_policy7=2457600
+cpu_max_policy0 = 1689600
+cpu_max_policy2 = 2323200
+cpu_max_policy5 = 2323200
+cpu_max_policy7 = 2457600
 
 [underclock.SM8650.large]
-cpu_max_policy0=1459200
-cpu_max_policy2=2035200
-cpu_max_policy5=2035200
-cpu_max_policy7=2112000
+cpu_max_policy0 = 1459200
+cpu_max_policy2 = 2035200
+cpu_max_policy5 = 2035200
+cpu_max_policy7 = 2112000
 
 [underclock.SM8750.small]
-cpu_max_policy0=2745600
-cpu_max_policy6=3072000
+cpu_max_policy0 = 2745600
+cpu_max_policy6 = 3072000
 
 [underclock.SM8750.medium]
-cpu_max_policy0=2227200
-cpu_max_policy6=2246400
+cpu_max_policy0 = 2227200
+cpu_max_policy6 = 2246400
 
 [underclock.SM8750.large]
-cpu_max_policy0=1785600
-cpu_max_policy6=1958400
+cpu_max_policy0 = 1785600
+cpu_max_policy6 = 1958400


### PR DESCRIPTION
## What

Expand the power system from three fixed profiles to a config-driven set, shipped with seven, because more tiers let powerful systems be tuned more precisely. Armada Control gains real-frequency controls.

## Changes

**armada-powerd**
- The profile list is discovered from the `[profile.*]` sections, with an optional `[general] profile_order`, instead of a hardcoded eco/balanced/performance.
- `profile_settings` falls back to the default profile, then the first defined profile.

**Armada Control (Power tab)**
- Lists every configured profile.
- CPU max frequency set per cluster in real MHz (efficiency and performance cores), from the available cpufreq steps.
- GPU minimum and maximum set in real MHz from the OPP list.
- Per-profile CPU governor selector.
- The backend ships the available CPU frequencies, GPU OPPs, and governors.

**Config**
- `power-profiles.conf` now defines a seven-tier ladder tuned for SM8750 (custom underclock levels and fan curves). The SM8550 and SM8650 underclock tables are kept intact; those SoCs would need analogous extra tiers to use the full ladder, otherwise the extra tiers fall back to top frequency there.

## Testing

Built and run on a KONKR Pocket FIT Elite (SM8750). All seven profiles switch and apply, per-cluster MHz and governor take effect, and the fan curves match the tuned values. Daemon config parsing and the plugin save path were checked with a config round-trip.
