### PR TITLE
power: add charge-aware auto sleep mode for Pocket EVO

### DIFF
--- a/decky/armada-control/py_modules/armada_control/system.py
+++ b/decky/armada-control/py_modules/armada_control/system.py
@@ -12,6 +12,7 @@ SLEEP_MODE_LABELS = {
     "fake": "Fake",
     "s2idle": "s2idle",
     "deep": "Deep",
+    "auto": "Auto adjust",
 }
 DESKTOP_MODE_LABELS = {
     "mobile": "Plasma Mobile",
@@ -130,7 +131,7 @@ def desktop_modes():
     return [{"data": mode, "label": DESKTOP_MODE_LABELS[mode]} for mode in modes]
 
 def sleep_modes():
-    modes = ["fake"]
+    modes = ["fake", "auto"]
     advertised = {word.strip("[]") for word in read_text(MEM_SLEEP_PATH).split()}
     modes.extend(mode for mode in ("s2idle", "deep") if mode in advertised)
     return [{"data": mode, "label": SLEEP_MODE_LABELS[mode]} for mode in modes]

--- a/system_files/usr/libexec/armada/armada-control
+++ b/system_files/usr/libexec/armada/armada-control
@@ -163,7 +163,6 @@ def select_mem_sleep(mode):
     if mode in {"s2idle", "deep"}:
         MEM_SLEEP_PATH.write_text(f"{mode}\n", encoding="utf-8")
 
-
 def abl_auto_enabled():
     for path, key in ((ABL_CONFIG, "auto_update_enabled"), (ABL_MANIFEST, "ARMADA_ABL_AUTO")):
         try:
@@ -268,7 +267,7 @@ def available_sleep_modes():
         }
     except OSError:
         advertised = set()
-    return {"fake"} | ({"s2idle", "deep"} & advertised)
+    return {"fake", "auto"} | ({"s2idle", "deep"} & advertised)
 
 def action_get_desktop_mode(request):
     return {"value": get_desktop_mode()}

--- a/system_files/usr/libexec/armada/device-env
+++ b/system_files/usr/libexec/armada/device-env
@@ -48,9 +48,9 @@ selected_mem_sleep=$(sed -n 's/.*\[\([^]]*\)\].*/\1/p' <<<"$mem_sleep_modes")
 sleep_config=${ARMADA_SLEEP_CONFIG:-/etc/armada/sleep.conf}
 if [[ -r "$sleep_config" ]]; then
     while IFS= read -r line || [[ -n "$line" ]]; do
-        if [[ "$line" =~ ^[[:space:]]*suspend_mode[[:space:]]*=[[:space:]]*(fake|s2idle|deep)[[:space:]]*$ ]]; then
+        if [[ "$line" =~ ^[[:space:]]*suspend_mode[[:space:]]*=[[:space:]]*(fake|s2idle|deep|auto)[[:space:]]*$ ]]; then
             suspend_mode=${BASH_REMATCH[1]}
-            if [[ "$suspend_mode" == fake ]] || grep -qw "$suspend_mode" <<<"$mem_sleep_modes"; then
+            if [[ "$suspend_mode" == fake || "$suspend_mode" == auto ]] || grep -qw "$suspend_mode" <<<"$mem_sleep_modes"; then
                 ARMADA_SUSPEND_MODE=$suspend_mode
             else
                 ARMADA_SUSPEND_MODE=$profile_suspend_mode
@@ -63,6 +63,20 @@ if [[ "${ARMADA_SUSPEND_MODE:-fake}" == "mem" ]]; then
         ARMADA_SUSPEND_MODE=$selected_mem_sleep
     else
         ARMADA_SUSPEND_MODE=fake
+    fi
+fi
+
+# auto: charge-aware sleep mode. Deep sleep powers down the ADSP, which
+# kills the PD contract and the battery-manager firmware — a plugged-in
+# device then drains instead of charging (and can wedge on attach).
+# s2idle keeps the ADSP alive, so charging continues. Pick s2idle while a
+# charger is present, deep otherwise.
+if [[ "${ARMADA_SUSPEND_MODE:-fake}" == "auto" ]]; then
+    usb_online=${ARMADA_USB_ONLINE_PATH:-/sys/class/power_supply/qcom-battmgr-usb/online}
+    if [[ -r "$usb_online" ]] && [[ "$(<"$usb_online")" == "1" ]]; then
+        ARMADA_SUSPEND_MODE=s2idle
+    else
+        ARMADA_SUSPEND_MODE=deep
     fi
 fi
 


### PR DESCRIPTION
## Summary

Adds an **"Auto adjust"** sleep-mode option to armada-control that resolves per suspend: **s2idle when a charger is present, deep sleep otherwise**.

### Why

Deep sleep powers down the ADSP on the Pocket EVO, which kills the PD contract and the battery-manager firmware:

- a plugged-in EVO in deep sleep **drains instead of charging** (0 W in, ~1.5 A out)
- the UCSI firmware can come back in **source mode** on wake (2 of 3 wakes in testing), requiring an ADSP restart to recover
- charging is uninterrupted in **s2idle** (ADSP stays alive; ~15–20 W through sleep, clean wake, charging resumes immediately)

"Auto adjust" picks per-suspend so the charge state can't be misconfigured: plugged → s2idle (charging continues), unplugged → deep (battery savings).

### Design

The choice is resolved **at suspend time**, not stored as a kernel mode:

- `device-env` — accepts `auto` in `/etc/armada/sleep.conf` and resolves it to `s2idle`/`deep` from the qcom-battmgr USB supply (`online=1` → s2idle, else deep). Every existing consumer (suspend-dispatch, device-quirks) sees only a concrete mode — no change to the suspend path.
- `armada-control` — advertises the new option in `available_sleep_modes()`; `select_mem_sleep()` deliberately skips writing `/sys/power/mem_sleep` for it (it is a resolution layer, not a kernel mode).
- decky `system.py` — adds the **"Auto adjust"** entry to the sleep-mode menu.

No kernel changes; no behavior change when the option is not selected (existing modes unchanged).

### Verification (on-device, hybrid 7.2.0-rc7)

- Plugged s2idle: ~15–20 W held through sleep, PD contract survives, battery charging on wake, policy re-establishes 28 W in ~90 s
- Unplugged deep: no charging (battery preserved)
- Charger attached during deep sleep: clean wake, PD renegotiates to PPS, charging resumes — no wedge
- 11-check automated harness (resolution, parsing, explicit-mode precedence) all passing

Closes the sleep-charging gap for Pocket EVO owners without forcing a single sleep mode on everyone.