### PR TITLE
Update system FEX layout and remove Proton registration / require_tool_appid stripping

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,12 +1,13 @@
 ARG FEX_PKG=ghcr.io/armada-os/armada-packages/fex@sha256:7ad92a80e6698245ade709b4f357988dd1520aca25203f7d39659585f2b9948f
 ARG MESA_PKG=ghcr.io/armada-os/armada-packages/mesa@sha256:713eddabb61575b1d9fed5e1c63a7e4459447d34e21d3c0b95f307f9cf54d716
 ARG MESA_ANDROID_PKG=ghcr.io/armada-os/armada-packages/mesa-android@sha256:57b03a625ebdfa12d67210c9642f24f8389c22b319e86ab32715eedfd7ee963b
+ARG MESA_X86_PKG=ghcr.io/armada-os/armada-packages/mesa-x86@sha256:17ca26c35250ce0cd6a98bd13b6a21e06ca44f9e51f299fd008b1e79c4cabfc4
 ARG MANGOHUD_PKG=ghcr.io/armada-os/armada-packages/mangohud@sha256:6ed92b44d267a8d2e1339968b59c2679cfd30e81494d4990dcc2c92e0be4fc10
 ARG GAMESCOPE_PKG=ghcr.io/armada-os/armada-packages/gamescope@sha256:b5e5b978b7d3afce55f03f790ba12ee88170fe6b58fac5163084634b0276f495
 ARG GAMESCOPE_SESSION_PKG=ghcr.io/armada-os/armada-packages/gamescope-session@sha256:d17006f02124427f91c70e3c841c7819ca1721ad1d4033659f3656a674f8ee35
 ARG KWIN_PKG=ghcr.io/armada-os/armada-packages/kwin@sha256:0f9bfcb4d0da4cab4a049cba7d90eb9936b3d4be610ceb00f25ec0f58d0dc812
 ARG POWERDEVIL_PKG=ghcr.io/armada-os/armada-packages/powerdevil@sha256:f6d25143dca84f5f71076a3c992e06de87f7ae25fd046cfeb21999df989c4f8b
-ARG KERNEL_PKG=ghcr.io/armada-os/armada-packages/kernel@sha256:ed38966debe25e1566e50d0456fd2b356844762eec7546232150c9ad7506d4d8
+ARG KERNEL_PKG=ghcr.io/armada-os/armada-packages/kernel@sha256:bf9f3be2279069a348aa66f0dba3ff211f8bfa22f80d177c4a6eccd154eaf8d3
 ARG INPUTPLUMBER_PKG=ghcr.io/armada-os/armada-packages/inputplumber@sha256:6196556fe04882547f16302763e3556b434e37e007b6f260d5f2e3f95fd43dea
 ARG EXTEST_PKG=ghcr.io/armada-os/armada-packages/extest@sha256:c68bd452dd8f9a20527862e87fd446045b86811dc222a2a1744ede8d8b858dfa
 ARG NETWORKMANAGER_PKG=ghcr.io/armada-os/armada-packages/networkmanager@sha256:043eae7f6f236945bc66466337391384949f56ad19807f21fe2e9b6f5c488b5f
@@ -26,6 +27,7 @@ FROM ${INPUTPLUMBER_PKG} AS inputplumber
 FROM ${NETWORKMANAGER_PKG} AS networkmanager
 FROM ${JUPITER_HW_SUPPORT_PKG} AS jupiter-hw-support
 FROM ${MESA_ANDROID_PKG} AS mesa-android
+FROM ${MESA_X86_PKG} AS mesa-x86
 FROM ${EXTEST_PKG} AS extest
 FROM ${ARMADA_SPLASH_PKG} AS armada-splash
 FROM ${UMTP_RESPONDER_PKG} AS umtp-responder
@@ -65,6 +67,7 @@ RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
     --mount=type=bind,from=networkmanager,source=/rpms,target=/packages/networkmanager \
     --mount=type=bind,from=jupiter-hw-support,source=/rpms,target=/packages/jupiter-hw-support \
     --mount=type=bind,from=mesa-android,source=/,target=/packages/mesa-android \
+    --mount=type=bind,from=mesa-x86,source=/,target=/packages/mesa-x86 \
     --mount=type=bind,from=extest,source=/,target=/packages/extest \
     --mount=type=bind,from=armada-splash,source=/rpms,target=/packages/armada-splash \
     --mount=type=bind,from=umtp-responder,source=/rpms,target=/packages/umtp-responder \

--- a/build_files/30-install-steam-session.sh
+++ b/build_files/30-install-steam-session.sh
@@ -48,16 +48,22 @@ dnf5 -y install --setopt=install_weak_deps=False /packages/fex/fex-emu-*.rpm
 
 # Use Arch rootfs for better compatibility with Linux games targeting SteamOS
 mkdir -p /usr/share/fex-emu/RootFS
-ARCH_ROOTFS_URL="https://rootfs.fex-emu.gg/ArchLinux/2026-01-08/ArchLinux.sqsh"
-ARCH_ROOTFS_SHA256="cb059973b7953ad9165845529655189b96f9a174b14a6a149c87ec884b0c5e90"
+ARCH_ROOTFS_URL="https://rootfs.fex-emu.gg/ArchLinux/2026-08-11/ArchLinux.sqsh"
+ARCH_ROOTFS_SHA256="5d0c1a38590c68e5c2597c2c8a26d2f80170b1b738c857d63e1cdadada5f5f2a"
 curl --retry 3 --retry-delay 2 -fsSL -o /usr/share/fex-emu/RootFS/ArchLinux.sqsh "${ARCH_ROOTFS_URL}"
 echo "${ARCH_ROOTFS_SHA256}  /usr/share/fex-emu/RootFS/ArchLinux.sqsh" | sha256sum -c -
 
+# Mountpoint for the rootfs at the path Steam's FEX compat tool hardcodes
+# for the x86 Proton chain; armada-guestos.service fills it at boot.
+mkdir -p /usr/share/guestos/fex-mesa
+
 # /usr/share config stays user-overridable; ~/.fex-emu would mask it.
+# RootFS is the armada-guestos mount so every x86 consumer shares one tree
+# (and the mesa payload); FEXServer skips its own per-user sqsh mount.
 cat > /usr/share/fex-emu/Config.json <<'EOF'
 {
   "Config": {
-    "RootFS": "ArchLinux.sqsh",
+    "RootFS": "/usr/share/guestos/fex-mesa",
     "TSOEnabled": "1",
     "X87ReducedPrecision": "1",
     "Multiblock": "0",
@@ -70,7 +76,6 @@ cat > /usr/share/fex-emu/Config.json <<'EOF'
   "ThunksDB": {
     "Vulkan": 1,
     "GL": 1,
-    "EGL": 1,
     "drm": 1,
     "WaylandClient": 1,
     "asound": 1

--- a/build_files/30-install-steam-session.sh
+++ b/build_files/30-install-steam-session.sh
@@ -52,6 +52,9 @@ ARCH_ROOTFS_URL="https://rootfs.fex-emu.gg/ArchLinux/2026-08-11/ArchLinux.sqsh"
 ARCH_ROOTFS_SHA256="5d0c1a38590c68e5c2597c2c8a26d2f80170b1b738c857d63e1cdadada5f5f2a"
 curl --retry 3 --retry-delay 2 -fsSL -o /usr/share/fex-emu/RootFS/ArchLinux.sqsh "${ARCH_ROOTFS_URL}"
 echo "${ARCH_ROOTFS_SHA256}  /usr/share/fex-emu/RootFS/ArchLinux.sqsh" | sha256sum -c -
+# Steam's FEX compat tool needs the manifest the rootfs ships; a bump to a
+# rootfs without one would otherwise fail only at x86 game launch.
+unsquashfs -cat /usr/share/fex-emu/RootFS/ArchLinux.sqsh graphics_provider.json | python3 -m json.tool >/dev/null
 
 # Mountpoint for the rootfs at the path Steam's FEX compat tool hardcodes
 # for the x86 Proton chain; armada-guestos.service fills it at boot.

--- a/build_files/40-vendor-system-files.sh
+++ b/build_files/40-vendor-system-files.sh
@@ -6,6 +6,10 @@ install -Dpm 0755 /packages/extest/libextest.so /usr/lib/extest/libextest.so
 
 cp -a /packages/mesa-android/waydroid/vendor /usr/share/armada/waydroid/
 
+# x86 Turnip payload for the guestos overlay; the rootfs's driver lacks armada's mesa patches
+mkdir -p /usr/share/armada/guestos-x86-mesa
+cp -a /packages/mesa-x86/guestos-x86-mesa/usr /usr/share/armada/guestos-x86-mesa/
+
 # Status text font for armada-splash (falls back to its embedded bitmap font
 # if this link dangles).
 splash_font="$(rpm -ql google-noto-sans-vf-fonts | grep -m1 '\.ttf$')"
@@ -66,6 +70,7 @@ systemctl enable seatd.service
 systemctl enable armada-input-calibration.service
 systemctl enable armada-controller-type.service
 systemctl enable inputplumber.service
+systemctl enable armada-guestos.service
 systemctl enable armada-device-quirks.service
 systemctl enable armada-fixups.service
 systemctl enable armada-installer-visibility.service

--- a/decky/armada-control/src/tabs/Compatibility.tsx
+++ b/decky/armada-control/src/tabs/Compatibility.tsx
@@ -77,7 +77,6 @@ const fexKnobs = [
 const thunkModules = [
   { module: "Vulkan", label: "Host Vulkan" },
   { module: "GL", label: "Host OpenGL" },
-  { module: "EGL", label: "Host EGL" },
   { module: "asound", label: "Host ALSA" },
   { module: "drm", label: "Host DRM" },
   { module: "WaylandClient", label: "Host Wayland" },

--- a/system_files/usr/lib/systemd/system/armada-guestos.service
+++ b/system_files/usr/lib/systemd/system/armada-guestos.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Present the FEX x86 rootfs at the path Steam's FEX compat tool expects
+ConditionPathExists=/usr/share/fex-emu/RootFS/ArchLinux.sqsh
+Before=systemd-user-sessions.service graphical.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/libexec/armada/armada-guestos-mount start
+ExecStop=/usr/libexec/armada/armada-guestos-mount stop
+
+[Install]
+WantedBy=multi-user.target

--- a/system_files/usr/libexec/armada/armada-game-launch
+++ b/system_files/usr/libexec/armada/armada-game-launch
@@ -15,7 +15,6 @@ import armada_perf
 
 
 BASE_FEX_CONFIG = pathlib.Path("/usr/share/fex-emu/Config.json")
-FEX_ROOTFS_DIR = BASE_FEX_CONFIG.parent / "RootFS"
 TWEAKS_CONFIG = pathlib.Path("/etc/armada/game-tweaks.json")
 FEX_PROFILES_CONFIG = pathlib.Path("/usr/share/armada/fex-profiles.json")
 PROTON_INJECT_SRC = pathlib.Path("/usr/share/armada/proton-inject/x86_64-linux-gnu")
@@ -64,11 +63,14 @@ def thunk_settings(settings, modules):
     return {name: 1 if thunks.get(name, True) else 0 for name in modules}
 
 
-def runtime_config_dir():
-    runtime = os.environ.get("XDG_RUNTIME_DIR")
-    if runtime:
-        return pathlib.Path(runtime) / "armada-fex"
-    return pathlib.Path("/tmp") / f"armada-fex-{os.getuid()}"
+def fex_config_dir():
+    # pressure-vessel shares this cache path into the container; a runtime-dir
+    # config is invisible there and FEX silently skips an unseen FEX_APP_CONFIG.
+    # Relative XDG_CACHE_HOME (invalid per XDG) would be re-anchored by portable FEX.
+    cache = os.environ.get("XDG_CACHE_HOME")
+    if cache and pathlib.Path(cache).is_absolute():
+        return pathlib.Path(cache) / "armada-fex"
+    return pathlib.Path.home() / ".cache" / "armada-fex"
 
 
 def resolve_fex_config(settings, profiles):
@@ -85,17 +87,17 @@ def apply_fex(settings, game_id, profiles, env):
     with BASE_FEX_CONFIG.open(encoding="utf-8") as f:
         config = json.load(f)
 
-    # portable FEX doesn't search the system RootFS directory
-    rootfs = config.get("Config", {}).get("RootFS")
-    if isinstance(rootfs, str) and rootfs and not pathlib.Path(rootfs).is_absolute():
-        config["Config"]["RootFS"] = str(FEX_ROOTFS_DIR / rootfs)
+    # each FEX resolves rootfs/thunk paths from its own global or template config;
+    # forcing Armada's onto the Steam FEX depot (Proton 11) empties its SLR4 rootfs
+    for key in ("RootFS", "ThunkGuestLibs", "ThunkHostLibs"):
+        config.get("Config", {}).pop(key, None)
 
     allowed = set().union(*(profile["config"].keys() for profile in profiles.values()))
     fex_config = resolve_fex_config(settings, profiles)
     config.setdefault("Config", {}).update({k: v for k, v in fex_config.items() if k in allowed})
     config["ThunksDB"] = thunk_settings(settings, config.get("ThunksDB", {}).keys())
 
-    config_dir = runtime_config_dir()
+    config_dir = fex_config_dir()
     config_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
     cutoff = time.time() - 86400
     for old in config_dir.glob("*.json"):

--- a/system_files/usr/libexec/armada/armada-guestos-mount
+++ b/system_files/usr/libexec/armada/armada-guestos-mount
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Present the FEX x86 rootfs at /usr/share/guestos/fex-mesa, the OS-provided
+# path Steam's FEX compat tool hardcodes for the x86 Proton chain.
+# graphics_provider.json must sit inside the tree, hence the tmpfs overlay.
+set -u
+
+SQSH=/usr/share/fex-emu/RootFS/ArchLinux.sqsh
+RUN=/run/armada/guestos
+TARGET=/usr/share/guestos/fex-mesa
+MANIFEST=/usr/share/armada/graphics_provider.json
+# optional rootfs-shaped tree (contains usr/) shadowing the rootfs's driver
+PAYLOAD=/usr/share/armada/guestos-x86-mesa
+
+case "${1:-start}" in
+  start)
+    [ -f "${SQSH}" ] || exit 0
+    mkdir -p "${RUN}/lower" "${RUN}/rw"
+    mountpoint -q "${RUN}/lower" || mount -t squashfs -o ro,loop "${SQSH}" "${RUN}/lower" || exit 1
+    mountpoint -q "${RUN}/rw" || mount -t tmpfs -o size=1M tmpfs "${RUN}/rw" || exit 1
+    mkdir -p "${RUN}/rw/upper" "${RUN}/rw/work"
+    install -Dm644 "${MANIFEST}" "${RUN}/rw/upper/graphics_provider.json" || exit 1
+    lower="${RUN}/lower"
+    [ -d "${PAYLOAD}/usr" ] && lower="${PAYLOAD}:${lower}"
+    mountpoint -q "${TARGET}" || mount -t overlay overlay \
+      -o "lowerdir=${lower},upperdir=${RUN}/rw/upper,workdir=${RUN}/rw/work" "${TARGET}" || exit 1
+    ;;
+  stop)
+    if mountpoint -q "${TARGET}"; then
+      umount "${TARGET}" || exit 1
+    fi
+    if mountpoint -q "${RUN}/rw"; then
+      umount "${RUN}/rw" || exit 1
+    fi
+    if mountpoint -q "${RUN}/lower"; then
+      umount "${RUN}/lower" || exit 1
+    fi
+    ;;
+esac
+exit 0

--- a/system_files/usr/libexec/armada/armada-guestos-mount
+++ b/system_files/usr/libexec/armada/armada-guestos-mount
@@ -1,35 +1,25 @@
 #!/usr/bin/env bash
 # Present the FEX x86 rootfs at /usr/share/guestos/fex-mesa, the OS-provided
 # path Steam's FEX compat tool hardcodes for the x86 Proton chain.
-# graphics_provider.json must sit inside the tree, hence the tmpfs overlay.
 set -u
 
 SQSH=/usr/share/fex-emu/RootFS/ArchLinux.sqsh
 RUN=/run/armada/guestos
 TARGET=/usr/share/guestos/fex-mesa
-MANIFEST=/usr/share/armada/graphics_provider.json
-# optional rootfs-shaped tree (contains usr/) shadowing the rootfs's driver
+# rootfs-shaped tree (contains usr/) shadowing the rootfs's driver
 PAYLOAD=/usr/share/armada/guestos-x86-mesa
 
 case "${1:-start}" in
   start)
     [ -f "${SQSH}" ] || exit 0
-    mkdir -p "${RUN}/lower" "${RUN}/rw"
+    mkdir -p "${RUN}/lower"
     mountpoint -q "${RUN}/lower" || mount -t squashfs -o ro,loop "${SQSH}" "${RUN}/lower" || exit 1
-    mountpoint -q "${RUN}/rw" || mount -t tmpfs -o size=1M tmpfs "${RUN}/rw" || exit 1
-    mkdir -p "${RUN}/rw/upper" "${RUN}/rw/work"
-    install -Dm644 "${MANIFEST}" "${RUN}/rw/upper/graphics_provider.json" || exit 1
-    lower="${RUN}/lower"
-    [ -d "${PAYLOAD}/usr" ] && lower="${PAYLOAD}:${lower}"
     mountpoint -q "${TARGET}" || mount -t overlay overlay \
-      -o "lowerdir=${lower},upperdir=${RUN}/rw/upper,workdir=${RUN}/rw/work" "${TARGET}" || exit 1
+      -o "lowerdir=${PAYLOAD}:${RUN}/lower" "${TARGET}" || exit 1
     ;;
   stop)
     if mountpoint -q "${TARGET}"; then
       umount "${TARGET}" || exit 1
-    fi
-    if mountpoint -q "${RUN}/rw"; then
-      umount "${RUN}/rw" || exit 1
     fi
     if mountpoint -q "${RUN}/lower"; then
       umount "${RUN}/lower" || exit 1

--- a/system_files/usr/libexec/armada/launch-steam
+++ b/system_files/usr/libexec/armada/launch-steam
@@ -28,58 +28,13 @@ if [[ -d "${steam_runtime_bin}" ]]; then
 fi
 export FUSERMOUNT_PROG=/run/host/usr/bin/fusermount3
 
-steamapps_dirs=("${steam_root}/steamapps")
-while IFS= read -r library; do
-    steamapps="${library}/steamapps"
-    [[ -d "${steamapps}" ]] || continue
-    steamapps_dirs+=("${steamapps}")
-done < <(grep -oP '"path"\s+"\K[^"]+' "${steam_root}/steamapps/libraryfolders.vdf" 2>/dev/null || true)
-
-# Register the official Proton 11.0 (ARM64) before Steam scans compatibilitytools.d.
-proton11_runner=""
+# prune the Proton 11 registration earlier releases wrote; the internal-name
+# match keeps user-created tool dirs safe
 proton11_reg="${steam_root}/compatibilitytools.d/proton-11-arm64"
-for steamapps in "${steamapps_dirs[@]}"; do
-    runner="${steamapps}/common/Proton 11.0 (ARM64)"
-    flags="$(grep -oP '"StateFlags"\s+"\K[0-9]+' "${steamapps}/appmanifest_4628740.acf" 2>/dev/null || true)"
-    if [[ -n "${flags}" ]] && (( flags & 4 )) && [[ -d "${runner}" ]]; then
-        proton11_runner="${runner}"
-        break
-    fi
-done
-if [[ -n "${proton11_runner}" ]]; then
-    mkdir -p "${proton11_reg}"
-    cat > "${proton11_reg}/compatibilitytool.vdf" <<EOF
-"compatibilitytools"
-{
-  "compat_tools"
-  {
-    "proton11_arm64"
-    {
-      "install_path" "${proton11_runner}"
-      "display_name" "Proton 11.0 (ARM64)"
-      "from_oslist"  "windows"
-      "to_oslist"    "linux"
-    }
-  }
-}
-EOF
-else
-    rm -rf "${proton11_reg}"
+if grep -q '"proton11_arm64"' "${proton11_reg}/compatibilitytool.vdf" 2>/dev/null; then
+    rm -f "${proton11_reg}/compatibilitytool.vdf"
+    rmdir "${proton11_reg}" 2>/dev/null || true
 fi
-
-# The ARM client can't resolve require_tool_appid for the SLR4 Arm64 runtime (4185400)
-# even when it's installed, so Protons requiring it fail "compat tool failed". Strip it
-# from every Proton and run bare.
-for manifest in "${steam_root}"/compatibilitytools.d/*/toolmanifest.vdf; do
-    [[ -f "${manifest}" ]] || continue
-    sed -i '/require_tool_appid.*4185400/d' "${manifest}"
-done
-for steamapps in "${steamapps_dirs[@]}"; do
-    for manifest in "${steamapps}"/common/Proton*/toolmanifest.vdf; do
-        [[ -f "${manifest}" ]] || continue
-        sed -i '/require_tool_appid.*4185400/d' "${manifest}"
-    done
-done
 
 touch "${steam_root}/.cef-enable-remote-debugging"
 cd "${steam_arm_dir}"

--- a/system_files/usr/share/armada/fex-profiles.json
+++ b/system_files/usr/share/armada/fex-profiles.json
@@ -4,7 +4,6 @@
       "thunks": {
         "Vulkan": true,
         "GL": true,
-        "EGL": true,
         "drm": true,
         "WaylandClient": true,
         "asound": true

--- a/system_files/usr/share/armada/graphics_provider.json
+++ b/system_files/usr/share/armada/graphics_provider.json
@@ -1,0 +1,5 @@
+{
+  "graphics_provider_v0": {
+    "architectures": ["x86_64-linux-gnu", "i386-linux-gnu"]
+  }
+}

--- a/system_files/usr/share/armada/graphics_provider.json
+++ b/system_files/usr/share/armada/graphics_provider.json
@@ -1,5 +1,0 @@
-{
-  "graphics_provider_v0": {
-    "architectures": ["x86_64-linux-gnu", "i386-linux-gnu"]
-  }
-}

--- a/tests/perf-settings-test.sh
+++ b/tests/perf-settings-test.sh
@@ -137,7 +137,7 @@ check("env tombstone removes global var", "A" not in merged_env)
 check("env global-only view intact", ap.merged_settings(env_tweaks, None)["env"] == {"A": "1", "B": "2"})
 
 # --- armada-game-launch: FEX path unchanged by perf keys --------------------
-os.environ["XDG_RUNTIME_DIR"] = WORK
+os.environ["XDG_CACHE_HOME"] = WORK
 launch = load_script("armada-game-launch")
 base_fex = os.path.join(WORK, "base-fex.json")
 with open(base_fex, "w") as f:
@@ -150,13 +150,14 @@ def fex_result(settings):
     env = {}
     launch.apply_fex(settings, "620", profiles, env)
     with open(env["FEX_APP_CONFIG"]) as f:
-        return json.load(f)
+        return env["FEX_APP_CONFIG"], json.load(f)
 
 
-plain = fex_result({"fexProfile": "default"})
-with_perf = fex_result({"fexProfile": "default", "cores": "big", "nice": -5,
-                        "gamescopeRr": True, "scheduler": "lavd",
-                        "env": {"X": "1"}, "wineTopology": False})
+config_path, plain = fex_result({"fexProfile": "default"})
+check("config lands in test cache dir", config_path.startswith(WORK + "/armada-fex/"))
+_, with_perf = fex_result({"fexProfile": "default", "cores": "big", "nice": -5,
+                           "gamescopeRr": True, "scheduler": "lavd",
+                           "env": {"X": "1"}, "wineTopology": False})
 check("FEX config unaffected by perf keys", plain == with_perf)
 check("FEX config content sane", plain["Config"]["Multiblock"] == "0")
 


### PR DESCRIPTION
- Current Steam chains its own FEX depot under every x86 title and needs an OS mounted rootfs at /usr/share/guestos/fex-mesa. armada-guestos.service provides the mount. mesa-x86 package layers armada-patched x86 Mesa into the tree.
- Per-game FEX config moves to ~/.cache (visible in pressure-vessel).
- Dead EGL thunk toggle removed.
- Arch RootFS bumped to 2026-08-11.
- Stop self-registering Proton 11 ARM and stripping require_tool_appid. Add cleanup of the old registration.