### PR TITLE
Add stick lighting control for the AYN Odin 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,10 @@ tabs:
   most titles; change these only if a game misbehaves. Settings are saved per game.
 - **Settings.** Choose the controller emulation type (**Xbox 360**, **Steam
   Deck**, or **DualSense**), launch stick and trigger **calibration**, and adjust
-  system options.
+  system options. On the AYN Odin 3 this is also where **Stick Lighting** lives:
+  colour, brightness, and a static or breathing mode for the rings around the
+  sticks. It is off by default, and the section is hidden on devices without
+  verified ring wiring.
 
 ### Desktop mode
 

--- a/build_files/40-vendor-system-files.sh
+++ b/build_files/40-vendor-system-files.sh
@@ -77,6 +77,7 @@ systemctl enable armada-installer-visibility.service
 systemctl enable armada-steamapps.service
 systemctl enable armada-powerd.service
 systemctl enable armada-control.service
+systemctl enable armada-leds.service
 systemctl enable armada-steamos-manager.service
 systemctl --global enable armada-steamos-manager.service
 systemctl enable armada-bootimg-sync.service

--- a/decky/armada-control/main.py
+++ b/decky/armada-control/main.py
@@ -9,6 +9,7 @@ from armada_control.calibration import (
 )
 from armada_control.config import build_config
 from armada_control.controller import set_controller_type
+from armada_control.leds import save_leds
 from armada_control.power import save_power_config
 from armada_control.steam import installed_games
 from armada_control.system import (
@@ -65,6 +66,10 @@ class Plugin:
 
     async def restart_game_mode(self):
         return await asyncio.to_thread(restart_game_mode)
+
+    async def save_leds(self, data):
+        await asyncio.to_thread(save_leds, data)
+        return await self.get_config()
 
     async def set_controller_type(self, value):
         return await asyncio.to_thread(set_controller_type, value)

--- a/decky/armada-control/py_modules/armada_control/config.py
+++ b/decky/armada-control/py_modules/armada_control/config.py
@@ -1,4 +1,5 @@
 from .controller import CONTROLLER_TYPES, controller_type
+from .leds import led_state
 from .power import factory_power_defaults, parse_power
 from .steam import installed_games
 from .system import (
@@ -19,6 +20,7 @@ from .tweaks import fex_profile_labels, load_fex_contract, load_tweaks
 def build_config(include_games=True):
     fex_contract = load_fex_contract()
     env = device_env()
+    leds = led_state()
     return {
         "power": parse_power(),
         "powerDefaults": factory_power_defaults(),
@@ -36,6 +38,8 @@ def build_config(include_games=True):
         "desktopModes": desktop_modes(),
         "sleepMode": env.get("ARMADA_SUSPEND_MODE", "fake"),
         "sleepModes": sleep_modes(),
+        "leds": leds["leds"],
+        "ledsSupported": leds["supported"],
         "controllerType": controller_type(),
         "controllerTypes": [{"data": key, "label": label} for key, label in CONTROLLER_TYPES.items()],
     }

--- a/decky/armada-control/py_modules/armada_control/leds.py
+++ b/decky/armada-control/py_modules/armada_control/leds.py
@@ -1,0 +1,27 @@
+from .privileged import call
+
+DEFAULTS = {
+    "enabled": False,
+    "mode": "static",
+    "brightness": 60,
+    "left": "ff0000",
+    "right": "ff0000",
+    "period": 4.0,
+}
+
+
+def led_state():
+    try:
+        result = call("get_leds")
+    except Exception:
+        return {"supported": False, "leds": dict(DEFAULTS)}
+    return {
+        "supported": bool(result.get("supported")),
+        "leds": result.get("leds") or dict(DEFAULTS),
+    }
+
+
+def save_leds(data):
+    if not isinstance(data, dict):
+        raise ValueError("invalid led config")
+    return call("set_leds", leds=data)

--- a/decky/armada-control/src/backend.ts
+++ b/decky/armada-control/src/backend.ts
@@ -1,5 +1,5 @@
 import { call } from "@decky/api";
-import type { CalibrationState, Capture, Config, InstalledGame, PowerConfig, Tweaks } from "./types";
+import type { CalibrationState, Capture, Config, InstalledGame, LedConfig, PowerConfig, Tweaks } from "./types";
 
 export const getConfig = () => call<[], Config>("get_config");
 export const getInstalledGames = () => call<[], InstalledGame[]>("get_installed_games");
@@ -22,6 +22,7 @@ export const setDesktopMode = (value: string) => call<[string], string>("set_des
 export const setSleepMode = (value: string) => call<[string], string>("set_sleep_mode", value);
 export const reapplyPerf = () => call<[], { pids?: number }>("reapply_perf");
 export const restartGameMode = () => call<[], boolean>("restart_game_mode");
+export const saveLeds = (data: LedConfig) => call<[LedConfig], Config>("save_leds", data);
 export const setControllerType = (value: string) => call<[string], string>("set_controller_type", value);
 export const getControllerState = () => call<[], CalibrationState>("get_controller_state");
 export const saveCalibration = (capture: Capture) => call<[Capture], CalibrationState>("save_calibration", capture);

--- a/decky/armada-control/src/components/StickLighting.tsx
+++ b/decky/armada-control/src/components/StickLighting.tsx
@@ -1,0 +1,126 @@
+import { toaster } from "@decky/api";
+import { PanelSection } from "@decky/ui";
+import { useEffect, useRef, useState } from "react";
+import type { Dispatch, SetStateAction } from "react";
+import { saveLeds as applyLeds } from "../backend";
+import { SelectEdit, SliderEdit, ToggleRow } from "./widgets";
+import type { Config, LedConfig } from "../types";
+
+const modes = [
+  { data: "static", label: "Static" },
+  { data: "breathing", label: "Breathing" },
+];
+
+// Colours are stored at full value; the brightness slider scales them, so the
+// picker only needs hue and saturation.
+export function hsToHex(hue: number, saturation: number): string {
+  const s = Math.max(0, Math.min(100, saturation)) / 100;
+  const h = ((hue % 360) + 360) % 360;
+  const c = s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = 1 - c;
+  const sector = Math.floor(h / 60) % 6;
+  const rgb = [
+    [c, x, 0],
+    [x, c, 0],
+    [0, c, x],
+    [0, x, c],
+    [x, 0, c],
+    [c, 0, x],
+  ][sector];
+  return rgb.map((part) => Math.round((part + m) * 255).toString(16).padStart(2, "0")).join("");
+}
+
+export function hexToHs(hex: string): { hue: number; saturation: number } {
+  const text = String(hex || "").replace("#", "");
+  if (text.length !== 6) return { hue: 0, saturation: 0 };
+  const [r, g, b] = [0, 2, 4].map((i) => parseInt(text.slice(i, i + 2), 16) / 255);
+  if ([r, g, b].some((part) => !Number.isFinite(part))) return { hue: 0, saturation: 0 };
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const delta = max - min;
+  const saturation = max ? Math.round((delta / max) * 100) : 0;
+  if (!delta) return { hue: 0, saturation };
+  let hue: number;
+  if (max === r) hue = 60 * (((g - b) / delta) % 6);
+  else if (max === g) hue = 60 * ((b - r) / delta + 2);
+  else hue = 60 * ((r - g) / delta + 4);
+  return { hue: Math.round(((hue % 360) + 360) % 360), saturation };
+}
+
+function ColorRows({ label, color, onChange }: {
+  label: string;
+  color: string;
+  onChange: (hex: string) => void;
+}) {
+  const { hue, saturation } = hexToHs(color);
+  return (
+    <>
+      <SliderEdit label={`${label} Hue`} value={hue} min={0} max={359} step={1} onChange={(v: number) => onChange(hsToHex(v, saturation))} />
+      <SliderEdit label={`${label} Saturation`} value={saturation} min={0} max={100} step={1} onChange={(v: number) => onChange(hsToHex(hue, v))} />
+    </>
+  );
+}
+
+export function StickLighting({ config, setConfig }: {
+  config: Config;
+  setConfig: Dispatch<SetStateAction<Config | null>>;
+}) {
+  const leds = config.leds;
+  const [linked, setLinked] = useState(leds.left === leds.right);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pending = useRef<LedConfig | null>(null);
+
+  const flush = () => {
+    const next = pending.current;
+    pending.current = null;
+    if (!next) return;
+    applyLeds(next).catch((error) => {
+      toaster.toast({ title: "Could not change stick lighting", body: String(error) });
+    });
+  };
+
+  // Sliders fire continuously; armada-ledd picks the file up within 100 ms, so
+  // a short debounce still previews live without hammering the socket.
+  const commit = (changes: Partial<LedConfig>) => {
+    const next = { ...leds, ...changes };
+    setConfig((current) => (current ? { ...current, leds: next } : current));
+    pending.current = next;
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(flush, 150);
+  };
+
+  useEffect(() => () => {
+    if (timer.current) clearTimeout(timer.current);
+    flush();
+  }, []);
+
+  const setColor = (side: "left" | "right", hex: string) => {
+    commit(linked ? { left: hex, right: hex } : { [side]: hex });
+  };
+
+  return (
+    <PanelSection title="Stick Lighting">
+      <ToggleRow label="Enabled" value={leds.enabled} onChange={(value) => commit({ enabled: value })} />
+      {leds.enabled ? (
+        <>
+          <SelectEdit label="Mode" value={leds.mode} options={modes} onChange={(value: string) => commit({ mode: value })} />
+          <SliderEdit label="Brightness" value={leds.brightness} min={0} max={100} step={1} onChange={(v: number) => commit({ brightness: v })} />
+          {leds.mode === "breathing" ? (
+            <SliderEdit label="Breath Length (s)" value={leds.period} min={1} max={10} step={0.5} onChange={(v: number) => commit({ period: v })} />
+          ) : null}
+          <ToggleRow
+            label="Match Both Sticks"
+            value={linked}
+            onChange={(value) => {
+              setLinked(value);
+              if (value) commit({ right: leds.left });
+            }}
+          />
+          <ColorRows label={linked ? "Colour" : "Left"} color={leds.left} onChange={(hex) => setColor("left", hex)} />
+          {linked ? null : <ColorRows label="Right" color={leds.right} onChange={(hex) => setColor("right", hex)} />}
+        </>
+      ) : null}
+    </PanelSection>
+  );
+}

--- a/decky/armada-control/src/tabs/Settings.tsx
+++ b/decky/armada-control/src/tabs/Settings.tsx
@@ -10,6 +10,7 @@ import {
   setSshEnabled as applySshEnabled,
 } from "../backend";
 import { openCalibration } from "../components/Calibration";
+import { StickLighting } from "../components/StickLighting";
 import { SelectEdit, ToggleRow } from "../components/widgets";
 import type { Config } from "../types";
 
@@ -96,6 +97,7 @@ export function Settings({ config, setConfig }: {
         />
         <ButtonItem layout="below" onClick={openCalibration}>Launch Calibration</ButtonItem>
       </PanelSection>
+      {config.ledsSupported ? <StickLighting config={config} setConfig={setConfig} /> : null}
       <PanelSection title="System">
         <ToggleRow label="Enable SSH" value={!!config.sshEnabled} onChange={setSshEnabled} />
         <Field label="OS Version" description={config.osVersion || "unknown"} />

--- a/decky/armada-control/src/types.ts
+++ b/decky/armada-control/src/types.ts
@@ -79,6 +79,15 @@ export interface PerfInfo {
   cpuCount: number;
 }
 
+export interface LedConfig {
+  enabled: boolean;
+  mode: string;
+  brightness: number;
+  left: string;
+  right: string;
+  period: number;
+}
+
 export interface Config {
   power: PowerConfig;
   powerDefaults: PowerConfig;
@@ -96,6 +105,8 @@ export interface Config {
   desktopModes: DropdownChoice[];
   sleepMode: string;
   sleepModes: DropdownChoice[];
+  leds: LedConfig;
+  ledsSupported: boolean;
   controllerType: string;
   controllerTypes: DropdownChoice[];
   calibration?: CalibrationState;

--- a/system_files/usr/lib/systemd/system/armada-leds.service
+++ b/system_files/usr/lib/systemd/system/armada-leds.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Armada stick lighting
+After=systemd-modules-load.service
+
+[Service]
+# Exits on its own when the device has no verified ring layout. Conditions are
+# deliberately absent: systemd evaluates them once, and the i2c LED controllers
+# can probe after this unit starts.
+Type=simple
+ExecStart=/usr/libexec/armada/armada-ledd
+Restart=no
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/system_files/usr/libexec/armada/armada-control
+++ b/system_files/usr/libexec/armada/armada-control
@@ -73,6 +73,27 @@ CALIBRATION_BACKENDS = {
     "rsinput": Path("/sys/module/rsinput/parameters"),
     "retroid": Path("/sys/module/retroid/parameters"),
 }
+LED_CONFIG = Path("/etc/armada/leds.json")
+LED_DIR = Path("/sys/class/leds")
+# Devices whose stick ring layout has been verified on hardware.
+LED_DEVICES = ("ayn-odin-3",)
+LED_MODES = ("static", "breathing")
+LED_CHANNELS = tuple(
+    f"{side}:{channel}{index}"
+    for side in ("l", "r")
+    for channel in ("r", "g", "b")
+    for index in (1, 2, 3, 4)
+)
+# Fully saturated hue 0; a washed out default hides what the hue slider does.
+LED_DEFAULT_COLOR = "ff0000"
+LED_DEFAULTS = {
+    "enabled": False,
+    "mode": "static",
+    "brightness": 60,
+    "left": LED_DEFAULT_COLOR,
+    "right": LED_DEFAULT_COLOR,
+    "period": 4.0,
+}
 
 
 def atomic_write(path, text):
@@ -299,6 +320,69 @@ def action_get_abl_auto_enabled(request):
     return {"enabled": abl_auto_enabled()}
 
 
+def leds_present():
+    return all((LED_DIR / name / "brightness").exists() for name in LED_CHANNELS)
+
+
+def leds_supported():
+    return device_env().get("ARMADA_DEVICE_ID", "") in LED_DEVICES and leds_present()
+
+
+def normalize_led_color(value, fallback):
+    text = str(value or "").strip().lstrip("#").lower()
+    if len(text) == 6 and all(char in "0123456789abcdef" for char in text):
+        return text
+    return fallback
+
+
+def normalize_leds(raw):
+    if not isinstance(raw, dict):
+        raise ValueError("led config must be an object")
+    try:
+        brightness = int(raw.get("brightness", LED_DEFAULTS["brightness"]))
+        period = float(raw.get("period", LED_DEFAULTS["period"]))
+    except (TypeError, ValueError):
+        raise ValueError("invalid led config value")
+    mode = str(raw.get("mode", LED_DEFAULTS["mode"])).strip().lower()
+    return {
+        "enabled": bool(raw.get("enabled", LED_DEFAULTS["enabled"])),
+        "mode": mode if mode in LED_MODES else LED_DEFAULTS["mode"],
+        "brightness": max(0, min(100, brightness)),
+        "period": max(0.5, min(30.0, period)),
+        "left": normalize_led_color(raw.get("left"), LED_DEFAULTS["left"]),
+        "right": normalize_led_color(raw.get("right"), LED_DEFAULTS["right"]),
+    }
+
+
+def read_leds():
+    try:
+        raw = json.loads(LED_CONFIG.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        raw = {}
+    try:
+        return normalize_leds(raw)
+    except ValueError:
+        return dict(LED_DEFAULTS)
+
+
+def action_get_leds(request):
+    return {"supported": leds_supported(), "leds": read_leds()}
+
+
+def action_set_leds(request):
+    if not leds_supported():
+        raise RuntimeError("stick lighting is not supported on this device")
+    config = normalize_leds(request.get("leds"))
+    atomic_write(LED_CONFIG, json.dumps(config, indent=2, sort_keys=True) + "\n")
+    # armada-ledd polls the config file; starting it is only needed after the
+    # first write on a fresh install, or if the user stopped the unit.
+    try:
+        run(["/usr/bin/systemctl", "start", "armada-leds.service"], timeout=10)
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(f"armada-control: could not start armada-leds.service: {exc}", file=sys.stderr)
+    return {"supported": True, "leds": config}
+
+
 def action_get_device_env(request):
     return {"env": device_env()}
 
@@ -510,6 +594,8 @@ ACTIONS = {
     "set_controller_type": action_set_controller_type,
     "get_controller_type": action_get_controller_type,
     "get_device_env": action_get_device_env,
+    "get_leds": action_get_leds,
+    "set_leds": action_set_leds,
     "get_abl_version": action_get_abl_version,
     "get_abl_auto_enabled": action_get_abl_auto_enabled,
     "get_ssh_enabled": action_get_ssh_enabled,

--- a/system_files/usr/libexec/armada/armada-ledd
+++ b/system_files/usr/libexec/armada/armada-ledd
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Drive the AYN Odin 3 stick ring LEDs from /etc/armada/leds.json.
+
+The panel exposes 24 single-colour LED class devices, four RGB emitters per
+stick: /sys/class/leds/{l,r}:{r,g,b}{1..4}. They are only grouped into rings
+by their physical placement, so a solid colour needs every channel written.
+
+The config file is polled rather than signalled so the Quick Access Menu can
+preview a colour while the user drags a slider.
+"""
+import json
+import math
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+CONFIG = Path(os.environ.get("ARMADA_LED_CONFIG", "/etc/armada/leds.json"))
+LED_DIR = Path(os.environ.get("ARMADA_LED_DIR", "/sys/class/leds"))
+DEVICE_ENV = os.environ.get("ARMADA_DEVICE_ENV", "/usr/libexec/armada/device-env")
+# Only devices whose ring wiring has been verified on hardware.
+SUPPORTED_DEVICES = ("ayn-odin-3",)
+SIDES = ("l", "r")
+CHANNELS = ("r", "g", "b")
+INDEXES = (1, 2, 3, 4)
+POLL_INTERVAL = 0.1
+# The i2c controllers can probe after this unit starts.
+PROBE_TIMEOUT = 30.0
+# 60 Hz: at 20 Hz the breathing ramp visibly bands on a 4 s period.
+FRAME_INTERVAL = float(os.environ.get("ARMADA_LED_FRAME_INTERVAL", "0.016"))
+# PWM duty is linear in current; eyes are not. Perceived brightness tracks
+# roughly duty^(1/2.2), so raise the requested level before writing.
+GAMMA = 2.2
+BREATH_FLOOR = 0.0
+# Fully saturated hue 0. A washed out default would leave the hue slider
+# looking broken until the user finds the saturation one.
+DEFAULT_COLOR = "ff0000"
+DEFAULTS = {
+    "enabled": False,
+    "mode": "static",
+    "brightness": 60,
+    "left": DEFAULT_COLOR,
+    "right": DEFAULT_COLOR,
+    "period": 4.0,
+}
+MODES = ("static", "breathing")
+
+
+def clamp(value, low, high):
+    return max(low, min(high, value))
+
+
+def parse_color(value, fallback):
+    text = str(value or "").strip().lstrip("#")
+    if len(text) != 6:
+        return fallback
+    try:
+        return tuple(int(text[i:i + 2], 16) for i in (0, 2, 4))
+    except ValueError:
+        return fallback
+
+
+def load_config():
+    config = dict(DEFAULTS)
+    try:
+        raw = json.loads(CONFIG.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        raw = {}
+    if not isinstance(raw, dict):
+        raw = {}
+    config["enabled"] = bool(raw.get("enabled", DEFAULTS["enabled"]))
+    mode = str(raw.get("mode", DEFAULTS["mode"])).strip().lower()
+    config["mode"] = mode if mode in MODES else DEFAULTS["mode"]
+    try:
+        config["brightness"] = clamp(int(raw.get("brightness", DEFAULTS["brightness"])), 0, 100)
+    except (TypeError, ValueError):
+        config["brightness"] = DEFAULTS["brightness"]
+    try:
+        config["period"] = clamp(float(raw.get("period", DEFAULTS["period"])), 0.5, 30.0)
+    except (TypeError, ValueError):
+        config["period"] = DEFAULTS["period"]
+    fallback = parse_color(DEFAULT_COLOR, (255, 255, 255))
+    config["left"] = parse_color(raw.get("left"), fallback)
+    config["right"] = parse_color(raw.get("right"), fallback)
+    return config
+
+
+def config_stamp():
+    try:
+        info = CONFIG.stat()
+    except OSError:
+        return None
+    return (info.st_mtime_ns, info.st_size)
+
+
+def device_id():
+    if "ARMADA_DEVICE_ID" in os.environ:
+        return os.environ["ARMADA_DEVICE_ID"]
+    try:
+        out = subprocess.run(["bash", "-c", f'eval "$({DEVICE_ENV})"; printf "%s" "$ARMADA_DEVICE_ID"'],
+                             check=False, capture_output=True, text=True, timeout=10)
+        return out.stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        return ""
+
+
+class Rings:
+    """Open file handles for every channel, keyed by (side, channel)."""
+
+    def __init__(self, led_dir):
+        self.handles = {}
+        self.last = {}
+        for side in SIDES:
+            for channel in CHANNELS:
+                paths = [led_dir / f"{side}:{channel}{index}" / "brightness" for index in INDEXES]
+                if not all(path.exists() for path in paths):
+                    continue
+                handles = [path.open("w") for path in paths]
+                if os.environ.get("ARMADA_LED_ORDER") == "reverse":
+                    handles.reverse()
+                self.handles[(side, channel)] = handles
+                self.last[(side, channel)] = None
+
+    def present(self):
+        return len(self.handles) == len(SIDES) * len(CHANNELS)
+
+    def write(self, side, channel, value):
+        key = (side, channel)
+        handles = self.handles.get(key)
+        if handles is None or self.last.get(key) == value:
+            return
+        text = str(value)
+        for handle in handles:
+            try:
+                # sysfs ignores the file offset, a regular file does not. Rewind
+                # so a shorter value cannot leave a tail behind.
+                handle.seek(0)
+                handle.truncate()
+                handle.write(text)
+                handle.flush()
+            except OSError:
+                pass
+        self.last[key] = value
+
+    def apply(self, colors, level):
+        # level is perceptual 0..1; convert once per frame, not per channel.
+        duty = level ** GAMMA
+        for side in SIDES:
+            color = colors[side]
+            for offset, channel in enumerate(CHANNELS):
+                self.write(side, channel, int(round(color[offset] * duty)))
+
+    def off(self):
+        for side in SIDES:
+            for channel in CHANNELS:
+                self.write(side, channel, 0)
+
+    def close(self):
+        for handles in self.handles.values():
+            for handle in handles:
+                try:
+                    handle.close()
+                except OSError:
+                    pass
+
+
+def breath_level(elapsed, period):
+    # Cosine so the ends of the ramp linger; a triangle wave visibly ticks.
+    phase = (1.0 - math.cos(2.0 * math.pi * elapsed / period)) / 2.0
+    return BREATH_FLOOR + (1.0 - BREATH_FLOOR) * phase
+
+
+def main():
+    device = device_id()
+    if device not in SUPPORTED_DEVICES:
+        print(f"armada-ledd: {device or 'unknown device'} has no verified ring layout, exiting",
+              file=sys.stderr)
+        return 0
+
+    deadline = time.monotonic() + PROBE_TIMEOUT
+    while True:
+        rings = Rings(LED_DIR)
+        if rings.present():
+            break
+        rings.close()
+        if time.monotonic() >= deadline:
+            print(f"armada-ledd: stick ring LEDs did not appear within {PROBE_TIMEOUT:.0f}s, exiting",
+                  file=sys.stderr)
+            return 0
+        time.sleep(0.5)
+
+    running = [True]
+
+    def stop(_signum, _frame):
+        running[0] = False
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        signal.signal(sig, stop)
+
+    config = load_config()
+    stamp = config_stamp()
+    colors = {"l": config["left"], "r": config["right"]}
+    started = time.monotonic()
+    next_poll = 0.0
+
+    try:
+        while running[0]:
+            now = time.monotonic()
+            if now >= next_poll:
+                next_poll = now + POLL_INTERVAL
+                current = config_stamp()
+                if current != stamp:
+                    stamp = current
+                    config = load_config()
+                    colors = {"l": config["left"], "r": config["right"]}
+                    started = now
+
+            if not config["enabled"] or not config["brightness"]:
+                rings.off()
+                time.sleep(POLL_INTERVAL)
+                continue
+
+            scale = config["brightness"] / 100.0
+            if config["mode"] == "breathing":
+                level = scale * breath_level(now - started, config["period"])
+                rings.apply(colors, level)
+                time.sleep(FRAME_INTERVAL)
+            else:
+                rings.apply(colors, scale)
+                time.sleep(POLL_INTERVAL)
+    finally:
+        rings.off()
+        rings.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/leds-test.sh
+++ b/tests/leds-test.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+python3 -B - "$ROOT" "$WORK" <<'PYEOF'
+import importlib.machinery
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+import time
+
+root = pathlib.Path(sys.argv[1])
+work = pathlib.Path(sys.argv[2])
+
+led_dir = work / "leds"
+sides = ("l", "r")
+channels = ("r", "g", "b")
+indexes = (1, 2, 3, 4)
+for side in sides:
+    for channel in channels:
+        for index in indexes:
+            path = led_dir / f"{side}:{channel}{index}"
+            path.mkdir(parents=True)
+            (path / "brightness").write_text("0", encoding="utf-8")
+
+config_path = work / "leds.json"
+os.environ["ARMADA_LED_CONFIG"] = str(config_path)
+os.environ["ARMADA_LED_DIR"] = str(led_dir)
+
+ledd_path = root / "system_files/usr/libexec/armada/armada-ledd"
+loader = importlib.machinery.SourceFileLoader("armada_ledd", str(ledd_path))
+spec = importlib.util.spec_from_loader("armada_ledd", loader)
+ledd = importlib.util.module_from_spec(spec)
+loader.exec_module(ledd)
+
+
+def read_channel(name):
+    return (led_dir / name / "brightness").read_text(encoding="utf-8").strip()
+
+
+# A missing config leaves the rings dark rather than guessing a colour.
+config = ledd.load_config()
+assert config["enabled"] is False, config
+assert config["mode"] == "static", config
+
+config_path.write_text(json.dumps({
+    "enabled": True,
+    "mode": "breathing",
+    "brightness": 150,
+    "period": 900,
+    "left": "#00B0FF",
+    "right": "nonsense",
+}), encoding="utf-8")
+config = ledd.load_config()
+assert config["enabled"] is True, config
+assert config["mode"] == "breathing", config
+assert config["brightness"] == 100, config
+assert config["period"] == 30.0, config
+assert config["left"] == (0, 0xB0, 0xFF), config
+# An unparsable colour falls back to the default instead of dropping the ring.
+assert config["right"] == (0xFF, 0, 0), config
+
+config_path.write_text(json.dumps({"enabled": True, "mode": "strobe", "brightness": -5}), encoding="utf-8")
+config = ledd.load_config()
+assert config["mode"] == "static", config
+assert config["brightness"] == 0, config
+
+rings = ledd.Rings(led_dir)
+assert rings.present()
+
+# Every emitter of a ring carries the same value: the four LEDs are not evenly
+# spaced, so per-position output would not line up anyway.
+rings.apply({"l": (255, 0, 0), "r": (0, 0, 255)}, 1.0)
+for index in indexes:
+    assert read_channel(f"l:r{index}") == "255", read_channel(f"l:r{index}")
+    assert read_channel(f"l:g{index}") == "0"
+    assert read_channel(f"r:b{index}") == "255"
+    assert read_channel(f"r:r{index}") == "0"
+
+# Perceptual level is gamma corrected before it reaches the PWM registers.
+rings.apply({"l": (255, 255, 255), "r": (255, 255, 255)}, 0.5)
+expected = str(int(round(255 * (0.5 ** ledd.GAMMA))))
+assert read_channel("l:r1") == expected, (read_channel("l:r1"), expected)
+assert expected != "128", "gamma correction is not being applied"
+
+rings.off()
+assert read_channel("l:r1") == "0"
+rings.close()
+
+# Breathing spans the full range and stays inside it.
+levels = [ledd.breath_level(step * 0.05, 4.0) for step in range(80)]
+assert min(levels) >= 0.0, min(levels)
+assert max(levels) <= 1.0, max(levels)
+assert max(levels) > 0.99, max(levels)
+assert levels[0] < 0.01, levels[0]
+
+# Only devices with a verified ring layout are driven.
+assert ledd.SUPPORTED_DEVICES == ("ayn-odin-3",)
+
+# The shipped colour is fully saturated so the hue slider does something.
+assert ledd.DEFAULT_COLOR == "ff0000"
+red, green, blue = ledd.parse_color(ledd.DEFAULT_COLOR, (0, 0, 0))
+assert round((red - min(red, green, blue)) / red * 100) == 100, (red, green, blue)
+
+# The unit is only useful if the image actually enables it, and the LED
+# controllers can probe after it starts, so it must not carry a Condition.
+unit = (root / "system_files/usr/lib/systemd/system/armada-leds.service").read_text(encoding="utf-8")
+assert not [line for line in unit.splitlines() if line.strip().startswith("Condition")], unit
+assert "WantedBy=multi-user.target" in unit, unit
+vendor = (root / "build_files/40-vendor-system-files.sh").read_text(encoding="utf-8")
+assert "systemctl enable armada-leds.service" in vendor
+
+# Unsupported devices exit instead of driving unknown hardware.
+os.environ["ARMADA_DEVICE_ID"] = "ayn-odin-2"
+assert ledd.main() == 0
+
+# A supported device with no rings yet waits, then gives up rather than hanging.
+os.environ["ARMADA_DEVICE_ID"] = "ayn-odin-3"
+ledd.LED_DIR = work / "missing"
+ledd.PROBE_TIMEOUT = 0.2
+started = time.monotonic()
+assert ledd.main() == 0
+assert time.monotonic() - started < 5, "probe wait did not time out"
+
+lib = root / "system_files/usr/lib/armada"
+sys.path.insert(0, str(lib))
+import armada_perf  # noqa: F401
+
+control_path = root / "system_files/usr/libexec/armada/armada-control"
+loader = importlib.machinery.SourceFileLoader("armada_control_daemon", str(control_path))
+spec = importlib.util.spec_from_loader("armada_control_daemon", loader)
+control = importlib.util.module_from_spec(spec)
+loader.exec_module(control)
+
+assert "set_leds" in control.ACTIONS
+assert "get_leds" in control.ACTIONS
+
+normalized = control.normalize_leds({
+    "enabled": 1,
+    "mode": "BREATHING",
+    "brightness": 250,
+    "period": 0.1,
+    "left": "#0AF",
+    "right": "00b0ff",
+})
+assert normalized["enabled"] is True, normalized
+assert normalized["mode"] == "breathing", normalized
+assert normalized["brightness"] == 100, normalized
+assert normalized["period"] == 0.5, normalized
+# Three digit hex is not expanded; the daemon expects six.
+assert normalized["left"] == "ff0000", normalized
+assert normalized["right"] == "00b0ff", normalized
+
+for bad in ("string", 5, None, []):
+    try:
+        control.normalize_leds(bad)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError(f"normalize_leds accepted {bad!r}")
+
+control.LED_DIR = led_dir
+assert control.leds_present()
+control.LED_DIR = work / "empty"
+assert not control.leds_present()
+
+control.LED_CONFIG = work / "control-leds.json"
+control.LED_DIR = led_dir
+control.device_env = lambda: {"ARMADA_DEVICE_ID": "ayn-odin-3"}
+assert control.leds_supported()
+control.device_env = lambda: {"ARMADA_DEVICE_ID": "ayn-odin-2"}
+assert not control.leds_supported()
+
+try:
+    control.action_set_leds({"leds": {"enabled": True}})
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("set_leds ran on an unverified device")
+
+# A corrupt config reads back as the defaults instead of raising.
+control.LED_CONFIG.write_text("{ not json", encoding="utf-8")
+assert control.read_leds() == control.LED_DEFAULTS
+
+print("led test passed")
+PYEOF


### PR DESCRIPTION
Closes #167 for the Odin 3.

The Odin 3 has two HTR3212 controllers driving four RGB emitters around each stick. The kernel already exposes all 24 channels at `/sys/class/leds/{l,r}:{r,g,b}{1..4}`, but nothing in userspace ever wrote to them, so the rings have always been dark. This adds a small daemon plus a **Stick Lighting** section in Armada Control's Settings tab: colour, brightness, and a static or breathing mode, with an optional separate colour per stick.

Off by default, so an update does not change how anyone's device looks without being asked.

## Verified on hardware, not read off the device tree

Everything below was measured on an Odin 3 running `beta` (20260729.d812101), not inferred:

- Channel labels match the emitted colours. The node labels in the DTS disagree with the exported labels (`ledr_b1` carries `label = "r:r1"`), and it is the exported labels that are right.
- Both rings run clockwise, but the right ring is offset by one position: upper left is `l:*4` and `r:*1`, upper right `l:*1` and `r:*2`, lower right `l:*2` and `r:*3`, lower left `l:*3` and `r:*4`.
- The four emitters are **not** evenly spaced. There is a wider gap on the left of each ring, which is why the right side of a ring visibly lights first on a ramp. Anything running around the circumference looks broken, so the modes are static and breathing only.
- Colours and mode survive suspend and resume, so no restore hook is needed.

## Implementation notes

- Levels are gamma corrected before they reach the PWM registers: duty is linear in current, perception is not. Breathing runs at 60 Hz because 20 Hz visibly bands on a four second ramp.
- `armada-ledd` polls its config file rather than taking a signal, so the Quick Access Menu can preview a colour while a slider is being dragged.
- The unit deliberately carries no `ConditionPathExists`. systemd evaluates conditions once, and the i2c controllers can probe after the unit starts, so the daemon waits for the LED devices itself and exits cleanly if they never appear.
- Gated on `ayn-odin-3`. AYN Thor, Odin 2 Portal and Retroid Pocket 6 declare the same controllers in their device trees, but nobody has confirmed their ring layout, so they are deliberately left out. Enabling them is a one line change once someone with the hardware maps them.

## Why Armada Control and not Steam's own UI

Steam has no general device lighting API, and `steamos-manager` exposes nothing for LEDs either. The only native route is the DualSense lightbar: InputPlumber 0.77.2 ships an LED source driver that forwards a target device's colour to a LED class device. Taking it would mean:

- a device tree change grouping the mono channels with `leds-group-multicolor` (the kconfig option is already enabled), because that driver needs `multi_intensity` and `multi_index`, which the Odin 3 does not expose;
- forcing controller emulation to DualSense, which changes button glyphs across the whole Steam UI and fights the existing Controller Emulation setting;
- one colour for both sticks, since Steam sends a single lightbar value;
- no breathing, since Steam only sets a static colour.

That route is worth having later, and the recipe above is the whole of it, but the two must be made mutually exclusive if it ever lands, because they would fight over the same LEDs.

## Tests

`tests/leds-test.sh` covers config clamping and fallbacks, the gamma conversion, both daemon exit paths, and asserts the unit has no `Condition` and that the image actually enables the service. It was checked by mutation: reverting the fixes turns it red.

The rest of `tests/` passes, except `abl-update-test.sh` and `perf-settings-test.sh`, which fail the same way on a pristine `main` and are unrelated to this change.
