### PR TITLE
Restore PATH for native non-Steam shortcuts

### DIFF
--- a/system_files/usr/libexec/armada/armada-game-launch
+++ b/system_files/usr/libexec/armada/armada-game-launch
@@ -19,7 +19,7 @@ BASE_FEX_CONFIG = pathlib.Path("/usr/share/fex-emu/Config.json")
 TWEAKS_CONFIG = pathlib.Path("/etc/armada/game-tweaks.json")
 FEX_PROFILES_CONFIG = pathlib.Path("/usr/share/armada/fex-profiles.json")
 PROTON_INJECT_SRC = pathlib.Path("/usr/share/armada/proton-inject/x86_64-linux-gnu")
-APPIMAGE_EXEC_PATHS = ("/usr/local/bin", "/usr/bin", "/bin")
+STANDARD_EXEC_PATHS = ("/usr/local/bin", "/usr/bin", "/bin")
 
 
 def is_appimage(command):
@@ -44,12 +44,21 @@ def is_appimage(command):
     )
 
 
-def prepare_appimage_path(args):
+def prepare_launch_path(args):
+    # Steam can omit PATH entirely for non-Steam shortcuts. Native launchers
+    # still need standard tools for their child processes, even when Steam
+    # invokes the top-level executable by absolute path.
+    paths = os.environ.get("PATH", "").split(":") if os.environ.get("PATH") else []
+    if not paths:
+        paths.extend(STANDARD_EXEC_PATHS)
+
+    # AppImages additionally need the standard paths appended to an existing
+    # Steam runtime PATH so fusermount can be discovered.
     if not any(is_appimage(arg) for arg in args):
+        os.environ["PATH"] = ":".join(paths)
         return
 
-    paths = os.environ.get("PATH", "").split(":") if os.environ.get("PATH") else []
-    for path in APPIMAGE_EXEC_PATHS:
+    for path in STANDARD_EXEC_PATHS:
         if path not in paths:
             paths.append(path)
     os.environ["PATH"] = ":".join(paths)
@@ -274,7 +283,7 @@ def main():
     except Exception as exc:
         print(f"armada-game-launch: failed to apply settings: {exc}", file=sys.stderr)
 
-    prepare_appimage_path(args)
+    prepare_launch_path(args)
 
     try:
         apply_perf(settings, game_id)

--- a/tests/perf-settings-test.sh
+++ b/tests/perf-settings-test.sh
@@ -137,7 +137,7 @@ check("env additive: game overrides entry", merged_env.get("B") == "override")
 check("env tombstone removes global var", "A" not in merged_env)
 check("env global-only view intact", ap.merged_settings(env_tweaks, None)["env"] == {"A": "1", "B": "2"})
 
-# --- armada-game-launch: FEX path unchanged by perf keys --------------------
+# --- armada-game-launch: launch environment + FEX settings ------------------
 os.environ["XDG_CACHE_HOME"] = WORK
 launch = load_script("armada-game-launch")
 with open(os.path.join(LIBEXEC, "armada-game-launch"), "rb") as f:
@@ -152,15 +152,19 @@ os.mkfifo(fifo)
 check("non-regular argv rejected", not launch.is_appimage(str(fifo)))
 saved_path = os.environ.get("PATH")
 try:
+    os.environ.pop("PATH", None)
+    launch.prepare_launch_path([str(not_appimage)])
+    check("native launcher gets standard PATH when Steam omits it",
+          os.environ["PATH"] == "/usr/local/bin:/usr/bin:/bin")
     os.environ["PATH"] = "/steam/runtime/bin"
-    launch.prepare_appimage_path(["/steam-launch-wrapper", "--", str(appimage)])
+    launch.prepare_launch_path(["/steam-launch-wrapper", "--", str(appimage)])
     check("AppImage command chain gets standard PATH",
           os.environ["PATH"] == "/steam/runtime/bin:/usr/local/bin:/usr/bin:/bin")
     os.environ["PATH"] = "/steam/runtime/bin"
-    launch.prepare_appimage_path(["/steam-launch-wrapper", "--", str(not_appimage)])
+    launch.prepare_launch_path(["/steam-launch-wrapper", "--", str(not_appimage)])
     check("non-AppImage PATH unchanged", os.environ["PATH"] == "/steam/runtime/bin")
     os.environ["PATH"] = "/usr/bin:/steam/runtime/bin:/bin"
-    launch.prepare_appimage_path([str(appimage)])
+    launch.prepare_launch_path([str(appimage)])
     check("existing PATH order preserved",
           os.environ["PATH"] == "/usr/bin:/steam/runtime/bin:/bin:/usr/local/bin")
 finally:


### PR DESCRIPTION
## Summary

- prepare a usable executable `PATH` for every game command, not only AppImages
- preserve an existing native-launch `PATH` and the AppImage-specific append behavior
- cover a native non-Steam launch whose Steam environment has no `PATH`

## Symptom

On an AYN Thor, Heroic games launch from KDE Desktop Mode, but the built-in controller is not usable there. Adding the games to Steam as non-Steam shortcuts supplies Steam Input's virtual controller, but in Game Mode the shortcuts briefly report that they are running and then stop before the game appears.

For _Caravan SandWitch_, Heroic's bundled Legendary helper terminated with:

```text
BrokenPipeError: [Errno 32] Broken pipe
```

The diagnosis, successful workaround, and end-user instructions are documented in this [Discord thread](https://discord.com/channels/1514293984095375490/1528152802642100374/threads/1540058475693088768).

## Root cause

Steam can omit `PATH` from the environment of a non-Steam shortcut in Game Mode. The top-level native ARM64 Heroic executable still starts because Steam invokes it by absolute path, but Heroic's bundled Legendary/Python helper cannot reliably start its child processes; its multiprocessing resource-tracker pipe closes and the helper aborts with `BrokenPipeError`.

`armada-game-launch` already repairs an incomplete `PATH` for AppImages (the failure reported in #103), but only when an AppImage is present in the command line. Packaged native launchers such as `/usr/lib64/heroic/heroic` bypass that branch, so the missing environment variable reaches Heroic unchanged.

## Fix

Generalize the existing path preparation so an absent or empty `PATH` is seeded with:

```text
/usr/local/bin:/usr/bin:/bin
```

An existing `PATH` remains byte-for-byte unchanged for native commands. AppImages continue to have any missing standard paths appended for `fusermount` discovery. Per-game environment settings are still applied afterward, so an explicit user override keeps taking precedence.

## Validation

### Root-cause reproduction

- Replayed Heroic's exact Steam launch environment: omitting `PATH` reproduced the Legendary `BrokenPipeError`; adding `/usr/local/bin:/usr/bin:/bin` let Legendary continue to authentication.

### On-device OS-wide test

Tested the PR launcher directly on the same AYN Thor without building or flashing a new image:

1. Installed the launcher from this branch as a root-owned file and bind-mounted it over `/usr/libexec/armada/armada-game-launch`.
2. Removed `/etc/armada/game-tweaks.json` from the active configuration and verified it was absent, so neither game had the earlier per-game `PATH` workaround.
3. Started each existing non-Steam shortcut through the running Steam Game Mode client.

Sanitized process evidence:

```text
PER_GAME_TWEAKS
absent

# Caravan SandWitch
X:\Games\Heroic\CaravanSandWitch\CaravanSandWitch\Binaries\Win64\CaravanSandWitch-Win64-Shipping.exe
winedevice_pid=364864 opens /dev/input/event12

# Sherlock Holmes Chapter One
X:\Games\Heroic\SherlockHolmesChapter1\SH9\Binaries\Win64\SHCO.exe
winedevice_pid=365585 opens /dev/input/event12
```

Both games progressed past Heroic/Legendary into their real Windows executables, with no new `BrokenPipeError`. In both launches, Wine's `winedevice.exe` held Steam's virtual controller device at `/dev/input/event12`, confirming the Game Mode controller path was active. The games were tested sequentially and stopped afterward; Steam remained running.

### Regression checks

- Added a regression assertion for a native non-AppImage command with no inherited `PATH`.
- `bash -n tests/perf-settings-test.sh`
- `python3 -m py_compile system_files/usr/libexec/armada/armada-game-launch`
- Focused launch-path regression checks on the modified module.
