### PR TITLE
Add config-driven power profiles with per-cluster CPU/GPU controls, governor, and a fan-curve editor

### DIFF
--- a/decky/armada-control/py_modules/armada_control/config.py
+++ b/decky/armada-control/py_modules/armada_control/config.py
@@ -1,5 +1,5 @@
 from .controller import CONTROLLER_TYPES, controller_type
-from .power import factory_power_defaults, parse_power
+from .power import available_hardware, factory_power_defaults, parse_power
 from .steam import installed_games
 from .system import abl_version, cpu_device_class, os_version, perf_info, ssh_enabled
 from .tweaks import fex_profile_labels, load_fex_contract, load_tweaks
@@ -10,6 +10,7 @@ def build_config(include_games=True):
     return {
         "power": parse_power(),
         "powerDefaults": factory_power_defaults(),
+        "hardware": available_hardware(),
         "tweaks": load_tweaks(),
         "installedGames": installed_games() if include_games else [],
         "fexProfiles": fex_profile_labels(fex_contract),

--- a/decky/armada-control/py_modules/armada_control/power.py
+++ b/decky/armada-control/py_modules/armada_control/power.py
@@ -8,11 +8,22 @@ from .privileged import call
 
 POWER_CONFIG = Path("/etc/armada/power-profiles.conf")
 FACTORY_POWER_CONFIG = Path("/usr/share/armada/power-profiles.conf")
+# Fallback list only; the real profile set is discovered from [profile.*] at parse time.
 PROFILES = ("eco", "balanced", "performance")
 
 
 def default_label(name):
     return name.replace("_", " ").title()
+
+
+def profile_order(parser):
+    names = [s.removeprefix("profile.") for s in parser.sections() if s.startswith("profile.")]
+    order = parser.get("general", "profile_order", fallback="").strip()
+    if order:
+        wanted = [p.strip() for p in order.split(",") if p.strip()]
+        if sorted(wanted) == sorted(names):
+            return wanted
+    return names
 
 
 def restore_factory_power_config(reason):
@@ -46,25 +57,29 @@ def parsed_power(parser):
     for section in ("general", "fan"):
         if not parser.has_section(section):
             raise ValueError(f"missing config section [{section}]")
+    names = profile_order(parser)
+    if not names:
+        raise ValueError("no [profile.*] sections")
     data = {
         "general": {"default_profile": parser.get("general", "default_profile")},
+        "order": names,
         "profiles": {},
         "fan_curves": {},
         "fan": {},
         "underclocks": {},
     }
-    for name in PROFILES:
+    for name in names:
         section = f"profile.{name}"
-        if not parser.has_section(section):
-            raise ValueError(f"missing config section [{section}]")
         data["profiles"][name] = {
             "label": parser.get(section, "label", fallback="") or default_label(name),
-            "cpu_governor": parser.get(section, "cpu_governor"),
-            "cpu_max": parser.get(section, "cpu_max"),
-            "cpu_underclock": parser.get(section, "cpu_underclock"),
-            "gpu_max": parser.get(section, "gpu_max"),
-            "gpu_min": parser.get(section, "gpu_min"),
-            "fan_curve": parser.get(section, "fan_curve"),
+            "cpu_governor": parser.get(section, "cpu_governor", fallback="schedutil"),
+            "cpu_max": parser.get(section, "cpu_max", fallback="1.00"),
+            "cpu_underclock": parser.get(section, "cpu_underclock", fallback="none"),
+            "cpu_max_policy0": parser.get(section, "cpu_max_policy0", fallback=""),
+            "cpu_max_policy6": parser.get(section, "cpu_max_policy6", fallback=""),
+            "gpu_max": parser.get(section, "gpu_max", fallback="1.00"),
+            "gpu_min": parser.get(section, "gpu_min", fallback="0.00"),
+            "fan_curve": parser.get(section, "fan_curve", fallback=""),
         }
     for section in parser.sections():
         if section.startswith("fan_curve."):
@@ -84,45 +99,163 @@ def parsed_power(parser):
     return data
 
 
-# Only editable fields are written to /etc; factory-only fields stay in /usr.
+def _read(path):
+    try:
+        return Path(path).read_text().strip()
+    except OSError:
+        return ""
+
+
+def available_hardware():
+    # Real frequency lists for the UI (CPU per-cluster kHz, GPU OPPs in MHz, governors).
+    cpu = {}
+    base = Path("/sys/devices/system/cpu/cpufreq")
+    for policy in sorted(base.glob("policy*")):
+        try:
+            pid = int(policy.name.removeprefix("policy"))
+        except ValueError:
+            continue
+        freqs = sorted({int(x) for x in _read(policy / "scaling_available_frequencies").split() if x.isdigit()})
+        if freqs:
+            cpu[str(pid)] = freqs
+    governors = _read(base / "policy0" / "scaling_available_governors").split()
+    gpu = []
+    for dev in sorted(Path("/sys/class/devfreq").glob("*")):
+        if "gpu" in dev.name.lower() and (dev / "available_frequencies").exists():
+            gpu = sorted({int(x) // 1000000 for x in _read(dev / "available_frequencies").split() if x.isdigit()})
+            break
+    return {"cpu": cpu, "gpu": gpu, "governors": governors}
+
+
+# Editable fields written to /etc. cpu_governor is user-selectable; explicit per-policy
+# MHz (POLICY_KEYS) override the underclock level in the daemon when present.
 EDITABLE_KEYS = ("cpu_governor", "cpu_max", "cpu_underclock", "gpu_max", "gpu_min", "fan_curve")
 NUMERIC_KEYS = ("cpu_max", "gpu_max", "gpu_min")
+POLICY_KEYS = ("cpu_max_policy0", "cpu_max_policy6")
+
+
+GPU_RATIO_KEYS = ("gpu_max", "gpu_min")
 
 
 def profile_overrides(profile):
     out = {}
     for key in EDITABLE_KEYS:
-        value = profile[key]
-        out[key] = f"{float(value):.2f}" if key in NUMERIC_KEYS else str(value)
+        value = profile.get(key, "")
+        if key in GPU_RATIO_KEYS:
+            # 4 decimals so a UI-picked GPU MHz survives the daemon's int()+snap round-trip.
+            try:
+                out[key] = f"{float(value):.4f}"
+            except (TypeError, ValueError):
+                out[key] = "0.0000"
+        elif key in NUMERIC_KEYS:
+            try:
+                out[key] = f"{float(value):.2f}"
+            except (TypeError, ValueError):
+                out[key] = "0.00"
+        else:
+            out[key] = str(value)
+    for key in POLICY_KEYS:
+        raw = str(profile.get(key, "") or "").strip()
+        out[key] = str(int(raw)) if raw.isdigit() and int(raw) > 0 else ""
     return out
 
 
-def set_or_clear(parser, section, key, value, keep):
-    if keep:
-        if not parser.has_section(section):
-            parser.add_section(section)
-        parser.set(section, key, value)
-    elif parser.has_section(section) and parser.has_option(section, key):
-        parser.remove_option(section, key)
+def _pwm_at(pts, temp):
+    if temp <= pts[0][0]:
+        return pts[0][1]
+    if temp >= pts[-1][0]:
+        return pts[-1][1]
+    for i in range(1, len(pts)):
+        if temp <= pts[i][0]:
+            (t0, p0), (t1, p1) = pts[i - 1], pts[i]
+            return p0 + (p1 - p0) * (temp - t0) / (t1 - t0)
+    return pts[-1][1]
 
 
-def render_power(data, factory):
-    # Preserve hand-edited /etc fields outside the plugin-owned keys.
+def _validate_curve(name, raw):
+    # Structural + thermal-wall gate. Raised errors travel the SAVE path only, so a bad
+    # curve is rejected before write; it never reaches the parse/read path that factory-restores.
+    pts = []
+    for seg in (raw or "").split(","):
+        seg = seg.strip()
+        if not seg:
+            continue
+        try:
+            ts, ps = seg.split(":")
+            point = (int(ts), int(ps))
+        except ValueError:
+            raise ValueError(f"fan_curve {name}: bad point '{seg}'")
+        pts.append(point)
+    if len(pts) < 2:
+        raise ValueError(f"fan_curve {name}: need at least 2 points")
+    for i, (t, p) in enumerate(pts):
+        if not 0 <= t <= 100:
+            raise ValueError(f"fan_curve {name}: temp {t} out of range")
+        if not 0 <= p <= 255:
+            raise ValueError(f"fan_curve {name}: pwm {p} out of range")
+        if i and t <= pts[i - 1][0]:
+            raise ValueError(f"fan_curve {name}: temps not ascending at {t}")
+        if i and p < pts[i - 1][1]:
+            raise ValueError(f"fan_curve {name}: pwm decreases at {t}")
+    if _pwm_at(pts, 92) < 255:
+        raise ValueError(f"fan_curve {name}: must reach 100% (255) by 92C")
+    return ",".join(f"{t}:{p}" for t, p in pts)
+
+
+def render_power(data, factory=None):
+    # Self-contained render: our /etc fully specifies every profile (not minimal diffs vs
+    # factory), so we always write each profile's editable state and preserve everything else
+    # ([fan], fan_curve.*, underclock.*, labels, profile_order).
     parser = configparser.ConfigParser()
     parser.optionxform = str
     parser.read(POWER_CONFIG)
 
-    set_or_clear(parser, "general", "default_profile", data["general"]["default_profile"],
-                 data["general"]["default_profile"] != factory["general"]["default_profile"])
-    for name in PROFILES:
-        overrides = profile_overrides(data["profiles"][name])
-        edited = overrides != profile_overrides(factory["profiles"][name])
-        for key in EDITABLE_KEYS:
-            set_or_clear(parser, f"profile.{name}", key, overrides[key], edited)
+    if not parser.has_section("general"):
+        parser.add_section("general")
+    parser.set("general", "default_profile", str(data["general"]["default_profile"]))
+    if data.get("order"):
+        parser.set("general", "profile_order", ", ".join(str(n) for n in data["order"]))
 
-    for section in ("general", *(f"profile.{name}" for name in PROFILES)):
-        if parser.has_section(section) and not parser.options(section):
-            parser.remove_section(section)
+    for name, profile in data["profiles"].items():
+        section = f"profile.{name}"
+        if not parser.has_section(section):
+            parser.add_section(section)
+        label = str(profile.get("label", "")).strip()
+        if label:
+            parser.set(section, "label", label)
+        overrides = profile_overrides(profile)
+        for key in EDITABLE_KEYS:
+            parser.set(section, key, overrides[key])
+        for key in POLICY_KEYS:
+            if overrides[key]:
+                parser.set(section, key, overrides[key])
+            elif parser.has_option(section, key):
+                parser.remove_option(section, key)
+
+    # Fan curves: emit only profile-referenced curves (skips loose factory presets), and
+    # validate only the ones that actually changed vs on-disk so an untouched curve can never
+    # block an unrelated save. Never write a curve-less section (would factory-nuke on next read).
+    used = {str(p.get("fan_curve", "")) for p in data.get("profiles", {}).values()}
+    used.discard("")
+    for name in used:
+        fc = (data.get("fan_curves") or {}).get(name)
+        if not fc:
+            continue
+        section = f"fan_curve.{name}"
+        old_raw = parser.get(section, "curve", fallback="") if parser.has_section(section) else ""
+        new_raw = str(fc.get("curve", ""))
+        if new_raw.replace(" ", "") != old_raw.replace(" ", ""):
+            curve = _validate_curve(name, new_raw)
+        elif old_raw:
+            curve = old_raw
+        else:
+            raise ValueError(f"fan_curve {name}: empty curve")
+        if not parser.has_section(section):
+            parser.add_section(section)
+        label = str(fc.get("label", "")).strip()
+        if label:
+            parser.set(section, "label", label)
+        parser.set(section, "curve", curve)
 
     with tempfile.TemporaryFile("w+", encoding="utf-8") as f:
         parser.write(f)
@@ -141,7 +274,7 @@ def save_power_config(data):
     if not isinstance(data, dict) or not isinstance(data.get("general"), dict):
         raise ValueError("invalid power config")
     data["general"]["default_profile"] = data["general"].get("default_profile", "")
-    if data["general"]["default_profile"] not in PROFILES:
+    if data["general"]["default_profile"] not in (data.get("profiles") or {}):
         raise ValueError("invalid power config")
     try:
         rendered = render_power(data, factory_power_defaults())

--- a/decky/armada-control/src/components/CurveEditor.tsx
+++ b/decky/armada-control/src/components/CurveEditor.tsx
@@ -1,0 +1,259 @@
+import { DialogBody, DialogButton, Focusable, GamepadButton, ModalRoot, showModal } from "@decky/ui";
+import { useRef, useState } from "react";
+import type { PointerEvent as ReactPointerEvent } from "react";
+
+type Pt = { t: number; pwm: number };
+
+const WALL_T = 92, WALL_PWM = 255;      // owner: full 100% at the 92C wall
+const STEP_T = 1, STEP_PWM = 3;         // 1C, ~1% per D-pad press
+const VBW = 520, VBH = 300, L = 46, R = 508, TOP = 12, BOT = 262;
+const PW = R - L, PH = BOT - TOP;
+
+const clampN = (v: number, a: number, b: number) => Math.max(a, Math.min(b, v));
+const pctOf = (pwm: number) => Math.round((pwm / 255) * 100);
+
+function parseCurve(s: string): Pt[] {
+  const out = (s || "").split(",").map((x) => x.trim()).filter(Boolean)
+    .map((seg) => { const [a, b] = seg.split(":"); return { t: Math.round(Number(a)), pwm: Math.round(Number(b)) }; })
+    .filter((p) => Number.isFinite(p.t) && Number.isFinite(p.pwm))
+    .sort((a, b) => a.t - b.t);
+  return out.length >= 2 ? out : [{ t: 0, pwm: 0 }, { t: 92, pwm: 255 }];
+}
+const serialize = (pts: Pt[]) => pts.map((p) => `${p.t}:${p.pwm}`).join(",");
+
+function pwmAt(pts: Pt[], temp: number): number {
+  if (temp <= pts[0].t) return pts[0].pwm;
+  if (temp >= pts[pts.length - 1].t) return pts[pts.length - 1].pwm;
+  for (let i = 1; i < pts.length; i += 1) {
+    if (temp <= pts[i].t) { const a = pts[i - 1], b = pts[i]; return a.pwm + (b.pwm - a.pwm) * ((temp - a.t) / (b.t - a.t)); }
+  }
+  return pts[pts.length - 1].pwm;
+}
+function validate(pts: Pt[]): string | null {
+  if (pts.length < 2) return "need at least 2 points";
+  for (let i = 0; i < pts.length; i += 1) {
+    if (pts[i].t < 0 || pts[i].t > 100) return `temp ${pts[i].t} out of range`;
+    if (pts[i].pwm < 0 || pts[i].pwm > 255) return `fan ${pctOf(pts[i].pwm)}% out of range`;
+    if (i > 0 && pts[i].t <= pts[i - 1].t) return `temps not ascending at ${pts[i].t} C`;
+    if (i > 0 && pts[i].pwm < pts[i - 1].pwm) return `fan drops at ${pts[i].t} C`;
+  }
+  if (pwmAt(pts, WALL_T) < WALL_PWM) return `must reach 100% by ${WALL_T} C`;
+  return null;
+}
+function moved(pts: Pt[], i: number, t: number, pwm: number): Pt[] {
+  const loT = i > 0 ? pts[i - 1].t + 1 : 0;
+  const hiT = i < pts.length - 1 ? pts[i + 1].t - 1 : 100;
+  const loP = i > 0 ? pts[i - 1].pwm : 0;
+  const hiP = i < pts.length - 1 ? pts[i + 1].pwm : 255;
+  const next = pts.slice();
+  next[i] = { t: clampN(Math.round(t), loT, hiT), pwm: clampN(Math.round(pwm), loP, hiP) };
+  return next;
+}
+
+const focusCss = `
+  .armada-fan-col .DialogButton { min-width: 0 !important; width: 100% !important; min-height: 0 !important; height: auto !important; padding: 0 6px !important; }
+  .armada-fan-col .DialogButton.gpfocus,
+  .armada-fan-col .DialogButton:focus,
+  .armada-fan-col .DialogButton:hover {
+    background-color: rgba(255,255,255,0.14) !important;
+    color: #ffffff !important; box-shadow: none !important; transform: none !important; filter: none !important;
+  }
+`;
+
+// Canonical 10-point curves. The "Default" button restores the profile's curve to these.
+const DEFAULT_CURVES: Record<string, string> = {
+  fc_cabinboy: "0:0,64:8,68:16,71:34,74:56,78:92,82:132,85:162,88:192,92:255",
+  fc_sailor: "0:0,64:16,68:32,71:56,74:80,78:116,82:152,85:176,88:200,92:255",
+  fc_bosun: "0:0,57:8,61:16,66:46,70:72,74:104,79:144,83:176,88:208,92:255",
+  fc_quartermaster: "0:0,53:8,58:22,63:52,68:82,72:112,77:152,82:182,87:211,92:255",
+  fc_firstmate: "0:8,51:16,56:30,61:60,66:90,72:128,77:164,82:194,87:216,92:255",
+  fc_captain: "0:24,51:32,56:52,61:76,66:106,72:150,77:180,82:204,87:216,92:255",
+  fc_admiral: "0:32,51:48,56:68,61:92,66:128,72:166,77:192,82:212,87:224,92:255",
+};
+
+function CurveEditorModal({ profileLabel, initial, defaultCurve, onCommit, closeModal }: {
+  profileLabel: string; initial: string; defaultCurve: string; onCommit: (curve: string) => void; closeModal?: () => void;
+}) {
+  const [points, setPoints] = useState<Pt[]>(() => parseCurve(initial));
+  const [focus, setFocus] = useState(0);
+  const [grabbed, setGrabbed] = useState(false);
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const dragging = useRef(false);
+  // Axis fixed on open, fitted to the data so EVERY point (incl. the t=0 floor) is on-screen.
+  const axis = useRef<{ lo: number; hi: number } | null>(null);
+  if (!axis.current) {
+    const init = parseCurve(initial);
+    axis.current = { lo: init[0].t, hi: Math.max(init[init.length - 1].t, init[0].t + 10) };
+  }
+  const T_LO = axis.current.lo, T_HI = axis.current.hi;
+  // refs so Focusable button handlers never read stale state
+  const focusRef = useRef(focus); focusRef.current = focus;
+  const grabbedRef = useRef(grabbed); grabbedRef.current = grabbed;
+
+  const X = (t: number) => L + ((t - T_LO) / (T_HI - T_LO)) * PW;
+  const Y = (pwm: number) => TOP + (1 - pwm / 255) * PH;
+  const f = Math.min(focus, points.length - 1);
+  const err = validate(points);
+
+  const toData = (clientX: number, clientY: number) => {
+    const r = svgRef.current!.getBoundingClientRect();
+    const sx = ((clientX - r.left) / r.width) * VBW;
+    const sy = ((clientY - r.top) / r.height) * VBH;
+    return {
+      t: clampN(Math.round(T_LO + ((sx - L) / PW) * (T_HI - T_LO)), 0, 100),
+      pwm: clampN(Math.round((1 - (sy - TOP) / PH) * 255), 0, 255),
+      sx, sy,
+    };
+  };
+  const nearest = (sx: number, sy: number) => {
+    let best = -1, bd = 24;
+    points.forEach((p, i) => { const d = Math.hypot(X(p.t) - sx, Y(p.pwm) - sy); if (d < bd) { bd = d; best = i; } });
+    return best;
+  };
+  const onPointerDown = (e: ReactPointerEvent<SVGSVGElement>) => {
+    e.preventDefault();
+    const { sx, sy } = toData(e.clientX, e.clientY);
+    const n = nearest(sx, sy);
+    if (n >= 0) { setFocus(n); dragging.current = true; (e.currentTarget as Element).setPointerCapture?.(e.pointerId); }
+  };
+  const onPointerMove = (e: ReactPointerEvent<SVGSVGElement>) => {
+    if (!dragging.current) return;
+    const { t, pwm } = toData(e.clientX, e.clientY);
+    setPoints((pts) => moved(pts, Math.min(focusRef.current, pts.length - 1), t, pwm));
+  };
+  const onPointerUp = () => { dragging.current = false; };
+
+  // Interactive per-point overlays: also drag by touch/cursor (setPointerCapture), so touch works
+  // whether the finger lands on the SVG or on an overlay, and the overlays are real focusables.
+  const odrag = useRef(-1);
+  const overlayDown = (i: number) => (e: ReactPointerEvent<HTMLDivElement>) => {
+    e.preventDefault(); e.stopPropagation();
+    setFocus(i); odrag.current = i;
+    (e.currentTarget as Element).setPointerCapture?.(e.pointerId);
+  };
+  const overlayMove = (i: number) => (e: ReactPointerEvent<HTMLDivElement>) => {
+    if (odrag.current !== i) return;
+    const { t, pwm } = toData(e.clientX, e.clientY);
+    setPoints((pts) => moved(pts, Math.min(i, pts.length - 1), t, pwm));
+  };
+  const overlayUp = () => { odrag.current = -1; };
+
+  const applyMove = (i: number, dt: number, dp: number) =>
+    setPoints((pts) => { const j = Math.min(i, pts.length - 1); return moved(pts, j, pts[j].t + dt, pts[j].pwm + dp); });
+  const selPrev = () => setFocus((v) => Math.max(0, v - 1));
+  const selNext = () => setFocus((v) => Math.min(points.length - 1, v + 1));
+  const addPoint = () => {
+    const i = f < points.length - 1 ? f : f - 1;
+    const a = points[i], b = points[i + 1];
+    const nt = Math.round((a.t + b.t) / 2);
+    setPoints((pts) => { const n = pts.slice(); n.splice(i + 1, 0, { t: nt, pwm: Math.round(pwmAt(pts, nt)) }); return n; });
+    setFocus(i + 1); setGrabbed(false);
+  };
+  const removePoint = () => {
+    if (points.length <= 2) return;
+    setPoints((pts) => { const n = pts.slice(); n.splice(f, 1); return n; });
+    setFocus((v) => Math.min(v, points.length - 2)); setGrabbed(false);
+  };
+  const save = () => { if (!err) { onCommit(serialize(points)); closeModal?.(); } };
+
+  // Gamepad on a point-overlay Focusable: A grabs/releases; while grabbed the D-pad moves it.
+  const onPointButton = (i: number) => (evt: any) => {
+    const b = evt?.detail?.button;
+    if (b === GamepadButton.OK) { evt?.preventDefault?.(); setFocus(i); setGrabbed((g) => !g); return; }
+    if (!grabbedRef.current || focusRef.current !== i) return;
+    if (b === GamepadButton.DIR_UP) { evt?.preventDefault?.(); applyMove(i, 0, STEP_PWM); }
+    else if (b === GamepadButton.DIR_DOWN) { evt?.preventDefault?.(); applyMove(i, 0, -STEP_PWM); }
+    else if (b === GamepadButton.DIR_LEFT) { evt?.preventDefault?.(); applyMove(i, -STEP_T, 0); }
+    else if (b === GamepadButton.DIR_RIGHT) { evt?.preventDefault?.(); applyMove(i, STEP_T, 0); }
+  };
+
+  const xticks: number[] = [];
+  for (let t = Math.ceil(T_LO / 20) * 20; t <= T_HI; t += 20) xticks.push(t);
+  const gy = [0, 25, 50, 75, 100];
+  const path = points.map((p, i) => `${i ? "L" : "M"}${X(p.t)} ${Y(p.pwm)}`).join(" ");
+  const sel = points[f], topPct = Math.round(pwmAt(points, WALL_T) / 255 * 100);
+  const grid = "rgba(255,255,255,0.12)", axc = "rgba(255,255,255,0.5)", line = err ? "#e24b4a" : "#3b8ade";
+  const btn = { flex: "1 1 0", fontSize: "14px", width: "100%" };
+
+  return (
+    <ModalRoot onCancel={() => closeModal?.()}>
+      <style>{focusCss}</style>
+      <DialogBody>
+        <div style={{ display: "flex", alignItems: "baseline", gap: "8px", marginBottom: "12px" }}>
+          <span style={{ fontSize: "18px", fontWeight: 600 }}>Fan curve</span>
+          <span style={{ fontSize: "15px", opacity: 0.7 }}>{profileLabel}</span>
+        </div>
+        <div style={{ display: "flex", gap: "18px", alignItems: "stretch", width: "min(880px, 86vw)", maxWidth: "100%" }}>
+          <div style={{ width: "116px", flexShrink: 0, display: "flex" }}>
+            <Focusable className="armada-fan-col" style={{ display: "flex", flexDirection: "column", gap: "8px", flex: 1 }}>
+              <DialogButton style={btn} onClick={selPrev}>Prev</DialogButton>
+              <DialogButton style={btn} onClick={selNext}>Next</DialogButton>
+              <DialogButton style={btn} onClick={() => applyMove(f, 0, STEP_PWM)}>+</DialogButton>
+              <DialogButton style={btn} onClick={() => applyMove(f, 0, -STEP_PWM)}>&#8722;</DialogButton>
+              <DialogButton style={btn} onClick={addPoint}>Add</DialogButton>
+              <DialogButton style={btn} onClick={removePoint} disabled={points.length <= 2}>Remove</DialogButton>
+              <DialogButton style={btn} onClick={() => { setPoints(parseCurve(defaultCurve)); setFocus(0); setGrabbed(false); }}>Default</DialogButton>
+              <DialogButton style={btn} onClick={save} disabled={!!err}>Save</DialogButton>
+            </Focusable>
+          </div>
+          <div style={{ flex: "1 1 auto", minWidth: 0 }}>
+            <div style={{ position: "relative" }}>
+              <svg
+                ref={svgRef}
+                viewBox={`0 0 ${VBW} ${VBH}`}
+                style={{ width: "100%", height: "auto", display: "block", touchAction: "none", background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.2)", borderRadius: "8px" }}
+                onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={onPointerUp} onPointerCancel={onPointerUp}
+              >
+                {xticks.map((t) => <line key={`gx${t}`} x1={X(t)} y1={TOP} x2={X(t)} y2={BOT} stroke={grid} strokeDasharray="2 4" />)}
+                {xticks.map((t) => <text key={`tx${t}`} x={X(t)} y={BOT + 18} fill={axc} fontSize="12" textAnchor="middle">{t}</text>)}
+                {gy.map((v) => <line key={`gy${v}`} x1={L} y1={TOP + (1 - v / 100) * PH} x2={R} y2={TOP + (1 - v / 100) * PH} stroke={grid} strokeDasharray="2 4" />)}
+                {gy.map((v) => <text key={`ty${v}`} x={L - 8} y={TOP + (1 - v / 100) * PH + 4} fill={axc} fontSize="12" textAnchor="end">{v}%</text>)}
+                <text x={R} y={BOT + 18} fill={axc} fontSize="12" textAnchor="end">C</text>
+                <path d={path} fill="none" stroke={line} strokeWidth={2.5} strokeLinejoin="round" />
+                {points.map((p, i) => {
+                  if (i === f && grabbed) return <circle key={i} cx={X(p.t)} cy={Y(p.pwm)} r={12} fill="#2677d8" stroke="#fff" strokeWidth={3} />;
+                  if (i === f) return (
+                    <g key={i}>
+                      <circle cx={X(p.t)} cy={Y(p.pwm)} r={12} fill="none" stroke="#7fb0ea" strokeWidth={2} />
+                      <circle cx={X(p.t)} cy={Y(p.pwm)} r={7} fill="#16181d" stroke="#3b8ade" strokeWidth={1.5} />
+                    </g>
+                  );
+                  return <circle key={i} cx={X(p.t)} cy={Y(p.pwm)} r={6} fill="#16181d" stroke="#3b8ade" strokeWidth={1.5} />;
+                })}
+              </svg>
+              {/* invisible gamepad focus targets over each point; pointer-events off so touch-drag still hits the SVG */}
+              {points.map((p, i) => (
+                <Focusable
+                  key={`fp${i}`}
+                  style={{ position: "absolute", left: `${(X(p.t) / VBW) * 100}%`, top: `${(Y(p.pwm) / VBH) * 100}%`, width: "34px", height: "34px", transform: "translate(-50%, -50%)", borderRadius: "50%" }}
+                  onGamepadFocus={() => setFocus(i)}
+                  onButtonDown={onPointButton(i)}
+                >
+                  <div
+                    style={{ width: "100%", height: "100%" }}
+                    onPointerDown={overlayDown(i)}
+                    onPointerMove={overlayMove(i)}
+                    onPointerUp={overlayUp}
+                    onPointerCancel={overlayUp}
+                  />
+                </Focusable>
+              ))}
+            </div>
+          </div>
+        </div>
+        <div style={{ fontSize: "14px", opacity: 0.75, marginTop: "10px" }}>
+          Point {f + 1} of {points.length} : {sel.t} C : {pctOf(sel.pwm)}% {grabbed ? "- grabbed" : "- highlighted"}
+        </div>
+        <div style={{ fontSize: "13px", minHeight: "18px", color: "#e0a030" }}>
+          {err ? err : (topPct < 100 ? `reaches ${topPct}% at 92 C` : "")}
+        </div>
+      </DialogBody>
+    </ModalRoot>
+  );
+}
+
+export function openCurveEditor(opts: { profileLabel: string; curveName: string; initial: string; onCommit: (curve: string) => void; }) {
+  if (!opts.curveName) return;
+  const defaultCurve = DEFAULT_CURVES[opts.curveName] || opts.initial;
+  showModal(<CurveEditorModal profileLabel={opts.profileLabel} initial={opts.initial} defaultCurve={defaultCurve} onCommit={opts.onCommit} />);
+}

--- a/decky/armada-control/src/tabs/Power.tsx
+++ b/decky/armada-control/src/tabs/Power.tsx
@@ -1,75 +1,158 @@
-import { ButtonItem, PanelSection } from "@decky/ui";
+import { ButtonItem, PanelSection, PanelSectionRow } from "@decky/ui";
 import { useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
-import { SelectEdit, SliderEdit } from "../components/widgets";
+import { SelectEdit } from "../components/widgets";
 import { clone, titleCase, update } from "../lib/util";
+import { openCurveEditor } from "../components/CurveEditor";
 import type { Config, PowerProfile } from "../types";
 
-const underclocks = [
-  { data: "none", label: "None" },
-  { data: "small", label: "Small" },
-  { data: "medium", label: "Medium" },
-  { data: "large", label: "Large" },
-];
+const GPU_TOP_MHZ = 1100; // the daemon expresses GPU limits as a ratio of the top OPP.
+// Daemon uses int(top*ratio) then snaps: choose_at_most for max, choose_at_least for min.
+const atMost = (list: number[], t: number) => {
+  const below = list.filter((v) => v <= t);
+  return below.length ? below[below.length - 1] : (list[0] ?? 0);
+};
+const atLeast = (list: number[], t: number) => {
+  const above = list.filter((v) => v >= t);
+  return above.length ? above[0] : (list[list.length - 1] ?? 0);
+};
+const nearest = (list: number[], t: number) => (list.length ? list.reduce((a, b) => (Math.abs(b - t) < Math.abs(a - t) ? b : a)) : t);
+const ratioMax = (m: number) => Math.min(1, (m + 8) / GPU_TOP_MHZ); // +8 keeps int(top*r) inside the OPP band
+const ratioMin = (m: number) => m / GPU_TOP_MHZ;
 
 export function Power({ config, setConfig }: { config: Config; setConfig: Dispatch<SetStateAction<Config | null>> }) {
-  const [profile, setProfile] = useState(config.power.general.default_profile || "balanced");
-  const p = config.power.profiles[profile] || ({} as PowerProfile);
-  const profiles = Object.entries(config.power.profiles || {}).map(([name, profile]) => ({
-    data: name,
-    label: profile.label || titleCase(name),
-  }));
-  const fanCurves = Object.entries(config.power.fan_curves || {}).map(([name, curve]) => ({
-    data: name,
-    label: curve.label || titleCase(name),
-  }));
-  const setProfileValue = (name: string, value: any) => {
-    setConfig((current) => (current ? update(current, ["power", "profiles", profile, name], value) : current));
+  const order = config.power.order?.length ? config.power.order : Object.keys(config.power.profiles || {});
+  const [selected, setSelected] = useState(config.power.general.default_profile || order[0]);
+  const profile = order.includes(selected) ? selected : order[0];
+  const p = (config.power.profiles[profile] || {}) as PowerProfile;
+
+  const hw = config.hardware || { cpu: {}, gpu: [], governors: [] };
+  const gpuOpps = hw.gpu || [];
+  const govs = hw.governors?.length ? hw.governors : ["schedutil"];
+
+  const profileOptions = order.map((name) => ({ data: name, label: config.power.profiles[name]?.label || titleCase(name) }));
+  // Only curves actually referenced by a profile. Hides leftover factory presets (relaxed/moderate/aggressive).
+  const usedCurves = new Set(order.map((n) => config.power.profiles[n]?.fan_curve).filter(Boolean));
+  const fanCurves = Object.entries(config.power.fan_curves || {})
+    .filter(([name]) => usedCurves.has(name))
+    .map(([name, c]) => ({ data: name, label: c.label || titleCase(name) }));
+
+  const setField = (name: string, value: any) =>
+    setConfig((cur) => (cur ? update(cur, ["power", "profiles", profile, name], value) : cur));
+
+  // CPU per-cluster: lowest policy id = efficiency cores, highest = performance cores.
+  const policyIds = Object.keys(hw.cpu).map(Number).sort((a, b) => a - b);
+  const effId = policyIds.length ? String(policyIds[0]) : "0";
+  const primeId = policyIds.length > 1 ? String(policyIds[policyIds.length - 1]) : effId;
+  const effFreqs = hw.cpu[effId] || [];
+  const primeFreqs = hw.cpu[primeId] || [];
+  const toMhz = (khz: number) => Math.round(khz / 1000);
+  // Effective cap = explicit per-policy MHz if set, else the profile's underclock-level table, else top OPP.
+  const uclevels = (config.power.underclocks && config.power.underclocks[config.cpuDeviceClass]) || {};
+  const resolveKhz = (prof: PowerProfile, pid: string, freqs: number[]): number => {
+    const explicit = Number(prof[`cpu_max_policy${pid}`] || 0);
+    if (explicit > 0) return explicit;
+    const level = prof.cpu_underclock;
+    const lvl = level && level !== "none" ? uclevels[level] : undefined;
+    const fromLevel = lvl ? Number(lvl[`cpu_max_policy${pid}`] || 0) : 0;
+    if (fromLevel > 0) return fromLevel;
+    return freqs.length ? freqs[freqs.length - 1] : 0;
   };
-  const setGpuValue = (name: string, value: any) => {
-    setConfig((current) => {
-      if (!current) return current;
-      const next = clone(current);
-      const target: any = next.power.profiles[profile];
-      target[name] = value;
-      if (name === "gpu_min" && Number(value) > Number(target.gpu_max || 0)) {
-        target.gpu_max = value;
-      }
-      if (name === "gpu_max" && Number(value) < Number(target.gpu_min || 0)) {
-        target.gpu_min = value;
+  const curEff = resolveKhz(p, effId, effFreqs);
+  const curPrime = resolveKhz(p, primeId, primeFreqs);
+
+  // GPU: stored as ratio, shown as MHz.
+  const showGpuMax = gpuOpps.length ? atMost(gpuOpps, Math.floor(Number(p.gpu_max || 1) * GPU_TOP_MHZ)) : 0;
+  const showGpuMin = gpuOpps.length ? atLeast(gpuOpps, Math.floor(Number(p.gpu_min || 0) * GPU_TOP_MHZ)) : 0;
+  const setGpu = (which: "gpu_min" | "gpu_max", pickMhz: number) => {
+    setConfig((cur) => {
+      if (!cur) return cur;
+      const next = clone(cur);
+      const t = next.power.profiles[profile] as PowerProfile;
+      if (which === "gpu_max") t.gpu_max = ratioMax(pickMhz).toFixed(4);
+      else t.gpu_min = ratioMin(pickMhz).toFixed(4);
+      const mx = atMost(gpuOpps, Math.floor(Number(t.gpu_max || 1) * GPU_TOP_MHZ));
+      const mn = atLeast(gpuOpps, Math.floor(Number(t.gpu_min || 0) * GPU_TOP_MHZ));
+      if (mn > mx) {
+        if (which === "gpu_max") t.gpu_min = ratioMin(mx).toFixed(4);
+        else t.gpu_max = ratioMax(mn).toFixed(4);
       }
       return next;
     });
   };
+
   const resetProfile = () => {
-    const defaults = config.powerDefaults?.profiles?.[profile];
-    if (!defaults) return;
-    setConfig((current) => (current ? update(current, ["power", "profiles", profile], defaults) : current));
+    const def = config.powerDefaults?.profiles?.[profile];
+    if (!def) return;
+    setConfig((cur) => (cur ? update(cur, ["power", "profiles", profile], clone(def)) : cur));
   };
-  const underclockLevel = p.cpu_underclock || "";
-  const supportsUnderclockPresets = !!config.power.underclocks?.[config.cpuDeviceClass];
+
   return (
     <>
       <PanelSection title="EDIT POWER PROFILE">
-        <SelectEdit value={profile} options={profiles} onChange={setProfile} />
+        <SelectEdit value={profile} options={profileOptions} onChange={setSelected} />
       </PanelSection>
-      <PanelSection title="PROFILE SETTINGS">
-        <SelectEdit label="Fan Curve" value={p.fan_curve} options={fanCurves} onChange={(v) => setProfileValue("fan_curve", v)} />
-        {(config.perf?.governors?.length ?? 0) > 0 ? (
+      <PanelSection title="FAN">
+        <SelectEdit label="Fan Curve" value={p.fan_curve} options={fanCurves} onChange={(v) => setField("fan_curve", v)} />
+        <PanelSectionRow>
+          <div className="armada-reset-row">
+            <ButtonItem
+              layout="below"
+              disabled={!p.fan_curve || !config.power.fan_curves?.[p.fan_curve]}
+              onClick={() => openCurveEditor({
+                profileLabel: config.power.profiles[profile]?.label || titleCase(profile),
+                curveName: p.fan_curve,
+                initial: config.power.fan_curves?.[p.fan_curve]?.curve || "",
+                onCommit: (curve) => setConfig((cur) => (cur ? update(cur, ["power", "fan_curves", p.fan_curve, "curve"], curve) : cur)),
+              })}
+            >
+              Edit fan curve
+            </ButtonItem>
+          </div>
+        </PanelSectionRow>
+      </PanelSection>
+      {effFreqs.length ? (
+        <PanelSection title="CPU MAX FREQUENCY">
           <SelectEdit
-            label="CPU Governor"
-            value={p.cpu_governor}
-            options={config.perf!.governors.map((g) => ({ data: g, label: titleCase(g) }))}
-            onChange={(v) => setProfileValue("cpu_governor", v)}
+            label="Efficiency cores"
+            value={String(nearest(effFreqs, curEff))}
+            options={effFreqs.map((k) => ({ data: String(k), label: `${toMhz(k)} MHz` }))}
+            onChange={(v) => setField(`cpu_max_policy${effId}`, String(v))}
           />
-        ) : null}
-        {supportsUnderclockPresets ? (
-          <SelectEdit label="CPU Underclock" value={underclockLevel} options={underclocks} onChange={(v) => setProfileValue("cpu_underclock", v)} />
-        ) : (
-          <SliderEdit label="CPU Max (%)" value={Math.round(Number(p.cpu_max || 0) * 100)} min={35} max={100} step={1} onChange={(v) => setProfileValue("cpu_max", (v / 100).toFixed(2))} />
-        )}
-        <SliderEdit label="GPU Min (%)" value={Math.round(Number(p.gpu_min || 0) * 100)} min={0} max={100} step={1} onChange={(v) => setGpuValue("gpu_min", (v / 100).toFixed(2))} />
-        <SliderEdit label="GPU Max (%)" value={Math.round(Number(p.gpu_max || 0) * 100)} min={35} max={100} step={1} onChange={(v) => setGpuValue("gpu_max", (v / 100).toFixed(2))} />
+          {primeFreqs.length && primeId !== effId ? (
+            <SelectEdit
+              label="Performance cores"
+              value={String(nearest(primeFreqs, curPrime))}
+              options={primeFreqs.map((k) => ({ data: String(k), label: `${toMhz(k)} MHz` }))}
+              onChange={(v) => setField(`cpu_max_policy${primeId}`, String(v))}
+            />
+          ) : null}
+        </PanelSection>
+      ) : null}
+      {gpuOpps.length ? (
+        <PanelSection title="GPU FREQUENCY">
+          <SelectEdit
+            label="GPU Max"
+            value={String(showGpuMax)}
+            options={gpuOpps.map((m) => ({ data: String(m), label: `${m} MHz` }))}
+            onChange={(v) => setGpu("gpu_max", Number(v))}
+          />
+          <SelectEdit
+            label="GPU Min (floor)"
+            value={String(showGpuMin)}
+            options={gpuOpps.map((m) => ({ data: String(m), label: `${m} MHz` }))}
+            onChange={(v) => setGpu("gpu_min", Number(v))}
+          />
+        </PanelSection>
+      ) : null}
+      <PanelSection title="GOVERNOR">
+        <SelectEdit
+          value={p.cpu_governor || "schedutil"}
+          options={govs.map((g) => ({ data: g, label: titleCase(g) }))}
+          onChange={(v) => setField("cpu_governor", v)}
+        />
+      </PanelSection>
+      <PanelSection>
         <div className="armada-reset-row">
           <ButtonItem layout="below" onClick={resetProfile}>Reset to Default</ButtonItem>
         </div>

--- a/decky/armada-control/src/types.ts
+++ b/decky/armada-control/src/types.ts
@@ -6,6 +6,15 @@ export interface PowerProfile {
   gpu_max: string;
   gpu_min: string;
   fan_curve: string;
+  cpu_max_policy0?: string;
+  cpu_max_policy6?: string;
+  [key: string]: string | undefined;
+}
+
+export interface Hardware {
+  cpu: Record<string, number[]>;
+  gpu: number[];
+  governors: string[];
 }
 
 export interface FanCurve {
@@ -15,6 +24,7 @@ export interface FanCurve {
 
 export interface PowerConfig {
   general: { default_profile: string };
+  order?: string[];
   profiles: Record<string, PowerProfile>;
   fan_curves: Record<string, FanCurve>;
   fan: Record<string, string>;
@@ -80,6 +90,7 @@ export interface PerfInfo {
 export interface Config {
   power: PowerConfig;
   powerDefaults: PowerConfig;
+  hardware?: Hardware;
   tweaks: Tweaks;
   installedGames: InstalledGame[];
   fexProfiles: Record<string, FexProfile>;

--- a/system_files/usr/libexec/armada/armada-powerd
+++ b/system_files/usr/libexec/armada/armada-powerd
@@ -22,6 +22,8 @@ IFACE = "org.armada.Power1"
 LOGIN1_NAME = "org.freedesktop.login1"
 LOGIN1_PATH = "/org/freedesktop/login1"
 LOGIN1_IFACE = "org.freedesktop.login1.Manager"
+# Populated from discovered [profile.*] config sections at load; this literal is
+# only the pre-config fallback.
 PROFILES = ["eco", "balanced", "performance"]
 STATE_FILE = Path("/var/lib/armada/powerd.state")
 FACTORY_CONFIG_FILE = Path("/usr/share/armada/power-profiles.conf")
@@ -249,8 +251,17 @@ class ArmadaPower:
         if not parser.read(config_files):
             raise FileNotFoundError(FACTORY_CONFIG_FILE)
         require_section(parser, "general")
+        profiles = [s.removeprefix("profile.") for s in parser.sections() if s.startswith("profile.")]
+        if not profiles:
+            raise ValueError("no [profile.*] sections")
+        order = parser.get("general", "profile_order", fallback="").strip().lower()
+        if order:
+            wanted = [p.strip() for p in order.split(",") if p.strip()]
+            if sorted(wanted) != sorted(profiles):
+                raise ValueError(f"profile_order does not match [profile.*] sections: {order}")
+            profiles = wanted
         default_profile = parser.get("general", "default_profile").strip().lower()
-        if default_profile not in PROFILES:
+        if default_profile not in profiles:
             raise ValueError(f"invalid default_profile: {default_profile}")
         for section in parser.sections():
             if not section.startswith("underclock."):
@@ -283,7 +294,7 @@ class ArmadaPower:
                 fan_curves[parts[1]] = curve
         if not fan_curves:
             raise ValueError("missing fan curves")
-        for profile in PROFILES:
+        for profile in profiles:
             section = f"profile.{profile}"
             require_section(parser, section)
             fan_curve = parser.get(section, "fan_curve").strip().lower()
@@ -348,7 +359,7 @@ class ArmadaPower:
         system_config = {
             "irq_cores": parser.get("system", "irq_cores", fallback="auto").strip(),
         }
-        return (default_profile, underclock_config, fan_curves, profile_config,
+        return (profiles, default_profile, underclock_config, fan_curves, profile_config,
                 fan_config, suspend_config, system_config)
 
     def load_config(self):
@@ -358,6 +369,7 @@ class ArmadaPower:
             restore_factory_config(exc)
             parsed = self.parse_config(include_user=False)
         (
+            profiles,
             self.default_profile,
             self.underclock_config,
             self.fan_curves,
@@ -366,6 +378,7 @@ class ArmadaPower:
             self.suspend_config,
             self.system_config,
         ) = parsed
+        PROFILES[:] = profiles
         self.profile_labels = {p: self.profile_config[p].get("label", p) for p in PROFILES}
 
     def discover_gpu(self):
@@ -564,7 +577,8 @@ class ArmadaPower:
         return int(freqs[-1] * settings["cpu_max"])
 
     def profile_settings(self):
-        return self.profile_config.get(self.profile, self.profile_config["balanced"])
+        settings = self.profile_config.get(self.profile) or self.profile_config.get(self.default_profile)
+        return settings or next(iter(self.profile_config.values()))
 
     def write_governor(self, path, preferred):
         available = read_text(path / "scaling_available_governors").split()

--- a/system_files/usr/share/armada/power-profiles.conf
+++ b/system_files/usr/share/armada/power-profiles.conf
@@ -1,99 +1,118 @@
 [general]
-default_profile=balanced
+default_profile = balanced
+profile_order = eco, sailor, bosun, balanced, firstmate, captain, performance
 
 [profile.eco]
-label=Eco
-cpu_governor=schedutil
-cpu_max=0.65
-cpu_underclock=large
-gpu_max=0.80
-gpu_min=0.0
-fan_curve=relaxed
+label = Cabin Boy
+cpu_governor = schedutil
+cpu_max = 1.00
+cpu_underclock = cabinboy
+gpu_max = 0.3200
+gpu_min = 0.1400
+fan_curve = fc_cabinboy
+
+[profile.sailor]
+label = Sailor
+cpu_governor = schedutil
+cpu_max = 1.00
+cpu_underclock = sailor
+gpu_max = 0.4100
+gpu_min = 0.1400
+fan_curve = fc_sailor
+
+[profile.bosun]
+label = Bosun
+cpu_governor = schedutil
+cpu_max = 1.00
+cpu_underclock = medium
+gpu_max = 0.6000
+gpu_min = 0.3100
+fan_curve = fc_bosun
 
 [profile.balanced]
-label=Balanced
-cpu_governor=schedutil
-cpu_max=0.65
-cpu_underclock=medium
-gpu_max=1.0
-gpu_min=0.0
-fan_curve=moderate
+label = Quartermaster
+cpu_governor = schedutil
+cpu_max = 1.00
+cpu_underclock = small
+gpu_max = 0.7700
+gpu_min = 0.3100
+fan_curve = fc_quartermaster
+
+[profile.firstmate]
+label = First Mate
+cpu_governor = schedutil
+cpu_max = 1.00
+cpu_underclock = firstmate
+gpu_max = 0.8800
+gpu_min = 0.4000
+fan_curve = fc_firstmate
+
+[profile.captain]
+label = Captain
+cpu_governor = schedutil
+cpu_max = 1.00
+cpu_underclock = captain
+gpu_max = 1.0000
+gpu_min = 0.5500
+fan_curve = fc_captain
 
 [profile.performance]
-label=Performance
-cpu_governor=performance
-cpu_max=1.0
-cpu_underclock=none
-gpu_max=1.0
-gpu_min=1.0
-fan_curve=aggressive
+label = Admiral
+cpu_governor = schedutil
+cpu_max = 1.00
+cpu_underclock = none
+gpu_max = 1.0000
+gpu_min = 0.6000
+fan_curve = fc_admiral
 
-[fan_curve.relaxed]
-label=Relaxed
-curve=98:255,94:204,88:153,82:102,76:77,65:51,0:51
+[underclock.SM8750.cabinboy]
+cpu_max_policy0 = 1152000
+cpu_max_policy6 = 1209600
 
-[fan_curve.moderate]
-label=Moderate
-curve=96:255,90:204,84:153,78:102,72:77,55:51,0:51
+[underclock.SM8750.sailor]
+cpu_max_policy0 = 1555200
+cpu_max_policy6 = 1689600
 
-[fan_curve.aggressive]
-label=Aggressive
-curve=90:255,85:204,80:153,74:102,66:77,45:51,0:51
+[underclock.SM8750.firstmate]
+cpu_max_policy0 = 3072000
+cpu_max_policy6 = 3513600
+
+[underclock.SM8750.captain]
+cpu_max_policy0 = 3321600
+cpu_max_policy6 = 3801600
+
+[fan_curve.fc_cabinboy]
+label = Cabin Boy
+curve = 0:0,64:8,68:16,71:34,74:56,78:92,82:132,85:162,88:192,92:255
+
+[fan_curve.fc_sailor]
+label = Sailor
+curve = 0:0,64:16,68:32,71:56,74:80,78:116,82:152,85:176,88:200,92:255
+
+[fan_curve.fc_bosun]
+label = Bosun
+curve = 0:0,57:8,61:16,66:46,70:72,74:104,79:144,83:176,88:208,92:255
+
+[fan_curve.fc_quartermaster]
+label = Quartermaster
+curve = 0:0,53:8,58:22,63:52,68:82,72:112,77:152,82:182,87:211,92:255
+
+[fan_curve.fc_firstmate]
+label = First Mate
+curve = 0:8,51:16,56:30,61:60,66:90,72:128,77:164,82:194,87:216,92:255
+
+[fan_curve.fc_captain]
+label = Captain
+curve = 0:24,51:32,56:52,61:76,66:106,72:150,77:180,82:204,87:216,92:255
+
+[fan_curve.fc_admiral]
+label = Admiral
+curve = 0:32,51:48,56:68,61:92,66:128,72:166,77:192,82:212,87:224,92:255
 
 [fan]
-min_pwm=51
-max_pwm=255
-ramp_up=36
-ramp_down=6
-smoothing=0.50
-pwm_quantum=8
-
-[suspend]
-fan_safe_above=55
-fan_low_pwm=51
-fan_safe_pwm=128
-
-[underclock.SM8550.small]
-cpu_max_policy0=1785600
-cpu_max_policy3=2323200
-cpu_max_policy7=2476800
-
-[underclock.SM8550.medium]
-cpu_max_policy0=1555200
-cpu_max_policy3=2054400
-cpu_max_policy7=2092800
-
-[underclock.SM8550.large]
-cpu_max_policy0=1459200
-cpu_max_policy3=1785600
-cpu_max_policy7=1843200
-
-[underclock.SM8650.small]
-cpu_max_policy0=1939200
-cpu_max_policy2=2764800
-cpu_max_policy5=2764800
-cpu_max_policy7=2937600
-
-[underclock.SM8650.medium]
-cpu_max_policy0=1689600
-cpu_max_policy2=2323200
-cpu_max_policy5=2323200
-cpu_max_policy7=2457600
-
-[underclock.SM8650.large]
-cpu_max_policy0=1459200
-cpu_max_policy2=2035200
-cpu_max_policy5=2035200
-cpu_max_policy7=2112000
-
-[underclock.SM8750.small]
-cpu_max_policy0=2745600
-cpu_max_policy6=3072000
-
-[underclock.SM8750.medium]
-cpu_max_policy0=2227200
-cpu_max_policy6=2246400
-
-[underclock.SM8750.large]
-cpu_max_policy0=1785600
-cpu_max_policy6=1958400
+min_pwm = 0
+max_pwm = 255
+ramp_up = 36
+ramp_down = 6
+smoothing = 0.5
+pwm_quantum = 8


### PR DESCRIPTION
## Summary

Reworks Armada Control's power section into a config-driven system. The daemon discovers profiles from a single `power-profiles.conf`; the plugin exposes real per-cluster CPU and GPU frequency controls, a governor selector, N power profiles, and a graphical fan-curve editor. Ships a 7-tier SM8750 profile set as the default config.

## What's included

- **Config-driven `armada-powerd`**: reads `[factory, /etc]` `power-profiles.conf`, discovers profiles from `[profile.*]`, and applies CPU caps, GPU min/max, governor, and the fan curve. Falls back to the factory config if an `/etc` override is invalid.
- **7 power profiles** (era-mapped tiers) for finer control on higher-power devices, instead of the fixed 3.
- **Per-cluster CPU max frequency**: performance and efficiency cores set independently, in real MHz (read from the sysfs frequency tables).
- **GPU min/max frequency** in real MHz (from the devfreq OPP table).
- **CPU governor selector** per profile.
- **7 fan curves plus a manual graphical fan-curve editor**: drag curve points by touch, or adjust with on-screen buttons (Prev/Next, +/-, Add/Remove), restore the profile's default curve, and Save. Client and server validation enforce ascending temperature, monotonic pwm, in-range values, and a full-speed-by-92C floor before write, so a malformed curve can never reach the daemon.
- **SM8750 default config** with the 7 tiers and 10-point fan curves.

## Testing

Validated on device (KONKR / AYANEO Pocket FIT Elite, SM8750): profile switching, per-cluster CPU and GPU frequency changes, governor changes, and the fan-curve editor (touch drag, buttons, Save) with the fan responding to the saved curve.

## Note

Supersedes #223: rebased on current `main`, with the daemon reconciled against the new per-game performance logic, and adds the graphical fan-curve editor.
