### PR TITLE
Add a sing-box VPN toggle, profiles, and a browser-based config import

### DIFF
--- a/build_files/46-install-singbox.sh
+++ b/build_files/46-install-singbox.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euxo pipefail
+
+# sing-box static binary, pinned release + sha256 (arm64).
+SB_VER=1.13.16
+SB_SHA=d587fb00bdc3c044227f35d15d154f271bc75108475091eda2542e4b82bb2949
+curl -fsSL -o /tmp/sing-box.tar.gz     "https://github.com/SagerNet/sing-box/releases/download/v${SB_VER}/sing-box-${SB_VER}-linux-arm64.tar.gz"
+echo "${SB_SHA}  /tmp/sing-box.tar.gz" | sha256sum -c -
+tar -xzf /tmp/sing-box.tar.gz -C /tmp
+install -m 0755 "/tmp/sing-box-${SB_VER}-linux-arm64/sing-box" /usr/bin/sing-box
+rm -rf /tmp/sing-box.tar.gz "/tmp/sing-box-${SB_VER}-linux-arm64"
+/usr/bin/sing-box version

--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -8,6 +8,7 @@ cd /ctx/build_files
 ./30-install-steam-session.sh
 ./40-vendor-system-files.sh
 ./45-install-decky-plugins.sh
+./46-install-singbox.sh
 ./50-create-user.sh
 ./55-generate-initramfs.sh
 ./60-set-default-target.sh

--- a/decky/armada-control/main.py
+++ b/decky/armada-control/main.py
@@ -11,8 +11,9 @@ from armada_control.config import build_config
 from armada_control.controller import set_controller_type
 from armada_control.power import save_power_config
 from armada_control.steam import installed_games
-from armada_control.system import reapply_perf, set_ssh_enabled
+from armada_control.system import reapply_perf, set_ssh_enabled, set_vpn_enabled, set_vpn_profile
 from armada_control.tweaks import load_compat_applied, save_compat_applied, save_tweaks
+from armada_control.vpn_import import start as vpn_import_start, status as vpn_import_status, stop as vpn_import_stop
 
 
 class Plugin:
@@ -40,6 +41,20 @@ class Plugin:
     async def set_ssh_enabled(self, enabled):
         return await asyncio.to_thread(set_ssh_enabled, enabled)
 
+    async def set_vpn_enabled(self, enabled):
+        return await asyncio.to_thread(set_vpn_enabled, enabled)
+
+    async def set_vpn_profile(self, profile):
+        return await asyncio.to_thread(set_vpn_profile, profile)
+
+    async def start_vpn_import(self, profile="1"):
+        return await asyncio.to_thread(vpn_import_start, profile)
+
+    async def stop_vpn_import(self):
+        return await asyncio.to_thread(vpn_import_stop)
+
+    async def vpn_import_status(self):
+        return await asyncio.to_thread(vpn_import_status)
     async def reapply_perf(self):
         return await asyncio.to_thread(reapply_perf)
 

--- a/decky/armada-control/package-lock.json
+++ b/decky/armada-control/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@decky/api": "1.1.3",
-        "@decky/ui": "4.11.6"
+        "@decky/ui": "4.11.6",
+        "qrcode.react": "^4.2.0"
       },
       "devDependencies": {
         "@decky/rollup": "1.0.2",
@@ -2244,6 +2245,15 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -2264,6 +2274,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/rechoir": {
       "version": "0.6.2",

--- a/decky/armada-control/package.json
+++ b/decky/armada-control/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "@decky/api": "1.1.3",
-    "@decky/ui": "4.11.6"
+    "@decky/ui": "4.11.6",
+    "qrcode.react": "^4.2.0"
   },
   "devDependencies": {
     "@decky/rollup": "1.0.2",

--- a/decky/armada-control/py_modules/armada_control/config.py
+++ b/decky/armada-control/py_modules/armada_control/config.py
@@ -1,7 +1,7 @@
 from .controller import CONTROLLER_TYPES, controller_type
 from .power import factory_power_defaults, parse_power
 from .steam import installed_games
-from .system import abl_version, cpu_device_class, os_version, perf_info, ssh_enabled
+from .system import abl_version, cpu_device_class, os_version, perf_info, ssh_enabled, vpn_enabled, vpn_profile
 from .tweaks import fex_profile_labels, load_fex_contract, load_tweaks
 
 
@@ -18,6 +18,8 @@ def build_config(include_games=True):
         "osVersion": os_version(),
         "ablVersion": abl_version(),
         "sshEnabled": ssh_enabled(),
+        "vpnEnabled": vpn_enabled(),
+        "vpnProfile": vpn_profile(),
         "controllerType": controller_type(),
         "controllerTypes": [{"data": key, "label": label} for key, label in CONTROLLER_TYPES.items()],
     }

--- a/decky/armada-control/py_modules/armada_control/system.py
+++ b/decky/armada-control/py_modules/armada_control/system.py
@@ -77,6 +77,36 @@ def read_text(path):
         return ""
 
 
+def vpn_enabled():
+    try:
+        return bool(call("get_vpn_enabled").get("enabled"))
+    except Exception:
+        pass
+    active = run_cmd(["/usr/bin/systemctl", "is-active", "sing-box"])
+    active_s = active.stdout.strip() if active else ""
+    return active_s == "active"
+
+
+def vpn_profile():
+    try:
+        return str(call("get_vpn_profile").get("profile") or "1")
+    except Exception:
+        pass
+    try:
+        with open("/etc/sing-box/active") as fh:
+            return fh.read().strip() or "1"
+    except Exception:
+        return "1"
+
+
+def set_vpn_profile(profile):
+    return str(call("set_vpn_profile", profile=str(profile)).get("profile") or "1")
+
+
+def set_vpn_enabled(enabled):
+    return bool(call("set_vpn_enabled", enabled=bool(enabled)).get("enabled"))
+
+
 def set_ssh_enabled(enabled):
     return bool(call("set_ssh_enabled", enabled=bool(enabled)).get("enabled"))
 

--- a/decky/armada-control/py_modules/armada_control/vpn_import.py
+++ b/decky/armada-control/py_modules/armada_control/vpn_import.py
@@ -1,0 +1,114 @@
+import http.server
+import json
+import socket
+import threading
+from urllib.parse import parse_qs, urlparse
+
+from .privileged import call
+
+IMPORT_PORT = 8799
+
+_server = None
+_thread = None
+_state = {"received": False, "last_profile": ""}
+
+
+def _lan_ip():
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect(("8.8.8.8", 80))
+        ip = s.getsockname()[0]
+        s.close()
+        return ip
+    except Exception:
+        return "127.0.0.1"
+
+
+_PAGE = """<!doctype html><html><head><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Import VPN config</title><style>
+body{font-family:sans-serif;background:#14171c;color:#e8e8e8;margin:0;padding:24px;max-width:760px}
+h2{font-weight:500}code{color:#8ab4f8}
+textarea{width:100%;height:280px;box-sizing:border-box;font-family:monospace;font-size:13px;background:#0f1216;color:#dfe;border:1px solid #333;border-radius:8px;padding:10px}
+button{margin-top:14px;padding:12px 22px;font-size:16px;border:0;border-radius:8px;color:#fff;cursor:pointer}
+.b1{background:#2677d8}.b2{background:#1d9e75;margin-left:10px}
+.msg{margin-top:14px;font-size:15px}.ok{color:#5dcaa5}.err{color:#e24b4a}
+</style></head><body>
+<h2>Import VPN config</h2>
+<p>Paste a <code>vless://</code> link <b>or</b> a full sing-box <code>config.json</code>, then choose a profile:</p>
+<textarea id="c" placeholder="vless://uuid@host:443?type=grpc&security=reality&sni=...&pbk=...&sid=...   (or a full config.json)"></textarea>
+<div>
+  <button class="b1" onclick="save('1')">Save to Profile 1</button>
+  <button class="b2" onclick="save('2')">Save to Profile 2</button>
+</div>
+<div id="m" class="msg"></div>
+<script>
+async function save(p){var m=document.getElementById('m');m.className='msg';m.textContent='Saving to Profile '+p+'...';
+try{var r=await fetch('/import?profile='+p,{method:'POST',headers:{'Content-Type':'text/plain'},body:document.getElementById('c').value});
+var j=await r.json();if(j.ok){m.className='msg ok';m.textContent='Saved to Profile '+j.profile+(j.active?' (VPN restarted)':'')+'. Paste another to save to the other profile, or close this page.';}
+else{m.className='msg err';m.textContent='Error: '+(j.error||'failed');}}catch(e){m.className='msg err';m.textContent='Error: '+e;}}
+</script></body></html>"""
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, *args):
+        pass
+
+    def _send(self, code, body, ctype="text/html; charset=utf-8"):
+        data = body.encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_GET(self):
+        if urlparse(self.path).path == "/import":
+            self._send(200, _PAGE)
+        else:
+            self._send(404, "not found")
+
+    def do_POST(self):
+        parsed = urlparse(self.path)
+        if parsed.path != "/import":
+            self._send(404, "not found")
+            return
+        try:
+            profile = (parse_qs(parsed.query).get("profile") or ["1"])[0]
+            if profile not in ("1", "2"):
+                raise ValueError("choose Profile 1 or 2")
+            length = int(self.headers.get("Content-Length", 0))
+            text = self.rfile.read(length).decode("utf-8")
+            result = call("import_vpn_config", profile=profile, text=text)
+            _state["received"] = True
+            _state["last_profile"] = result.get("profile", profile)
+            self._send(200, json.dumps({"ok": True, "profile": result.get("profile"), "active": result.get("active")}), "application/json")
+        except Exception as exc:
+            self._send(200, json.dumps({"ok": False, "error": str(exc)[:300]}), "application/json")
+
+
+def start(profile="1"):
+    global _server, _thread
+    stop()
+    _state["received"] = False
+    _state["last_profile"] = ""
+    _server = http.server.ThreadingHTTPServer(("0.0.0.0", IMPORT_PORT), _Handler)
+    _thread = threading.Thread(target=_server.serve_forever, daemon=True)
+    _thread.start()
+    return {"url": "http://%s:%d/import" % (_lan_ip(), IMPORT_PORT), "port": IMPORT_PORT}
+
+
+def stop():
+    global _server, _thread
+    if _server is not None:
+        try:
+            _server.shutdown()
+            _server.server_close()
+        except Exception:
+            pass
+    _server = None
+    _thread = None
+    return {"ok": True}
+
+
+def status():
+    return {"running": _server is not None, "received": _state["received"], "profile": _state.get("last_profile", "")}

--- a/decky/armada-control/src/backend.ts
+++ b/decky/armada-control/src/backend.ts
@@ -16,6 +16,8 @@ export const saveCompatApplied = (appids: string[]) => {
   return request;
 };
 export const setSshEnabled = (enabled: boolean) => call<[boolean], boolean>("set_ssh_enabled", enabled);
+export const setVpnEnabled = (enabled: boolean) => call<[boolean], boolean>("set_vpn_enabled", enabled);
+export const setVpnProfile = (profile: string) => call<[string], string>("set_vpn_profile", profile);
 export const reapplyPerf = () => call<[], { pids?: number }>("reapply_perf");
 export const setControllerType = (value: string) => call<[string], string>("set_controller_type", value);
 export const getControllerState = () => call<[], CalibrationState>("get_controller_state");
@@ -23,3 +25,6 @@ export const saveCalibration = (capture: Capture) => call<[Capture], Calibration
 export const resetCalibration = () => call<[], CalibrationState>("reset_calibration");
 export const beginCalibrationSession = (token: string) => call<[string], boolean>("begin_calibration_session", token);
 export const endCalibrationSession = (token: string) => call<[string], boolean>("end_calibration_session", token);
+export const startVpnImport = (profile: string) => call<[string], { url: string; port: number; profile: string }>("start_vpn_import", profile);
+export const stopVpnImport = () => call<[], { ok: boolean }>("stop_vpn_import");
+export const vpnImportStatus = () => call<[], { running: boolean; profile: string; received: boolean }>("vpn_import_status");

--- a/decky/armada-control/src/components/VpnImport.tsx
+++ b/decky/armada-control/src/components/VpnImport.tsx
@@ -1,0 +1,69 @@
+import { DialogBody, DialogButton, DialogFooter, ModalRoot, showModal } from "@decky/ui";
+import { useEffect, useState } from "react";
+import { QRCodeSVG } from "qrcode.react";
+import { startVpnImport, stopVpnImport, vpnImportStatus } from "../backend";
+
+function VpnImportModal({ closeModal }: { closeModal?: () => void }) {
+  const [url, setUrl] = useState("");
+  const [err, setErr] = useState("");
+  const [savedProfile, setSavedProfile] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    startVpnImport("1")
+      .then((r) => { if (!cancelled) setUrl(r.url); })
+      .catch((e) => { if (!cancelled) setErr(String(e)); });
+    const timer = window.setInterval(async () => {
+      try {
+        const s = await vpnImportStatus();
+        if (!cancelled && s.received) setSavedProfile(s.profile || "?");
+      } catch (e) {
+        // ignore transient poll errors
+      }
+    }, 1500);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+      stopVpnImport().catch(() => {});
+    };
+  }, []);
+
+  const close = () => closeModal?.();
+
+  return (
+    <ModalRoot onCancel={close}>
+      <DialogBody>
+        <div style={{ textAlign: "center" }}>
+          <div style={{ fontSize: "18px", fontWeight: 600, marginBottom: "12px" }}>Import VPN config</div>
+          {err ? (
+            <div style={{ color: "#e24b4a" }}>{err}</div>
+          ) : url ? (
+            <>
+              <div style={{ background: "#ffffff", padding: "12px", display: "inline-block", borderRadius: "8px" }}>
+                <QRCodeSVG value={url} size={190} />
+              </div>
+              <div style={{ marginTop: "14px", fontSize: "13px", opacity: 0.7 }}>
+                Open this on your computer or phone (same Wi-Fi), paste your vless:// link or config, then pick Profile 1 or 2:
+              </div>
+              <div style={{ marginTop: "6px", fontFamily: "monospace", fontSize: "16px", color: "#3b8ade" }}>{url}</div>
+              {savedProfile ? (
+                <div style={{ marginTop: "16px", color: "#5dcaa5", fontWeight: 500 }}>Config saved to Profile {savedProfile}.</div>
+              ) : (
+                <div style={{ marginTop: "16px", opacity: 0.6 }}>Waiting for your config...</div>
+              )}
+            </>
+          ) : (
+            <div style={{ opacity: 0.6 }}>Starting server...</div>
+          )}
+        </div>
+      </DialogBody>
+      <DialogFooter>
+        <DialogButton onClick={close}>{savedProfile ? "Done" : "Cancel"}</DialogButton>
+      </DialogFooter>
+    </ModalRoot>
+  );
+}
+
+export function openVpnImport() {
+  showModal(<VpnImportModal />);
+}

--- a/decky/armada-control/src/tabs/Settings.tsx
+++ b/decky/armada-control/src/tabs/Settings.tsx
@@ -1,7 +1,8 @@
 import { ButtonItem, Field, PanelSection } from "@decky/ui";
 import type { Dispatch, SetStateAction } from "react";
-import { setControllerType as applyControllerType, setSshEnabled as applySshEnabled } from "../backend";
+import { setControllerType as applyControllerType, setSshEnabled as applySshEnabled, setVpnEnabled as applyVpnEnabled, setVpnProfile as applyVpnProfile } from "../backend";
 import { openCalibration } from "../components/Calibration";
+import { openVpnImport } from "../components/VpnImport";
 import { SelectEdit, ToggleRow } from "../components/widgets";
 import type { Config } from "../types";
 
@@ -19,6 +20,28 @@ export function Settings({ config, setConfig }: {
       setConfig((current) => (current ? { ...current, sshEnabled: applied } : current));
     } catch (error) {
       setConfig((current) => (current ? { ...current, sshEnabled: !enabled } : current));
+    }
+  };
+  const setVpnEnabled = async (enabled: boolean) => {
+    if (enabled === !!config.vpnEnabled) {
+      return;
+    }
+    setConfig((current) => (current ? { ...current, vpnEnabled: enabled } : current));
+    try {
+      const applied = await applyVpnEnabled(enabled);
+      setConfig((current) => (current ? { ...current, vpnEnabled: applied } : current));
+    } catch (error) {
+      setConfig((current) => (current ? { ...current, vpnEnabled: !enabled } : current));
+    }
+  };
+  const setVpnProfile = async (value: string) => {
+    const previous = config.vpnProfile || "1";
+    setConfig((current) => (current ? { ...current, vpnProfile: value } : current));
+    try {
+      const applied = await applyVpnProfile(value);
+      setConfig((current) => (current ? { ...current, vpnProfile: applied } : current));
+    } catch (error) {
+      setConfig((current) => (current ? { ...current, vpnProfile: previous } : current));
     }
   };
   const setControllerType = async (value: string) => {
@@ -44,6 +67,14 @@ export function Settings({ config, setConfig }: {
       </PanelSection>
       <PanelSection title="System">
         <ToggleRow label="Enable SSH" value={!!config.sshEnabled} onChange={setSshEnabled} />
+        <ToggleRow label="Enable VPN" value={!!config.vpnEnabled} onChange={setVpnEnabled} />
+        <SelectEdit
+          label="VPN Profile"
+          value={config.vpnProfile || "1"}
+          options={[{ data: "1", label: "Profile 1" }, { data: "2", label: "Profile 2" }]}
+          onChange={setVpnProfile}
+        />
+        <ButtonItem layout="below" onClick={() => openVpnImport()}>Import VPN config</ButtonItem>
         <Field label="OS Version" description={config.osVersion || "unknown"} />
         <Field label="ABL Version" description={config.ablVersion || "unknown"} />
       </PanelSection>

--- a/decky/armada-control/src/types.ts
+++ b/decky/armada-control/src/types.ts
@@ -88,6 +88,8 @@ export interface Config {
   osVersion: string;
   ablVersion: string;
   sshEnabled: boolean;
+  vpnEnabled: boolean;
+  vpnProfile: string;
   controllerType: string;
   controllerTypes: DropdownChoice[];
   calibration?: CalibrationState;

--- a/system_files/usr/lib/systemd/system/sing-box.service
+++ b/system_files/usr/lib/systemd/system/sing-box.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=sing-box VPN service
+Documentation=https://sing-box.sagernet.org
+After=network-online.target nss-lookup.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+StateDirectory=sing-box
+ExecStartPre=/usr/bin/mkdir -p /etc/sing-box
+ExecStart=/usr/bin/sing-box -D /var/lib/sing-box -c /etc/sing-box/config.json run
+Restart=on-failure
+RestartSec=2
+LimitNOFILE=infinity
+
+[Install]
+WantedBy=multi-user.target

--- a/system_files/usr/libexec/armada/armada-control
+++ b/system_files/usr/libexec/armada/armada-control
@@ -5,8 +5,9 @@ import os
 import selectors
 import shlex
 import socket
-import struct
 import subprocess
+from urllib.parse import parse_qs, unquote, urlparse
+import struct
 import sys
 import tempfile
 import time
@@ -143,6 +144,49 @@ def action_get_controller_type(request):
     return {"value": result}
 
 
+def vpn_enabled():
+    result = subprocess.run(
+        ["/usr/bin/systemctl", "is-active", "sing-box"],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        timeout=5,
+    )
+    return result.stdout.strip() == "active"
+
+
+def vpn_profile():
+    try:
+        with open("/etc/sing-box/active") as fh:
+            return fh.read().strip() or "1"
+    except Exception:
+        return "1"
+
+
+def action_get_vpn_profile(request):
+    return {"profile": vpn_profile()}
+
+
+def action_set_vpn_profile(request):
+    p = str(request.get("profile", "1"))
+    if p not in ("1", "2"):
+        raise ValueError("bad profile")
+    run(["/usr/libexec/armada/sauna-vpn", "use", p], timeout=30)
+    return {"profile": vpn_profile()}
+
+
+def action_set_vpn_enabled(request):
+    enabled = bool(request.get("enabled"))
+    action = "enable" if enabled else "disable"
+    run(["/usr/bin/systemctl", action, "--now", "sing-box"], timeout=30)
+    return {"enabled": vpn_enabled()}
+
+
+def action_get_vpn_enabled(request):
+    return {"enabled": vpn_enabled()}
+
+
 def action_set_ssh_enabled(request):
     enabled = bool(request.get("enabled"))
     action = "enable" if enabled else "disable"
@@ -194,6 +238,143 @@ def action_write_config(request):
     return {"ok": True}
 
 
+_DEFAULT_VPN_TEMPLATE = {
+    "log": {"level": "warn", "timestamp": True},
+    "dns": {
+        "servers": [{"type": "tcp", "tag": "proxy-dns", "server": "8.8.8.8", "detour": "proxy"}],
+        "final": "proxy-dns",
+        "strategy": "ipv4_only",
+    },
+    "inbounds": [{
+        "type": "tun", "tag": "tun-in", "address": ["172.19.0.1/30"],
+        "auto_route": True, "strict_route": True, "stack": "mixed",
+    }],
+    "outbounds": [
+        {"type": "vless", "tag": "proxy", "server": "", "server_port": 443, "uuid": "", "flow": "",
+         "tls": {"enabled": True, "server_name": "", "utls": {"enabled": True, "fingerprint": "chrome"}}},
+        {"type": "direct", "tag": "direct"},
+    ],
+    "route": {
+        "rules": [
+            {"action": "sniff"},
+            {"protocol": "dns", "action": "hijack-dns"},
+            {"ip_is_private": True, "outbound": "direct"},
+        ],
+        "final": "proxy",
+        "auto_detect_interface": True,
+    },
+}
+
+
+def _vless_to_config(link, profile):
+    # Convert a vless:// share link into a full sing-box config, reusing the profile's
+    # existing config as a template (preserving its dns/tun/route tuning) and swapping the
+    # proxy outbound. The connection host is pinned to an IP so the server stays reachable
+    # without needing DNS through the not-yet-up tunnel.
+    u = urlparse(link)
+    if u.scheme != "vless" or not u.username or not u.hostname:
+        raise ValueError("not a valid vless:// link")
+    q = {k: v[0] for k, v in parse_qs(u.query).items()}
+    host = u.hostname
+    try:
+        server = socket.gethostbyname(host)
+    except Exception:
+        server = host
+    template = Path("/etc/sing-box/config-%s.json" % profile)
+    if template.exists():
+        cfg = json.loads(template.read_text())
+    else:
+        cfg = json.loads(json.dumps(_DEFAULT_VPN_TEMPLATE))
+    ob = None
+    for candidate in cfg.get("outbounds", []):
+        if candidate.get("type") == "vless" or candidate.get("tag") == "proxy":
+            ob = candidate
+            break
+    if ob is None:
+        raise ValueError("template has no vless/proxy outbound")
+    ob["type"] = "vless"
+    ob["server"] = server
+    ob["server_port"] = int(u.port or 443)
+    ob["uuid"] = u.username
+    ob["flow"] = q.get("flow", "")
+    tls = ob.setdefault("tls", {})
+    tls["enabled"] = True
+    tls["server_name"] = q.get("sni") or q.get("host") or host
+    utls = tls.setdefault("utls", {})
+    utls["enabled"] = True
+    utls["fingerprint"] = q.get("fp", "chrome")
+    alpn = [a for a in q.get("alpn", "").split(",") if a]
+    if alpn:
+        tls["alpn"] = alpn
+    else:
+        tls.pop("alpn", None)
+    if q.get("security") == "reality":
+        reality = tls.setdefault("reality", {})
+        reality["enabled"] = True
+        reality["public_key"] = q.get("pbk", "")
+        reality["short_id"] = q.get("sid", "")
+    else:
+        tls.pop("reality", None)
+    net = q.get("type", "tcp")
+    if net == "grpc":
+        ob["transport"] = {"type": "grpc", "service_name": q.get("serviceName") or q.get("servicename") or ""}
+    elif net == "ws":
+        transport = {"type": "ws"}
+        if q.get("path"):
+            transport["path"] = unquote(q["path"])
+        if q.get("host"):
+            transport["headers"] = {"Host": q["host"]}
+        ob["transport"] = transport
+    elif net in ("http", "httpupgrade"):
+        transport = {"type": "http"}
+        if q.get("path"):
+            transport["path"] = unquote(q["path"])
+        if q.get("host"):
+            transport["host"] = [q["host"]]
+        ob["transport"] = transport
+    else:
+        ob.pop("transport", None)
+    return json.dumps(cfg, indent=2)
+
+
+def action_import_vpn_config(request):
+    p = str(request.get("profile", "1"))
+    text = request.get("text")
+    if p not in ("1", "2") or not isinstance(text, str):
+        raise ValueError("invalid vpn config import")
+    text = text.strip()
+    if len(text.encode("utf-8")) > MAX_REQUEST:
+        raise ValueError("config payload too large")
+    if text.startswith("vless://"):
+        text = _vless_to_config(text, p)
+    try:
+        cfg = json.loads(text)
+    except ValueError:
+        raise ValueError("not valid JSON")
+    if not isinstance(cfg, dict) or "outbounds" not in cfg:
+        raise ValueError("not a sing-box config (missing outbounds)")
+    fd, tmp = tempfile.mkstemp(prefix=".sbcheck.", suffix=".json")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+        chk = subprocess.run(
+            ["/usr/bin/sing-box", "check", "-c", tmp],
+            check=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, timeout=15,
+        )
+        if chk.returncode != 0:
+            raise ValueError("sing-box check failed: " + (chk.stdout or "").strip()[:300])
+    finally:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+    dest = Path(f"/etc/sing-box/config-{p}.json")
+    atomic_write(dest, text)
+    os.chmod(dest, 0o600)
+    active = vpn_profile() == p
+    if active and vpn_enabled():
+        run(["/usr/bin/systemctl", "restart", "sing-box"], timeout=30)
+    return {"profile": p, "active": active}
 class PerfManager:
     """Owns the perf state file: global defaults, the per-game override,
     and the pidfd that restores defaults on game exit."""
@@ -359,7 +540,12 @@ ACTIONS = {
     "get_ssh_enabled": action_get_ssh_enabled,
     "inputplumber_intercept": action_inputplumber_intercept,
     "set_ssh_enabled": action_set_ssh_enabled,
+    "set_vpn_enabled": action_set_vpn_enabled,
+    "set_vpn_profile": action_set_vpn_profile,
+    "get_vpn_profile": action_get_vpn_profile,
+    "get_vpn_enabled": action_get_vpn_enabled,
     "write_config": action_write_config,
+    "import_vpn_config": action_import_vpn_config,
     "reapply_perf": action_reapply_perf,
 }
 

--- a/system_files/usr/libexec/armada/sauna-vpn
+++ b/system_files/usr/libexec/armada/sauna-vpn
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -uo pipefail
+CFG=/etc/sing-box
+case "${1:-}" in
+  use)
+    n="${2:?profile 1 or 2}"
+    [ -f "$CFG/config-$n.json" ] || { echo "no profile $n"; exit 1; }
+    ln -sf "config-$n.json" "$CFG/config.json"
+    echo "$n" > "$CFG/active"
+    if systemctl is-active --quiet sing-box; then systemctl restart sing-box; echo "profile $n (vpn restarted)"; else echo "profile $n (vpn off)"; fi ;;
+  on)  systemctl enable --now sing-box ;;
+  off) systemctl disable --now sing-box ;;
+  status)
+    echo "profile: $(cat $CFG/active 2>/dev/null || echo none)"
+    echo "vpn: $(systemctl is-active sing-box)" ;;
+  ip)  curl -s --max-time 8 https://api.ipify.org; echo ;;
+  *) echo "usage: sauna-vpn use 1|2 | on | off | status | ip"; exit 1 ;;
+esac


### PR DESCRIPTION
## Summary

Adds an optional sing-box VPN section to Armada Control: an enable toggle, two profiles, and a browser-based config import.

## What's included

- **VPN toggle and two profiles** in the Advanced tab: enable/disable the sing-box service and switch between `config-1` and `config-2`.
- **Import VPN config**: a button that opens a small local web server on the device, shown as a QR code and URL in the QAM. Open it from a computer or phone on the same network and paste a `vless://` link or a full sing-box `config.json`. The page has two buttons (Save to Profile 1 / Save to Profile 2). The device validates the config with `sing-box check` and writes it to the chosen profile, restarting the service if that profile is active.
- **vless:// conversion**: a pasted share link is converted into a full sing-box config, pinning the server to an IP and reusing the profile's existing config as a template so its dns, tun and route settings are preserved.
- **sing-box install, service, and helper**: a pinned sing-box binary installer, a systemd service, and a small `sauna-vpn` helper.

## Notes

- The import web server is HTTP, ephemeral (it runs only while the import dialog is open), and write-only.
- User VPN configs are supplied by the user and are never bundled in the image.
- Adds `qrcode.react` for the QR code.
- Touches `config.py`, `types.ts` and `package.json`, which also change in the power-profiles PR; whichever merges second needs a trivial rebase.

## Testing

Validated on device (KONKR / AYANEO Pocket FIT Elite, SM8750): the toggle, the profile switch, and the import flow end to end (paste a `vless://` link in a computer browser, the config is written, and the VPN connects and routes traffic).
