### PR TITLE
Disable mobile auto-lock

### DIFF
--- a/system_files/etc/xdg/kscreenlockerrc
+++ b/system_files/etc/xdg/kscreenlockerrc
@@ -1,3 +1,6 @@
 [Daemon]
 Autolock=false
+Timeout=0
 LockOnResume=false
+LockOnStart=false
+RequirePassword=false


### PR DESCRIPTION
Update `kscreenlockerrc` to disable password requirements on the lock screen and ensure that it never auto locks.