### PR TITLE
Toggle Plasma Mobile via Armada-Control

### DIFF
--- a/decky/armada-control/main.py
+++ b/decky/armada-control/main.py
@@ -16,6 +16,7 @@ from armada_control.system import (
     restart_game_mode,
     set_abl_auto_enabled,
     set_mtp_enabled,
+    set_desktop_mode,
     set_sleep_mode,
     set_ssh_enabled,
 )
@@ -52,6 +53,9 @@ class Plugin:
 
     async def set_abl_auto_enabled(self, enabled):
         return await asyncio.to_thread(set_abl_auto_enabled, enabled)
+
+    async def set_desktop_mode(self, value):
+        return await asyncio.to_thread(set_desktop_mode, value)
 
     async def set_sleep_mode(self, value):
         return await asyncio.to_thread(set_sleep_mode, value)

--- a/decky/armada-control/py_modules/armada_control/config.py
+++ b/decky/armada-control/py_modules/armada_control/config.py
@@ -8,6 +8,8 @@ from .system import (
     mtp_enabled,
     os_version,
     perf_info,
+    desktop_mode,
+    desktop_modes,
     sleep_modes,
     ssh_enabled,
 )
@@ -30,6 +32,8 @@ def build_config(include_games=True):
         "ablAutoEnabled": abl_auto_enabled(),
         "sshEnabled": ssh_enabled(),
         "mtpEnabled": mtp_enabled(),
+        "desktopMode": desktop_mode(),
+        "desktopModes": desktop_modes(),
         "sleepMode": env.get("ARMADA_SUSPEND_MODE", "fake"),
         "sleepModes": sleep_modes(),
         "controllerType": controller_type(),

--- a/decky/armada-control/py_modules/armada_control/system.py
+++ b/decky/armada-control/py_modules/armada_control/system.py
@@ -13,6 +13,10 @@ SLEEP_MODE_LABELS = {
     "s2idle": "s2idle",
     "deep": "Deep",
 }
+DESKTOP_MODE_LABELS = {
+    "mobile": "Plasma Mobile",
+    "desktop": "Plasma Desktop"
+}
 
 
 def run_cmd(cmd, timeout=5, capture=True):
@@ -107,6 +111,23 @@ def set_mtp_enabled(enabled):
 def set_abl_auto_enabled(enabled):
     return bool(call("set_abl_auto_enabled", enabled=bool(enabled)).get("enabled"))
 
+def desktop_mode() -> str:
+    try:
+        value = str(call("get_desktop_mode").get("value", ""))
+    except Exception:
+        return "desktop"
+
+    return value if value in DESKTOP_MODE_LABELS else "desktop"
+
+
+def set_desktop_mode(value: str) -> str:
+    return str(
+        call("set_desktop_mode", value=str(value)).get("value")
+    )
+
+def desktop_modes():
+    modes = ["desktop", "mobile"]
+    return [{"data": mode, "label": DESKTOP_MODE_LABELS[mode]} for mode in modes]
 
 def sleep_modes():
     modes = ["fake"]

--- a/decky/armada-control/src/backend.ts
+++ b/decky/armada-control/src/backend.ts
@@ -18,6 +18,7 @@ export const saveCompatApplied = (appids: string[]) => {
 export const setSshEnabled = (enabled: boolean) => call<[boolean], boolean>("set_ssh_enabled", enabled);
 export const setMtpEnabled = (enabled: boolean) => call<[boolean], boolean>("set_mtp_enabled", enabled);
 export const setAblAutoEnabled = (enabled: boolean) => call<[boolean], boolean>("set_abl_auto_enabled", enabled);
+export const setDesktopMode = (value: string) => call<[string], string>("set_desktop_mode", value);
 export const setSleepMode = (value: string) => call<[string], string>("set_sleep_mode", value);
 export const reapplyPerf = () => call<[], { pids?: number }>("reapply_perf");
 export const restartGameMode = () => call<[], boolean>("restart_game_mode");

--- a/decky/armada-control/src/tabs/Settings.tsx
+++ b/decky/armada-control/src/tabs/Settings.tsx
@@ -5,6 +5,7 @@ import {
   setAblAutoEnabled as applyAblAutoEnabled,
   setControllerType as applyControllerType,
   setMtpEnabled as applyMtpEnabled,
+  setDesktopMode as applyDesktopMode,
   setSleepMode as applySleepMode,
   setSshEnabled as applySshEnabled,
 } from "../backend";
@@ -62,6 +63,17 @@ export function Settings({ config, setConfig }: {
       setConfig((current) => (current ? { ...current, ablAutoEnabled: !enabled } : current));
     }
   };
+  const setDesktopMode = async (value: string) => {
+    const previous = config.desktopMode || "desktop";
+    setConfig((current: Config | null) => (current ? { ...current, desktopMode: value } : current));
+    try {
+      const applied = await applyDesktopMode(value);
+      setConfig((current: Config | null) => (current ? { ...current, desktopMode: applied } : current));
+    } catch (error) {
+      setConfig((current: Config | null) => (current ? { ...current, desktopMode: previous } : current));
+      toaster.toast({ title: "Could not change desktop mode", body: String(error) });
+    }
+  }
   const setSleepMode = async (value: string) => {
     const previous = config.sleepMode || "fake";
     setConfig((current) => (current ? { ...current, sleepMode: value } : current));
@@ -96,6 +108,14 @@ export function Settings({ config, setConfig }: {
             value={config.sleepMode || "fake"}
             options={config.sleepModes || []}
             onChange={setSleepMode}
+          />
+        )}
+        {(config.desktopModes?.length || 0) > 1 && (
+          <SelectEdit
+            label="Desktop Mode"
+            value={config.desktopMode || "desktop"}
+            options={config.desktopModes || []}
+            onChange={setDesktopMode}
           />
         )}
         <ToggleRow

--- a/decky/armada-control/src/types.ts
+++ b/decky/armada-control/src/types.ts
@@ -92,6 +92,8 @@ export interface Config {
   ablAutoEnabled: boolean;
   sshEnabled: boolean;
   mtpEnabled: boolean;
+  desktopMode: string;
+  desktopModes: DropdownChoice[];
   sleepMode: string;
   sleepModes: DropdownChoice[];
   controllerType: string;

--- a/system_files/usr/libexec/armada/armada-control
+++ b/system_files/usr/libexec/armada/armada-control
@@ -32,6 +32,8 @@ SLEEP_CONFIG = Path("/etc/armada/sleep.conf")
 SUSPEND_MODE_KEY = "suspend_mode"
 NM_IGNORE_SLEEP = Path("/etc/NetworkManager/ignore-sleep")
 MEM_SLEEP_PATH = Path("/sys/power/mem_sleep")
+DESKTOP_SESSION_PATH = Path("/etc/armada/desktop-session")
+DESKTOP_MODES = {"desktop", "mobile"}
 CONFIG_PATHS = {
     "power": Path("/etc/armada/power-profiles.conf"),
     "tweaks": Path("/etc/armada/game-tweaks.json"),
@@ -142,6 +144,20 @@ def set_networkmanager_sleep_allowed(allow_sleep):
     else:
         NM_IGNORE_SLEEP.touch()
 
+def get_desktop_mode() -> str:
+    try:
+        mode = DESKTOP_SESSION_PATH.read_text(encoding="utf-8").strip()
+    except OSError:
+        return "desktop"
+
+    return mode if mode in DESKTOP_MODES else "desktop"
+
+
+def set_desktop_mode(mode: str):
+    if mode not in DESKTOP_MODES:
+        raise ValueError("invalid desktop mode")
+
+    atomic_write(DESKTOP_SESSION_PATH, f"{mode}\n")
 
 def select_mem_sleep(mode):
     if mode in {"s2idle", "deep"}:
@@ -254,6 +270,14 @@ def available_sleep_modes():
         advertised = set()
     return {"fake"} | ({"s2idle", "deep"} & advertised)
 
+def action_get_desktop_mode(request):
+    return {"value": get_desktop_mode()}
+
+
+def action_set_desktop_mode(request):
+    value = str(request.get("value", ""))
+    set_desktop_mode(value)
+    return {"value": get_desktop_mode()}
 
 def action_set_sleep_mode(request):
     value = str(request.get("value", ""))
@@ -494,6 +518,8 @@ ACTIONS = {
     "set_ssh_enabled": action_set_ssh_enabled,
     "set_mtp_enabled": action_set_mtp_enabled,
     "set_abl_auto_enabled": action_set_abl_auto_enabled,
+    "get_desktop_mode": action_get_desktop_mode,
+    "set_desktop_mode": action_set_desktop_mode,
     "set_sleep_mode": action_set_sleep_mode,
     "write_config": action_write_config,
     "reapply_perf": action_reapply_perf,

--- a/system_files/usr/libexec/armada/session-control
+++ b/system_files/usr/libexec/armada/session-control
@@ -2,8 +2,14 @@
 # zz- sorts after armada.conf so its Session= wins (User=/Relogin= stay there).
 set -euo pipefail
 
+desktop_session=armada-plasma.desktop
+
+if [[ $(cat /etc/armada/desktop-session 2> /dev/null) == mobile ]]; then
+  desktop_session=armada-plasma-mobile.desktop
+fi
+
 case "${1:-}" in
-    switch-desktop)  session=armada-plasma.desktop ;;
+    switch-desktop)  session=$desktop_session ;;
     switch-gamemode) session=gamescope-session-steam.desktop ;;
     default-gamemode) session=gamescope-session-steam.desktop; default_only=1 ;;
     *) echo "usage: $0 {switch-desktop|switch-gamemode|default-gamemode}" >&2; exit 1 ;;

--- a/system_files/usr/libexec/armada/start-plasma-mobile
+++ b/system_files/usr/libexec/armada/start-plasma-mobile
@@ -1,0 +1,15 @@
+#!/usr/bin/bash
+set -euo pipefail
+
+export DESKTOP_SESSION=plasma-mobile
+export XDG_CURRENT_DESKTOP=KDE
+export XDG_SESSION_DESKTOP=KDE
+export XDG_SESSION_TYPE=wayland
+
+if command -v /usr/libexec/armada/device-env >/dev/null 2>&1; then
+  set -a
+  eval "$(/usr/libexec/armada/device-env)"
+  set +a
+fi
+
+exec /usr/bin/startplasmamobile

--- a/system_files/usr/share/wayland-sessions/armada-plasma-mobile.desktop
+++ b/system_files/usr/share/wayland-sessions/armada-plasma-mobile.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=Armada Desktop
+Comment=Plasma Desktop for Armada
+Exec=/usr/libexec/armada/start-plasma-mobile
+TryExec=/usr/bin/startplasma-wayland
+Type=Application


### PR DESCRIPTION
PR to add toggling between Plasma Mobile and Plasma Desktop in Armada Control.
* Current desktop value stored in `/etc/armada/desktop-session`
    - Valid Values: `desktop`, `mobile`
* Add new advanced option to Armada Control to toggle between the modes