### PR TITLE
Armada Control Backend + RGB Decky

### DIFF
--- a/build_files/40-vendor-system-files.sh
+++ b/build_files/40-vendor-system-files.sh
@@ -77,6 +77,7 @@ systemctl enable armada-controller-type.service
 systemctl enable inputplumber.service
 systemctl enable armada-guestos.service
 systemctl enable armada-device-quirks.service
+systemctl enable armada-rgb.service
 systemctl enable armada-fixups.service
 systemctl enable armada-update-reserve.service
 systemctl enable armada-installer-visibility.service

--- a/decky/armada-control/main.py
+++ b/decky/armada-control/main.py
@@ -10,6 +10,7 @@ from armada_control.calibration import (
 from armada_control.config import build_config
 from armada_control.controller import set_controller_type
 from armada_control.power import save_power_config
+from armada_control.rgb import get_rgb, set_rgb
 from armada_control.steam import compat_mapped_appids, installed_games
 from armada_control.system import (
     reapply_perf,
@@ -73,6 +74,12 @@ class Plugin:
 
     async def set_controller_type(self, value):
         return await asyncio.to_thread(set_controller_type, value)
+
+    async def get_rgb(self):
+        return await asyncio.to_thread(get_rgb)
+
+    async def set_rgb(self, enabled, color, brightness):
+        return await asyncio.to_thread(set_rgb, enabled, color, brightness)
 
     async def get_controller_state(self):
         return await asyncio.to_thread(controller_state)

--- a/decky/armada-control/py_modules/armada_control/rgb.py
+++ b/decky/armada-control/py_modules/armada_control/rgb.py
@@ -1,0 +1,14 @@
+from .privileged import call
+
+
+def get_rgb():
+    return call("get_rgb")
+
+
+def set_rgb(enabled, color, brightness):
+    return call(
+        "set_rgb",
+        enabled=enabled,
+        color=color,
+        brightness=brightness,
+    )

--- a/decky/armada-control/src/backend.ts
+++ b/decky/armada-control/src/backend.ts
@@ -1,5 +1,5 @@
 import { call } from "@decky/api";
-import type { CalibrationState, Capture, Config, CurvesState, FanCurve, FanSettings, InstalledGame, PowerConfig, Tweaks } from "./types";
+import type { CalibrationState, Capture, Config, CurvesState, FanCurve, FanSettings, InstalledGame, PowerConfig, RgbConfig, Tweaks } from "./types";
 
 export const getConfig = () => call<[], Config>("get_config");
 export const getInstalledGames = () => call<[], InstalledGame[]>("get_installed_games");
@@ -24,6 +24,9 @@ export const setSleepMode = (value: string) => call<[string], string>("set_sleep
 export const reapplyPerf = () => call<[], { pids?: number }>("reapply_perf");
 export const restartGameMode = () => call<[], boolean>("restart_game_mode");
 export const setControllerType = (value: string) => call<[string], string>("set_controller_type", value);
+export const getRgb = () => call<[], RgbConfig | null>("get_rgb");
+export const setRgb = (enabled: boolean, color: string, brightness: number) =>
+  call<[boolean, string, number], RgbConfig>("set_rgb", enabled, color, brightness);
 export const getControllerState = () => call<[], CalibrationState>("get_controller_state");
 export const saveCalibration = (capture: Capture) => call<[Capture], CalibrationState>("save_calibration", capture);
 export const resetCalibration = () => call<[], CalibrationState>("reset_calibration");

--- a/decky/armada-control/src/components/RgbLighting.tsx
+++ b/decky/armada-control/src/components/RgbLighting.tsx
@@ -1,0 +1,113 @@
+import { toaster } from "@decky/api";
+import { PanelSection } from "@decky/ui";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getRgb, setRgb } from "../backend";
+import type { RgbConfig } from "../types";
+import { SliderEdit, ToggleRow } from "./widgets";
+
+function colorHue(color: string): number {
+  const red: number = Number.parseInt(color.slice(0, 2), 16) / 255;
+  const green: number = Number.parseInt(color.slice(2, 4), 16) / 255;
+  const blue: number = Number.parseInt(color.slice(4, 6), 16) / 255;
+  const maximum: number = Math.max(red, green, blue);
+  const difference: number = maximum - Math.min(red, green, blue);
+
+  if (difference === 0) return 0;
+
+  let hue: number;
+  if (maximum === red) hue = (green - blue) / difference;
+  else if (maximum === green) hue = 2 + (blue - red) / difference;
+  else hue = 4 + (red - green) / difference;
+
+  return Math.round((hue * 60 + 360) % 360);
+}
+
+function hexChannel(value: number): string {
+  return Math.round(value).toString(16).padStart(2, "0").toUpperCase();
+}
+
+function hueColor(hue: number): string {
+  const normalizedHue: number = hue % 360;
+  const section: number = Math.floor(normalizedHue / 60);
+  const value: number = ((normalizedHue % 60) / 60) * 255;
+  const rising: string = hexChannel(value);
+  const falling: string = hexChannel(255 - value);
+
+  switch (section) {
+    case 0: return `FF${rising}00`;
+    case 1: return `${falling}FF00`;
+    case 2: return `00FF${rising}`;
+    case 3: return `00${falling}FF`;
+    case 4: return `${rising}00FF`;
+    default: return `FF00${falling}`;
+  }
+}
+
+export function RgbLighting() {
+  const [config, setConfig] = useState<RgbConfig | null>(null);
+  const savedConfig = useRef<string>("");
+
+  const load = useCallback(async () => {
+    try {
+      const next: RgbConfig | null = await getRgb();
+      savedConfig.current = JSON.stringify(next);
+      setConfig(next);
+    } catch (error) {
+      toaster.toast({ title: "Could not load RGB lighting", body: String(error) });
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  useEffect(() => {
+    if (!config) return;
+    const current: string = JSON.stringify(config);
+    if (current === savedConfig.current) return;
+
+    const timer: number = window.setTimeout(async () => {
+      try {
+        await setRgb(config.enabled, config.color, config.brightness);
+        savedConfig.current = current;
+      } catch (error) {
+        toaster.toast({ title: "Could not change RGB lighting", body: String(error) });
+        load();
+      }
+    }, 150);
+
+    return () => window.clearTimeout(timer);
+  }, [config, load]);
+
+  if (!config) return null;
+
+  return (
+    <PanelSection title="RGB Lighting">
+      <ToggleRow
+        label="Enabled"
+        value={config.enabled}
+        onChange={(enabled: boolean) => setConfig({ ...config, enabled })}
+      />
+      <SliderEdit
+        label="Brightness"
+        value={config.brightness}
+        min={0}
+        max={100}
+        step={1}
+        disabled={!config.enabled}
+        onChange={(brightness: number) => setConfig({ ...config, brightness })}
+      />
+      <SliderEdit
+        label="Color"
+        value={colorHue(config.color)}
+        min={0}
+        max={359}
+        step={1}
+        disabled={!config.enabled}
+        showValue={false}
+        wrapperClassName="armada-slider-field armada-rgb-hue"
+        onChange={(hue: number) => setConfig({ ...config, color: hueColor(hue) })}
+      />
+    </PanelSection>
+  );
+}

--- a/decky/armada-control/src/components/widgets.tsx
+++ b/decky/armada-control/src/components/widgets.tsx
@@ -47,7 +47,7 @@ export function ToggleRow({ label, value, onChange, disabled, description, wrapp
   );
 }
 
-export function SliderEdit({ label, value, min, max, step, onChange, format, disabled, wrapperClassName = "armada-slider-field" }: {
+export function SliderEdit({ label, value, min, max, step, onChange, format, disabled, showValue = true, wrapperClassName = "armada-slider-field" }: {
   label: ReactNode;
   value: any;
   min: number;
@@ -56,6 +56,7 @@ export function SliderEdit({ label, value, min, max, step, onChange, format, dis
   onChange: (value: any) => void;
   format?: (value: number) => any;
   disabled?: boolean;
+  showValue?: boolean;
   wrapperClassName?: string;
 }) {
   const numeric = Number(value);
@@ -68,7 +69,7 @@ export function SliderEdit({ label, value, min, max, step, onChange, format, dis
           min={min}
           max={max}
           step={step}
-          showValue
+          showValue={showValue}
           disabled={disabled}
           onChange={(next) => onChange(format ? format(next) : next)}
         />

--- a/decky/armada-control/src/styles.ts
+++ b/decky/armada-control/src/styles.ts
@@ -1,3 +1,5 @@
+import { gamepadSliderClasses } from "@decky/ui";
+
 export const styles = `
       .armada-control-tabs {
         height: 95%;
@@ -46,6 +48,11 @@ export const styles = `
       .armada-control-tabs .armada-slider-field * {
         min-width: 0 !important;
         max-width: 100% !important;
+      }
+      .armada-control-tabs .armada-rgb-hue .${gamepadSliderClasses.SliderTrack} {
+        --left-track-color: #0000;
+        --colored-toggles-main-color: #0000;
+        background: linear-gradient(90deg, #f00, #ff0, #0f0, #0ff, #00f, #f0f, #f00);
       }
       .armada-control-tabs .armada-subheader {
         text-transform: uppercase;

--- a/decky/armada-control/src/tabs/Settings.tsx
+++ b/decky/armada-control/src/tabs/Settings.tsx
@@ -10,6 +10,7 @@ import {
   setSshEnabled as applySshEnabled,
 } from "../backend";
 import { openCalibration } from "../components/Calibration";
+import { RgbLighting } from "../components/RgbLighting";
 import { SelectEdit, ToggleRow } from "../components/widgets";
 import type { Config } from "../types";
 
@@ -96,6 +97,7 @@ export function Settings({ config, setConfig }: {
         />
         <ButtonItem layout="below" onClick={openCalibration}>Launch Calibration</ButtonItem>
       </PanelSection>
+      <RgbLighting />
       <PanelSection title="System">
         <ToggleRow label="Enable SSH" value={!!config.sshEnabled} onChange={setSshEnabled} />
         <Field label="OS Version" description={config.osVersion || "unknown"} />

--- a/decky/armada-control/src/types.ts
+++ b/decky/armada-control/src/types.ts
@@ -66,6 +66,13 @@ export interface CalibrationState {
   params?: Record<string, number>;
 }
 
+export interface RgbConfig {
+  version: number;
+  enabled: boolean;
+  brightness: number;
+  color: string;
+}
+
 export interface GameRef {
   appid: string;
   name: string;

--- a/system_files/usr/lib/systemd/system/armada-rgb.service
+++ b/system_files/usr/lib/systemd/system/armada-rgb.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Restore Armada RGB lighting
+ConditionPathExists=/etc/armada/rgb.json
+After=armada-device-quirks.service
+Before=display-manager.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/armada-rgb apply
+
+[Install]
+WantedBy=multi-user.target

--- a/system_files/usr/libexec/armada/armada-control
+++ b/system_files/usr/libexec/armada/armada-control
@@ -18,6 +18,7 @@ import armada_perf
 SOCKET = Path("/run/armada/control.sock")
 SESSION_SOCKET = Path(armada_perf.SESSION_SOCKET)
 ABL_VERSION_TOOL = "/usr/lib/armada/abl-version"
+RGB_TOOL = "/usr/bin/armada-rgb"
 ABL_CONFIG = Path("/etc/armada/abl.conf")
 ABL_MANIFEST = Path("/usr/lib/armada/abl/manifest")
 ABL_PARTITIONS = (
@@ -307,6 +308,51 @@ def action_get_abl_version(request):
     return {"version": abl_version()}
 
 
+def run_rgb(command):
+    output = subprocess.check_output([RGB_TOOL, *command], text=True, timeout=5)
+    config = json.loads(output)
+    if not isinstance(config, dict):
+        raise RuntimeError("invalid armada-rgb response")
+    return config
+
+
+def action_get_rgb(request):
+    if not device_env().get("ARMADA_RGB_BACKEND"):
+        return None
+    return run_rgb(["get"])
+
+
+def action_set_rgb(request):
+    if not device_env().get("ARMADA_RGB_BACKEND"):
+        raise RuntimeError("RGB lighting is not supported on this device")
+
+    enabled = request.get("enabled")
+    if not isinstance(enabled, bool):
+        raise ValueError("invalid RGB enabled state")
+    if not enabled:
+        return run_rgb(["off"])
+
+    color = request.get("color")
+    brightness = request.get("brightness")
+    valid_color = (
+        isinstance(color, str)
+        and len(color) == 6
+        and all(character in "0123456789abcdefABCDEF" for character in color)
+    )
+    if not valid_color:
+        raise ValueError("invalid RGB color")
+    valid_brightness = (
+        isinstance(brightness, int)
+        and not isinstance(brightness, bool)
+        and 0 <= brightness <= 100
+    )
+    if not valid_brightness:
+        raise ValueError("invalid RGB brightness")
+
+    command = ["set", "--color", color, "--brightness", str(brightness)]
+    return run_rgb(command)
+
+
 def action_inputplumber_intercept(request):
     mode = str(request.get("mode", ""))
     if mode not in INTERCEPT_MODES:
@@ -511,6 +557,8 @@ ACTIONS = {
     "get_controller_type": action_get_controller_type,
     "get_device_env": action_get_device_env,
     "get_abl_version": action_get_abl_version,
+    "get_rgb": action_get_rgb,
+    "set_rgb": action_set_rgb,
     "get_abl_auto_enabled": action_get_abl_auto_enabled,
     "get_ssh_enabled": action_get_ssh_enabled,
     "get_mtp_enabled": action_get_mtp_enabled,

--- a/tests/armada-control-rgb-test.sh
+++ b/tests/armada-control-rgb-test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+python3 -B - "$ROOT" <<'PYEOF'
+import importlib.machinery
+import importlib.util
+from pathlib import Path
+import sys
+
+root = Path(sys.argv[1])
+sys.path.insert(0, str(root / "system_files/usr/lib/armada"))
+
+control_path = root / "system_files/usr/libexec/armada/armada-control"
+loader = importlib.machinery.SourceFileLoader("armada_control_service", str(control_path))
+spec = importlib.util.spec_from_loader("armada_control_service", loader)
+control = importlib.util.module_from_spec(spec)
+loader.exec_module(control)
+
+commands = []
+
+
+def check_output(command, **kwargs):
+    commands.append(command)
+    if command[-1] == "get":
+        return '{"version":1,"enabled":false,"brightness":25,"color":"FFFFFF"}'
+    return '{"version":1,"enabled":true,"brightness":40,"color":"A1B2C3"}'
+
+
+control.subprocess.check_output = check_output
+control.device_env = lambda: {}
+assert control.action_get_rgb({}) is None
+assert commands == []
+
+control.device_env = lambda: {"ARMADA_RGB_BACKEND": "multicolor"}
+state = control.action_get_rgb({})
+assert state["color"] == "FFFFFF"
+assert commands.pop() == [control.RGB_TOOL, "get"]
+
+state = control.action_set_rgb({"enabled": True, "color": "a1b2c3", "brightness": 40})
+assert state["color"] == "A1B2C3"
+assert commands.pop() == [
+    control.RGB_TOOL,
+    "set",
+    "--color",
+    "a1b2c3",
+    "--brightness",
+    "40",
+]
+
+control.action_set_rgb({"enabled": False})
+assert commands.pop() == [control.RGB_TOOL, "off"]
+
+for request in (
+    {"enabled": True, "color": "12345", "brightness": 40},
+    {"enabled": True, "color": "FFFFFF", "brightness": 101},
+):
+    try:
+        control.action_set_rgb(request)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("invalid RGB state was accepted")
+
+sys.path.insert(0, str(root / "decky/armada-control/py_modules"))
+from armada_control import rgb
+
+calls = []
+rgb.call = lambda action, **payload: calls.append((action, payload)) or {}
+assert rgb.get_rgb() == {}
+assert calls.pop() == ("get_rgb", {})
+rgb.set_rgb(True, "112233", 50)
+assert calls.pop() == (
+    "set_rgb",
+    {"enabled": True, "color": "112233", "brightness": 50},
+)
+PYEOF
+
+printf 'Armada Control RGB tests passed\n'

--- a/tests/armada-control-rgb-test.sh
+++ b/tests/armada-control-rgb-test.sh
@@ -78,4 +78,8 @@ assert calls.pop() == (
 )
 PYEOF
 
+grep -Fq 'ConditionPathExists=/etc/armada/rgb.json' "$ROOT/system_files/usr/lib/systemd/system/armada-rgb.service"
+grep -Fq 'ExecStart=/usr/bin/armada-rgb apply' "$ROOT/system_files/usr/lib/systemd/system/armada-rgb.service"
+grep -Fq 'systemctl enable armada-rgb.service' "$ROOT/build_files/40-vendor-system-files.sh"
+
 printf 'Armada Control RGB tests passed\n'


### PR DESCRIPTION
Adds RGB lighting controls to Armada Control using the `armada-rgb` backend added in #317.

* Only displays RGB lighting controls on supported device profiles.
* Adds enabled, brightness and simple hue controls.
* Restores saved enabled or disabled lighting state during boot.

This intentionally keeps the initial interface limited to solid colours. Effects, individual channels and per-zone controls can be added later without changing the hardware abstraction.

Tested on AYN Thor.

<img width="1920" height="1080" alt="armada-rgb-thor-20260825" src="https://github.com/user-attachments/assets/dfd85141-7aa0-4ac0-92c9-02f79b82bc6d" />

Big thanks to everyone who worked on the previous RGB implementations and provided the device knowledge and UI direction that informed this version:

* @antnyhills in #60 and #140
* @Ga1dz1 in #122
* @Rayekkk in #255
* @drewano in #270

Closes #60
Closes #122
Closes #140
Closes #255
Closes #270