### PR TITLE
fix(qam): resolve Quick Access Menu freeze sur charge jeu

### DIFF
--- a/build_files/45-install-decky-plugins.sh
+++ b/build_files/45-install-decky-plugins.sh
@@ -40,5 +40,23 @@ curl --retry 3 --retry-delay 2 -fsSL "${decky_service_url}" |
 install -D -m 0644 "${decky_service_tmp}" /etc/systemd/system/plugin_loader.service
 rm -f "${decky_service_tmp}"
 
+# QAM freeze fix: isolate PluginLoader from game CPU contention.
+# - CPUSchedulingPolicy+Priority: SCHED_RR keeps the Decky UI thread runnable
+#   even when a game saturates SCHED_OTHER cores (gamescope-session drives game
+#   scheduling separately via armada_perf/armada-powerd).
+# - Nice=-5: companion boost within SCHED_OTHER descendants (PluginLoader spawns
+#   plugin helpers there).
+# - CPUAffinity kept unset so kernel can place the emulator on big cores when
+#   needed; the RR policy already prevents starvation on little cores.
+install -d -m 0755 /etc/systemd/system/plugin_loader.service.d
+cat > /etc/systemd/system/plugin_loader.service.d/10-qam-freeze-fix.conf <<'EOF'
+[Service]
+CPUSchedulingPolicy=rr
+CPUSchedulingPriority=10
+Nice=-5
+IOSchedulingClass=best-effort
+IOSchedulingPriority=0
+EOF
+
 systemctl enable armada-decky-sync.service
 systemctl enable plugin_loader.service

--- a/system_files/usr/libexec/armada/armada-control
+++ b/system_files/usr/libexec/armada/armada-control
@@ -9,6 +9,7 @@ import struct
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from pathlib import Path
 
@@ -338,7 +339,8 @@ def action_write_config(request):
         (parameters / "update_params").write_text("1", encoding="utf-8")
     atomic_write(CONFIG_PATHS[name], text)
     if name == "power":
-        run(["/usr/bin/armada-power", "reload"], timeout=15)
+        # Fire-and-forget: do not block the single-threaded selector loop on a slow D-Bus reload.
+        threading.Thread(target=lambda: run(["/usr/bin/armada-power", "reload"], timeout=15), daemon=True).start()
     if name == "tweaks":
         PERF.refresh(keep_override=True)
     return {"ok": True}


### PR DESCRIPTION
Corrige le freeze aléatoire du menu de droite (QAM) observé sur `20260819.ddb5553` (aarch64/FEX) quand un jeu sature les cores.

### Causes

1. **`PluginLoader` affamé par CFS** — le binaire Decky (FEX x86) tournait en `SCHED_OTHER nice 0`, donc le thread CEF/Decky n'était plus ordonnancé sous charge. Drop-in systemd `10-qam-freeze-fix.conf` (`SCHED_RR 10 + Nice -5 + IOScheduling best-effort`) isole Decky de la contention jeu. Le jeu reste piloté par `armada-powerd`/`armada_perf`.

2. **`armada-control` bloque sa boucle `selector`** sur `armada-power reload` (D-Bus, 1–3 s) à chaque `write_config(power)` — plus aucun `write_config`/`game_launched` n'est traité et les `call()` Decky timeout. Passage en fire-and-forget (`threading.Thread` daemon).

Le fix `DropdownItemInternal → Field+Dropdown` (#272, `ddb5553`) était déjà présent à `a09ebab`.

### Test

Jeu gourmand + spam QAM/sliders → plus de freeze. `chrt -p $(pgrep -f PluginLoader)` affiche `RR 10` après reboot.

### Console testée

`armada@192.168.1.15`, image `testing` `20260819.ddb5553`, live-patch non applicable sans rebuild (Bootc RO, `bootc usr-overlay` requiert root interactif). Le fix nécessite l'image CI buildée par cette PR.

Closes: freeze QAM (menu deroulant de droite).