### PR TITLE
Add desktop applications to Steam

### DIFF
--- a/system_files/usr/bin/steamos-add-to-steam
+++ b/system_files/usr/bin/steamos-add-to-steam
@@ -1,0 +1,70 @@
+#!/usr/bin/bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Adapted from Valve's steamdeck-kde-presets helper for Armada's ARM client.
+set -euo pipefail
+
+show_dialog=0
+
+usage() {
+    echo "Usage: steamos-add-to-steam [-ui] <file>" >&2
+}
+
+show_error() {
+    if (( show_dialog )) && command -v kdialog >/dev/null 2>&1 &&
+            [[ -n ${DISPLAY:-}${WAYLAND_DISPLAY:-} ]]; then
+        kdialog --title "Add to Steam" --error "$1"
+    else
+        echo "steamos-add-to-steam: $1" >&2
+    fi
+}
+
+if [[ ${1:-} == -ui ]]; then
+    show_dialog=1
+    shift
+fi
+
+if (( EUID == 0 )); then
+    show_error "This command cannot be run as root."
+    exit 1
+fi
+if (( $# != 1 )); then
+    usage
+    exit 2
+fi
+
+if ! file=$(realpath -e -- "$1") || [[ ! -f ${file} ]]; then
+    show_error "File not found: $1"
+    exit 1
+fi
+
+mime=$(kmimetypefinder "${file}")
+case ${mime} in
+    application/x-desktop|application/x-ms-dos-executable|application/x-msdownload|application/vnd.microsoft.portable-executable)
+        ;;
+    application/x-executable|application/vnd.appimage|application/x-shellscript|application/x-sh|text/x-shellscript)
+        if [[ ! -x ${file} ]]; then
+            show_error "The selected file is not executable."
+            exit 1
+        fi
+        ;;
+    *)
+        show_error "Unsupported file type: ${mime}"
+        exit 1
+        ;;
+esac
+
+if [[ ${XDG_SESSION_TYPE:-tty} == tty ]] &&
+        ! pgrep -u "$(id -u)" -f '/steamrtarm64/steam([[:space:]]|$)' >/dev/null 2>&1; then
+    show_error "Steam must be running when this command is used from a terminal session."
+    exit 1
+fi
+
+encoded_url=$(python3 -c \
+    'import sys, urllib.parse; print("steam://addnonsteamgame/" + urllib.parse.quote(sys.argv[1], safe=""))' \
+    "${file}")
+
+# Steam watches this marker while processing the addnonsteamgame URI. The
+# launcher forwards the URI to an existing client or starts the ARM client.
+touch /tmp/addnonsteamgamefile
+nohup /usr/libexec/armada/launch-steam --desktop "${encoded_url}" \
+    </dev/null >/dev/null 2>&1 &

--- a/system_files/usr/share/kio/servicemenus/steam.desktop
+++ b/system_files/usr/share/kio/servicemenus/steam.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Service
+X-KDE-ServiceTypes=KonqPopupMenu/Plugin
+MimeType=application/x-desktop;application/x-executable;application/vnd.appimage;application/x-shellscript;application/x-sh;application/x-ms-dos-executable;application/x-msdownload;application/vnd.microsoft.portable-executable;text/x-shellscript;
+Actions=addToSteam;
+
+[Desktop Action addToSteam]
+Name=Add to Steam
+Icon=steam
+TryExec=steamos-add-to-steam
+Exec=steamos-add-to-steam -ui %f

--- a/system_files/usr/share/plasma/kickeractions/steam.desktop
+++ b/system_files/usr/share/plasma/kickeractions/steam.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Service
+Actions=addToSteam;
+
+[Desktop Action addToSteam]
+Name=Add to Steam
+Icon=steam
+TryExec=steamos-add-to-steam
+Exec=steamos-add-to-steam -ui %u


### PR DESCRIPTION
## What changed

- Add an `Add to Steam` helper for desktop files, executables, AppImages, scripts, and Windows executables.
- Add the action to Dolphin/KIO context menus.
- Add the action to Plasma’s application launcher.

## Why

Armada users currently have to add desktop applications through Steam manually. This provides the SteamOS-style desktop integration as an independent feature that can be reviewed and tested separately from Nested Desktop.

## Validation

- `bash -n system_files/usr/bin/steamos-add-to-steam`
- `git diff --check`
- Full Armada shell test suite passed on the current upstream base.
- The KDE service-menu files use KDE-specific `Type=Service` extensions, which the generic freedesktop desktop-file validator does not recognize.