### PR TITLE
Feat: Add Tailscale

### DIFF
--- a/build_files/10-base-packages.sh
+++ b/build_files/10-base-packages.sh
@@ -61,7 +61,8 @@ dnf5 -y install --setopt=install_weak_deps=False \
     distrobox \
     wl-clipboard \
     binutils \
-    btop
+    btop \
+    tailscale
 
 curl --connect-timeout 30 --max-time 120 --retry 3 -fsSL \
     -o /etc/yum.repos.d/negativo17-fedora-multimedia.repo \


### PR DESCRIPTION
Tailscale is one of the most common VPN solutions we get requested, and doesn't exist on Flathub. Adding to the base image so that users can use it via the CLI if they want to