### PR TITLE
fix(armada-control): resolve dropdown focus freeze in Game Mode

### DIFF
--- a/decky/armada-control/src/components/widgets.tsx
+++ b/decky/armada-control/src/components/widgets.tsx
@@ -1,4 +1,4 @@
-import { Dropdown, DropdownItemInternal, Field, PanelSection, PanelSectionRow, SliderField, ToggleField } from "@decky/ui";
+import { Dropdown, Field, PanelSection, PanelSectionRow, SliderField, ToggleField } from "@decky/ui";
 import type { ReactNode } from "react";
 import type { DropdownChoice } from "../types";
 
@@ -18,12 +18,10 @@ export function SelectEdit({ label, value, options, onChange, labelBelow, disabl
     <PanelSectionRow>
       {label === undefined ? (
         <Dropdown disabled={disabled} strDefaultLabel={placeholder} selectedOption={value} rgOptions={rgOptions} onChange={(option) => onChange(option.data)} />
-      ) : labelBelow ? (
+      ) : (
         <Field label={label} childrenLayout="below" childrenContainerWidth="max" disabled={disabled}>
           <Dropdown disabled={disabled} strDefaultLabel={placeholder} selectedOption={value} rgOptions={rgOptions} onChange={(option) => onChange(option.data)} />
         </Field>
-      ) : (
-        <DropdownItemInternal disabled={disabled} strDefaultLabel={placeholder} childrenContainerWidth="max" label={label} selectedOption={value} rgOptions={rgOptions} onChange={(option) => onChange(option.data)} />
       )}
     </PanelSectionRow>
   );


### PR DESCRIPTION
### Problem

When opening dropdown menus in Armada Control (e.g. Power Profiles, Controller Type, FEX Profiles, Desktop/Sleep mode) while a 3D game is actively running in Game Mode under Gamescope, `DropdownItemInternal` attempts to spawn a full modal dialog overlay via Steam's `FocusManager`. Under Gamescope + xwayland/libei with an active Vulkan application, the modal overlay gets focus-trapped in an un-focused state, completely deadlocking controller/touch input across the Quick Access Menu until `steamwebhelper` is killed.

This also addresses the root cause behind dropdown unresponsiveness reported in #221 and #40.

### Fix

Replaces `DropdownItemInternal` with `@decky/ui` standard `<Field childrenLayout="below" childrenContainerWidth="max"><Dropdown ... /></Field>`.

- Eliminates the modal focus deadlock entirely.
- Preserves full-width responsive layout.
- Tested and verified working seamlessly with 3D games (e.g. Mortal Sin) running in the background on Odin 2.