### PR TITLE
fix(fake-suspend): make audio unmute on resume reliable

### DIFF
--- a/system_files/usr/libexec/armada/fake-suspend
+++ b/system_files/usr/libexec/armada/fake-suspend
@@ -50,7 +50,20 @@ display_on() {
 }
 
 mute_audio()   { as_session wpctl set-mute @DEFAULT_AUDIO_SINK@ 1 2>/dev/null || true; }
-unmute_audio() { as_session wpctl set-mute @DEFAULT_AUDIO_SINK@ 0 2>/dev/null || true; }
+unmute_audio() {
+    # A single fire-and-forget set-mute loses the race when PipeWire is still
+    # coming back after resume: if it fails, the mute from do_suspend persists
+    # and the device wakes silent (WirePlumber restores the saved mute state).
+    # Retry until the sink actually reports unmuted, or give up after ~2s.
+    local i out
+    for (( i = 0; i < 8; i++ )); do
+        as_session wpctl set-mute @DEFAULT_AUDIO_SINK@ 0 2>/dev/null || true
+        out="$(as_session wpctl get-volume @DEFAULT_AUDIO_SINK@ 2>/dev/null)" || out=""
+        [[ -n "$out" && "$out" != *"[MUTED]"* ]] && return 0
+        sleep 0.25
+    done
+    log "audio still muted after resume; giving up"
+}
 
 radio_soft_blocked() {
     rfkill list "$1" 2>/dev/null | grep -q 'Soft blocked: yes'


### PR DESCRIPTION
## Problem

On resume from fake-suspend the device sometimes wakes **silent** — the Steam UI and games have no audio until you manually unmute the default sink. WirePlumber then keeps it muted across sessions, so it looks permanent.

## Root cause

`do_suspend()` mutes the default sink; `do_resume()` unmutes with a single fire-and-forget `wpctl set-mute @DEFAULT_AUDIO_SINK@ 0` (`2>/dev/null || true`). `unmute_audio` runs right after `unfreeze_processes`, while PipeWire is still coming back — if that one call loses the race (or `@DEFAULT_AUDIO_SINK@` isn't resolvable yet, or the `as_session` call hits its timeout), the mute set in `do_suspend()` persists. WirePlumber restores the saved mute state, so it survives across reboots too.

## Fix

Make `unmute_audio()` verify and retry: set-mute 0, then confirm via `wpctl get-volume` that the sink is no longer `[MUTED]`, retrying up to ~2s. It returns immediately on the common first-try success (no added resume latency); it only loops when the mute would otherwise have stuck.

## Testing

Tested on a Retroid Pocket 6 (SD 8 Gen 2): caught a sink actually left `[MUTED]` after a fake-suspend cycle in the wild, and confirmed the retry path clears it (first-try in the common case). Syntax-checked with `bash -n`. Single-function change; no happy-path behavior change.
