### PR TITLE
perf(sysctl): add min_free_kbytes headroom to prevent gaming memory allocation stalls

### DIFF
--- a/system_files/usr/lib/sysctl.d/60-armada-gaming.conf
+++ b/system_files/usr/lib/sysctl.d/60-armada-gaming.conf
@@ -5,6 +5,7 @@ kernel.watchdog=0
 vm.swappiness=180
 vm.watermark_boost_factor=0
 vm.watermark_scale_factor=125
+vm.min_free_kbytes=131072
 vm.dirty_bytes=268435456
 vm.dirty_background_bytes=67108864
 vm.dirty_writeback_centisecs=1500


### PR DESCRIPTION
## Description

Configures `vm.min_free_kbytes = 131072` (128 MB reserve headroom) in `60-armada-gaming.conf`.

### Context & Rationale
- Under heavy 3D gaming memory pressure (e.g. Proton 11 / Wine games allocating large GPU/CPU heap buffers), the Linux virtual memory manager can experience direct page allocation stalls (`kswapd` wakeups / direct reclaim latency spikes) when free memory drops below the critical low watermark.
- Adding a 128 MB (`131072 kbytes`) reserve headroom ensures the kernel always keeps sufficient clean free pages available for atomic and high-order memory allocations without latency spikes.
- Complements the existing gaming sysctl optimizations (`vm.watermark_boost_factor = 0` and `vm.watermark_scale_factor = 125`).

## Changes
- [x] Added `vm.min_free_kbytes=131072` to `system_files/usr/lib/sysctl.d/60-armada-gaming.conf`

## Testing
- Verified on AYN Odin 2 (Snapdragon 8 Gen 2 / SM8550) during heavy 3D gaming (*Mortal Sin*, *Persona 5 Royal*).