### PR TITLE
Switch the Pocket EVO to real suspend to RAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,10 +187,17 @@ desktop. The **Bazaar** app store and the **Armada Installer**
 
 ### Power button and sleep
 
-Pressing the power button does a "fake suspend" (inspired by ROCKNIX) rather than
-real S3 sleep: it blanks the screen and freezes the session, and the same press
-wakes it. Because the device does not truly sleep, idle battery drain is higher
-than it would be with real suspend.
+What the power button does depends on the device.
+
+On the **AYANEO Pocket EVO** it is a real suspend to RAM: the device genuinely
+powers down and the same press wakes it. Standby drain measures roughly 90–170 mA
+against about 283 mA for fake suspend — call it 2 to 4 days of standby rather
+than a little over one. That needs the SM8550 PCIe D3cold patches; without them
+it is about 237 mA.
+
+Everywhere else it is a "fake suspend" (inspired by ROCKNIX): the screen blanks
+and the session freezes, but the device stays powered, so idle battery drain is
+higher than it would be with real suspend.
 
 ## Updating
 

--- a/system_files/usr/lib/armada/devices/ayaneo-pocket-evo.conf
+++ b/system_files/usr/lib/armada/devices/ayaneo-pocket-evo.conf
@@ -8,3 +8,6 @@ ARMADA_PANEL_NATIVE_WIDTH=1080
 ARMADA_PANEL_NATIVE_HEIGHT=1920
 ARMADA_PANEL_REFRESH_RATES=60,120
 ARMADA_GAMEPAD_QUIRK=ayaneo-xbox
+# Requires the SM8550 TSENS suspend patch from armada-packages. Without it the
+# SoC leaves deep suspend after ~7s. See the deep-suspend PR there.
+ARMADA_SUSPEND_MODE=mem

--- a/system_files/usr/lib/systemd/sleep.conf.d/10-armada-suspend-state.conf
+++ b/system_files/usr/lib/systemd/sleep.conf.d/10-armada-suspend-state.conf
@@ -1,0 +1,6 @@
+[Sleep]
+# Only try suspend-to-RAM. systemd defaults to "mem standby freeze", so a
+# failed deep suspend falls through to s2idle -- which hard-crashes SM8550
+# (watchdog reset, last log line "PM: suspend entry (s2idle)"). A failed deep
+# should no-op instead.
+SuspendState=mem


### PR DESCRIPTION
Switch the Pocket EVO to real suspend to RAM

Depends on the SM8550 deep-suspend patches in armada-packages. Without them
the SoC leaves deep suspend after about seven seconds (TSENS uplow wake IRQs),
so this must not land first.

Two pieces:

ARMADA_SUSPEND_MODE=mem routes the power button to a real suspend instead of
fake-suspend.

SuspendState is pinned to mem. systemd defaults to "mem standby freeze", so a
failed deep suspend falls through to s2idle, which hard-crashes SM8550 -- a
watchdog reset with "PM: suspend entry (s2idle)" as the last line written. A
failed deep should no-op instead.

Measured on a Pocket EVO with a Steam session running, on battery, across four
windows from one hour to five:

  1.00h    88,473 uAh  =  88.4 mA   (capacity 42% -> 41%)
  5.22h   481,125 uAh  =  92.2 mA   (capacity 71% -> 66%)
  1.11h   288,169 uAh  = 258.7 mA   (capacity 62% -> 58%)
  6.58h combined       = 167.4 mA   (capacity 71% -> 58%)

So roughly 90-170 mA, call it 2 to 4 days of standby against about 1.2 for fake
suspend. Deep suspend held every cycle, resumed cleanly, and was woken only by
the RTC alarm, with no suspend failures. The spread between windows is wider
than I would like -- both instruments agree within a few percent on each window
individually -- so the range is quoted rather than a single figure.

That needs the PCIe D3cold series (armada-packages#28/#29). With only the TSENS
and UFS work it is 237 mA: this board carries a discrete Renesas uPD720201 PCIe
USB3 controller for the built-in gamepad whose rails are held by the PCI device
node, so nothing short of PHY power-down drops it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


---

Depends on armada-packages#28 (validated stack: TSENS + UFS + PCIe D3cold) and armada-packages#29 (its source). Do not merge before them.
