### PR TITLE
feat(inputplumber): complete KONKR Pocket FIT controller support

### DIFF
--- a/system_files/usr/share/inputplumber/capability_maps/ayaneo_type9.yaml
+++ b/system_files/usr/share/inputplumber/capability_maps/ayaneo_type9.yaml
@@ -1,0 +1,61 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/capability_map_v2.json
+version: 2
+kind: CapabilityMap
+name: AYANEO Type 9
+id: aya9
+
+mapping:
+  - name: Side button to Quick Access
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN7
+          value_type: button
+    target_event:
+      gamepad:
+        button: QuickAccess
+  - name: Front button to virtual keyboard (Steam)
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN6
+          value_type: button
+    target_event:
+      gamepad:
+        button: Guide
+  - name: Front button to virtual keyboard (X)
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN6
+          value_type: button
+    target_event:
+      gamepad:
+        button: North
+  - name: AYANEO button 2 to screenshot
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN5
+          value_type: button
+    target_event:
+      gamepad:
+        button: Screenshot
+  - name: Upper left back button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN3
+          value_type: button
+    target_event:
+      gamepad:
+        button: LeftTop
+  - name: Upper right back button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN4
+          value_type: button
+    target_event:
+      gamepad:
+        button: RightTop

--- a/system_files/usr/share/inputplumber/capability_maps/pocket_fit_dinput.yaml
+++ b/system_files/usr/share/inputplumber/capability_maps/pocket_fit_dinput.yaml
@@ -1,0 +1,240 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/capability_map_v2.json
+# Schema version number
+version: 2
+
+# The type of configuration schema
+kind: CapabilityMap
+
+# Name for the device event map
+name: KONKR Pocket FIT Main Gamepad
+
+# Unique identifier of the capability mapping
+id: pocket_fit_dinput
+
+# List of mapped events
+mapping:
+  - name: Guide Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_MODE
+          value_type: button
+    target_event:
+      gamepad:
+        button: Guide
+
+  - name: South Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_SOUTH
+          value_type: button
+    target_event:
+      gamepad:
+        button: South
+
+  - name: West Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_WEST
+          value_type: button
+    target_event:
+      gamepad:
+        button: West
+
+  - name: North Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_NORTH
+          value_type: button
+    target_event:
+      gamepad:
+        button: North
+
+  - name: East Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_EAST
+          value_type: button
+    target_event:
+      gamepad:
+        button: East
+
+  - name: Start Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_START
+          value_type: button
+    target_event:
+      gamepad:
+        button: Start
+
+  - name: Select Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_SELECT
+          value_type: button
+    target_event:
+      gamepad:
+        button: Select
+
+  - name: Right Trigger
+    source_events:
+      - evdev:
+          event_type: ABS
+          event_code: ABS_GAS
+          value_type: trigger
+    target_event:
+      gamepad:
+        trigger:
+          name: RightTrigger
+
+  - name: Left Trigger
+    source_events:
+      - evdev:
+          event_type: ABS
+          event_code: ABS_BRAKE
+          value_type: trigger
+    target_event:
+      gamepad:
+        trigger:
+          name: LeftTrigger
+
+  - name: Right Bumper
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_TR
+          value_type: button
+    target_event:
+      gamepad:
+        button: RightBumper
+
+  - name: Left Bumper
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_TL
+          value_type: button
+    target_event:
+      gamepad:
+        button: LeftBumper
+
+  - name: Lower right back button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_C
+          value_type: button
+    target_event:
+      gamepad:
+        button: RightPaddle2
+
+  - name: Lower left back button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_Z
+          value_type: button
+    target_event:
+      gamepad:
+        button: LeftPaddle2
+
+  - name: Right Stick
+    source_events:
+      - evdev:
+          event_type: ABS
+          event_code: ABS_Z
+          value_type: joystick_x
+      - evdev:
+          event_type: ABS
+          event_code: ABS_RZ
+          value_type: joystick_y
+    target_event:
+      gamepad:
+        axis:
+          name: RightStick
+
+  - name: Left Stick
+    source_events:
+      - evdev:
+          event_type: ABS
+          event_code: ABS_X
+          value_type: joystick_x
+      - evdev:
+          event_type: ABS
+          event_code: ABS_Y
+          value_type: joystick_y
+    target_event:
+      gamepad:
+        axis:
+          name: LeftStick
+
+  - name: Right Stick Click
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_THUMBR
+          value_type: button
+    target_event:
+      gamepad:
+        button: RightStick
+
+  - name: Left Stick Click
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_THUMBL
+          value_type: button
+    target_event:
+      gamepad:
+        button: LeftStick
+
+  - name: Dpad Left
+    source_events:
+      - evdev:
+          event_type: ABS
+          event_code: ABS_HAT0X
+          value_type: button
+          axis_direction: negative
+    target_event:
+      gamepad:
+        button: DPadLeft
+
+  - name: Dpad Right
+    source_events:
+      - evdev:
+          event_type: ABS
+          event_code: ABS_HAT0X
+          value_type: button
+          axis_direction: positive
+    target_event:
+      gamepad:
+        button: DPadRight
+
+  - name: Dpad Down
+    source_events:
+      - evdev:
+          event_type: ABS
+          event_code: ABS_HAT0Y
+          value_type: button
+          axis_direction: positive
+    target_event:
+      gamepad:
+        button: DPadDown
+
+  - name: Dpad Up
+    source_events:
+      - evdev:
+          event_type: ABS
+          event_code: ABS_HAT0Y
+          value_type: button
+          axis_direction: negative
+    target_event:
+      gamepad:
+        button: DPadUp

--- a/system_files/usr/share/inputplumber/devices/03-ayaneo-standard-controller.yaml
+++ b/system_files/usr/share/inputplumber/devices/03-ayaneo-standard-controller.yaml
@@ -1,16 +1,11 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
-# Schema version number
 version: 1
-
-# The type of configuration schema
 kind: CompositeDevice
-
-# Name of the composite device mapping
 name: AYANEO Standard Layout
 
-# Only use this profile if *any* of the given matches matches. If this list is
-# empty, then the source devices will *always* be checked.
-# /sys/class/dmi/id/product_name
+# The Pocket FIT and Pocket S2 expose the main gamepad and their auxiliary
+# buttons as two USB input devices. Keep both sources in one composite so Steam
+# cannot open the raw gamepad alongside InputPlumber's virtual controller.
 matches:
   - udev:
       sys_path: /sys/firmware/devicetree/base
@@ -23,33 +18,42 @@ matches:
         - name: model
           value: AYANEO Pocket S2
 
-# Only allow a single source device per composite device of this type.
-single_source: false
-
-# One or more source devices to combine into a single virtual device. The events
-# from these devices will be watched and translated according to the key map.
-source_devices:
-  - group: gamepad
-    evdev:
-      vendor_id: "1c4f"
-      product_id: "0002"
-      handler: event*
-    capability_map_id: ayaneo_mcu_xbox_standard
-  - group: gamepad
-    evdev:
-      vendor_id: "045e"
-      product_id: "028e"
-      handler: event*
-    capability_map_id: ayaneo_mcu_xbox_standard
-
-# Optional configuration for the composite device
+maximum_sources: 0
 options:
-  # If true, InputPlumber will automatically try to manage the input device. If
-  # this is false, InputPlumber will not try to manage the device unless an
-  # external service enables management of the device. Defaults to 'false'
   auto_manage: true
 
-# The target input device(s) to emulate by default
+source_devices:
+  # AYANEO/DInput mode
+  - group: gamepad
+    capability_map_id: pocket_fit_dinput
+    evdev:
+      name: AYANEO Controller
+      vendor_id: 4001
+      product_id: 0428
+      handler: event*
+  # The same physical HID carries AYANEO/DInput force-feedback output.
+  - group: gamepad
+    hidraw:
+      vendor_id: 0x4001
+      product_id: 0x0428
+      interface_num: 0
+  # Physical XInput mode remains available for Armada Control mode switching.
+  - group: gamepad
+    evdev:
+      phys_path: usb-0001:01:00.0-1/input0
+      vendor_id: 045e
+      product_id: 028e
+      handler: event*
+  # AYANEO auxiliary buttons and the upper pair of back buttons.
+  - group: keyboard
+    capability_map_id: aya9
+    evdev:
+      name: AYANEO DEVICE
+      vendor_id: 1c4f
+      product_id: 0002
+      handler: event*
+
 target_devices:
-  - xb360
+  - deck-uhid
   - keyboard
+  - mouse

--- a/tests/controller-profile-test.sh
+++ b/tests/controller-profile-test.sh
@@ -13,6 +13,7 @@ import sys
 root = Path(sys.argv[1])
 controller_type = root / "system_files/usr/libexec/armada/controller-type"
 devices = root / "system_files/usr/share/inputplumber/devices"
+capability_maps = root / "system_files/usr/share/inputplumber/capability_maps"
 udev_rules = root / "system_files/usr/lib/udev/rules.d/70-armada-inputplumber.rules"
 
 module = ast.parse(controller_type.read_text(encoding="utf-8"))
@@ -60,6 +61,70 @@ rules = udev_rules.read_text(encoding="utf-8")
 missing_rules = sorted(path for path in passthrough_paths if path not in rules)
 if missing_rules:
     raise SystemExit(f"udev rules are missing passthrough paths: {', '.join(missing_rules)}")
+
+pocket_fit = (devices / "03-ayaneo-standard-controller.yaml").read_text(encoding="utf-8")
+required_pocket_fit_entries = {
+    "unlimited composite sources": "maximum_sources: 0",
+    "AYANEO/DInput gamepad": "name: AYANEO Controller",
+    "Pocket FIT DirectInput map": "capability_map_id: pocket_fit_dinput",
+    "AYANEO/DInput vendor ID": "vendor_id: 4001",
+    "AYANEO/DInput product ID": "product_id: 0428",
+    "AYANEO/DInput haptics vendor ID": "vendor_id: 0x4001",
+    "AYANEO/DInput haptics product ID": "product_id: 0x0428",
+    "AYANEO/DInput haptics interface": "interface_num: 0",
+    "AYANEO auxiliary device": "name: AYANEO DEVICE",
+    "AYANEO type 9 map": "capability_map_id: aya9",
+    "Steam Deck target": "- deck-uhid",
+}
+missing_pocket_fit_entries = [
+    label for label, entry in required_pocket_fit_entries.items() if entry not in pocket_fit
+]
+if missing_pocket_fit_entries:
+    raise SystemExit(
+        "Pocket FIT profile is missing: " + ", ".join(missing_pocket_fit_entries)
+    )
+if "capability_map_id: ayaneo_mcu_xbox_standard" in pocket_fit:
+    raise SystemExit("Pocket FIT profile still applies the gamepad map to the auxiliary device")
+
+
+def require_button_mapping(text, source, target, label):
+    pattern = rf"event_code:\s*{re.escape(source)}\b.*?button:\s*{re.escape(target)}\b"
+    if not re.search(pattern, text, re.DOTALL):
+        raise SystemExit(f"{label} is missing mapping {source} -> {target}")
+
+
+pocket_fit_dinput_path = capability_maps / "pocket_fit_dinput.yaml"
+if not pocket_fit_dinput_path.exists():
+    raise SystemExit("Pocket FIT profile references missing main gamepad capability map")
+pocket_fit_dinput = pocket_fit_dinput_path.read_text(encoding="utf-8")
+for source, target in {
+    "BTN_MODE": "Guide",
+    "BTN_SOUTH": "South",
+    "BTN_EAST": "East",
+    "BTN_WEST": "West",
+    "BTN_NORTH": "North",
+    "BTN_START": "Start",
+    "BTN_SELECT": "Select",
+    "BTN_TL": "LeftBumper",
+    "BTN_TR": "RightBumper",
+    "BTN_Z": "LeftPaddle2",
+    "BTN_C": "RightPaddle2",
+}.items():
+    require_button_mapping(pocket_fit_dinput, source, target, "Pocket FIT main gamepad map")
+
+ayaneo_type9_path = capability_maps / "ayaneo_type9.yaml"
+if not ayaneo_type9_path.exists():
+    raise SystemExit("Pocket FIT profile references missing AYANEO type 9 capability map")
+ayaneo_type9 = ayaneo_type9_path.read_text(encoding="utf-8")
+for source, target in (
+    ("BTN7", "QuickAccess"),
+    ("BTN6", "Guide"),
+    ("BTN6", "North"),
+    ("BTN5", "Screenshot"),
+    ("BTN3", "LeftTop"),
+    ("BTN4", "RightTop"),
+):
+    require_button_mapping(ayaneo_type9, source, target, "AYANEO auxiliary map")
 
 print(
     f"controller profile test passed "


### PR DESCRIPTION
## Background

Armada already lists the KONKR Pocket FIT as a supported device and ships an InputPlumber profile for it, so I am not adding a new device from scratch.

While testing the existing support on the physical device, I found that the profile only covered part of the controller. The main gamepad, auxiliary button device, and controller modes were not combined correctly. Some standard and device-specific buttons were unavailable, the four back buttons were not exposed independently, and AYANEO/DInput mode had no rumble. An early rumble implementation also drove only one motor.

I completed the controller profile in this PR. The matching InputPlumber hidraw rumble driver is provided by [armada-packages#40](https://github.com/armada-os/armada-packages/pull/40).

## Controller mapping

I combined the `4001:0428` AYANEO/DInput main gamepad and the `1c4f:0002` AYANEO auxiliary button device into one InputPlumber composite controller. This prevents Steam from opening the raw gamepad alongside InputPlumber's virtual controller.

The standard controls are mapped as follows:

| Physical input | Virtual controller input |
| --- | --- |
| `BTN_SOUTH` | A / South |
| `BTN_EAST` | B / East |
| `BTN_WEST` | X / West |
| `BTN_NORTH` | Y / North |
| `BTN_START` | Menu / Start |
| `BTN_SELECT` | View / Select |
| `BTN_MODE` | Steam / Guide |
| `BTN_TL`, `BTN_TR` | LB, RB |
| `ABS_BRAKE`, `ABS_GAS` | LT, RT |
| `ABS_X/Y` | Left stick |
| `ABS_Z/RZ` | Right stick |
| `BTN_THUMBL`, `BTN_THUMBR` | L3, R3 |
| `ABS_HAT0X/Y` | D-pad |

The device-specific controls are mapped as follows:

| Physical control | Raw input | Final action |
| --- | --- | --- |
| Side shortcut that was previously mapped to Steam+A | `BTN7` | Quick Access Menu |
| Front shortcut that previously opened QAM | `BTN6` | Steam+X / virtual keyboard |
| Second AYANEO shortcut | `BTN5` | Screenshot |
| Upper-left back button | `BTN3` | L4 |
| Lower-left back button | `BTN_Z` | L5 |
| Upper-right back button | `BTN4` | R4 |
| Lower-right back button | `BTN_C` | R5 |

This removes the incorrect Steam+A action and prevents both back buttons on each side from collapsing into the same logical button.

I changed the default virtual target to the Steam Deck controller while keeping the keyboard and mouse targets.

## Rumble

I kept the physical controller in AYANEO/DInput mode so all four back buttons remain available instead of forcing Xbox mode as a workaround.

This profile adds the `4001:0428` interface 0 hidraw source used by the driver in armada-packages#40. The controller uses an 8-byte HID output report. Physical probing confirmed that byte 4 controls the left motor and byte 5 controls the right motor; the earlier one-sided result was caused by a one-byte offset.

## Tested

I tested this on:

- KONKR Pocket FIT
- Snapdragon 8 Gen 3 / SM8650
- Armada
- InputPlumber 0.77.2
- Steam Deck virtual controller target
- Native ARM64 release build

Automated validation:

- AYANEO rumble unit tests: 3 passed
- InputPlumber library tests: 13 passed
- Armada controller profile test passed
- Rust formatting check passed
- ARM64 Docker/QEMU release build passed
- Target replacement and rumble reset passed
- Left-only and right-only rumble passed through the real InputPlumber force-feedback path

I also verified every control on the physical device:

- A/B/X/Y, D-pad, bumpers, triggers, sticks, and stick clicks work;
- Steam, QAM, virtual keyboard, and screenshot shortcuts work;
- the four back buttons report independently as L4, L5, R4, and R5;
- the left and right motors work independently;
- normal in-game rumble works;
- InputPlumber remains active without crashes or service restarts.

Disclosure: I used OpenAI Codex to assist with analysis, implementation, and testing. I reviewed the final diff and validated it on the physical device.
