### PR TITLE
Add homescreen defaults to plasma mobile

### DIFF
--- a/system_files/usr/share/plasma/look-and-feel/org.fedoraproject.fedora.mobile/contents/plasmoidsetupscripts/org.kde.plasma.mobile.homescreen.folio.js
+++ b/system_files/usr/share/plasma/look-and-feel/org.fedoraproject.fedora.mobile/contents/plasmoidsetupscripts/org.kde.plasma.mobile.homescreen.folio.js
@@ -1,0 +1,14 @@
+// Add return to gamemode to the homescreen
+applet.writeConfig("Pages", `[[
+    {"column": 0, "row": 0, "storageId": "armada-return-to-gamemode.desktop", "type": "application"}
+]]`);
+
+// Add some useful apps that we ship to the favourites section
+applet.writeConfig("Favourites", `[
+    {"storageId": "org.mozilla.firefox.desktop", "type": "application"},
+    {"storageId": "io.github.kolunmi.Bazaar.desktop", "type": "application"},
+    {"storageId": "org.kde.dolphin.desktop", "type": "application"},
+    {"storageId": "steam.desktop", "type": "application"}
+]`);
+
+applet.reloadConfig();


### PR DESCRIPTION
Adds return to Game Mode to the homescreen pages and adds Firefox, Bazaar, Dolphin and Steam to favorites