### PR TITLE
Fix directory-opening actions in Desktop Mode

### DIFF
--- a/system_files/etc/xdg/mimeapps.list
+++ b/system_files/etc/xdg/mimeapps.list
@@ -1,5 +1,6 @@
 [Default Applications]
 application/vnd.flatpak.ref=io.github.kolunmi.Bazaar.desktop
+inode/directory=org.kde.dolphin.desktop
 text/html=org.mozilla.firefox.desktop
 x-scheme-handler/http=org.mozilla.firefox.desktop
 x-scheme-handler/https=org.mozilla.firefox.desktop

--- a/tests/steam-shortcut-test.sh
+++ b/tests/steam-shortcut-test.sh
@@ -52,6 +52,11 @@ grep -qx 'MimeType=x-scheme-handler/steam;' "$ENTRY" \
 grep -qx 'x-scheme-handler/steam=steam.desktop' "$MIMEAPPS" \
     || fail "mimeapps.list has no default for x-scheme-handler/steam"
 
+# Directory-opening actions such as Steam's file browser and Firefox's
+# "Show in Folder" need a system default on a fresh user profile.
+grep -qx 'inode/directory=org.kde.dolphin.desktop' "$MIMEAPPS" \
+    || fail "mimeapps.list has no default directory handler"
+
 # system_files is copied after the RPM scriptlets, so the cache needs a rebuild.
 grep -q 'update-desktop-database -q /usr/share/applications' "$VENDOR" \
     || fail "build does not refresh mimeinfo.cache after vendoring system_files"


### PR DESCRIPTION
## Summary

- register Dolphin as the system default handler for directories
- cover the MIME association in the existing Steam shortcut integration test

Fresh Armada profiles had no `inode/directory` default in `/etc/xdg/mimeapps.list`. Applications using the standard directory-opening association therefore had no system-level route to Dolphin, matching the Steam and Firefox behavior reported in #19.

## Validation

- full `tests/*-test.sh` suite passes
- `git diff --check` passes

Fixes #19