### PR TITLE
fix(guestos): mount FEX RootFS + Mesa layers from separate SquashFS images

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,7 @@
 ARG FEX_PKG=ghcr.io/armada-os/armada-packages/fex@sha256:7ad92a80e6698245ade709b4f357988dd1520aca25203f7d39659585f2b9948f
 ARG MESA_PKG=ghcr.io/armada-os/armada-packages/mesa@sha256:713eddabb61575b1d9fed5e1c63a7e4459447d34e21d3c0b95f307f9cf54d716
 ARG MESA_ANDROID_PKG=ghcr.io/armada-os/armada-packages/mesa-android@sha256:57b03a625ebdfa12d67210c9642f24f8389c22b319e86ab32715eedfd7ee963b
-ARG MESA_X86_PKG=ghcr.io/armada-os/armada-packages/mesa-x86@sha256:17ca26c35250ce0cd6a98bd13b6a21e06ca44f9e51f299fd008b1e79c4cabfc4
+ARG MESA_X86_PKG=ghcr.io/armada-os/armada-packages/mesa-x86@sha256:68ea12e625f577a311cd4bf65d2ea1110628200759598bc4a788c9afdaf8b81c
 ARG MANGOHUD_PKG=ghcr.io/armada-os/armada-packages/mangohud@sha256:6ed92b44d267a8d2e1339968b59c2679cfd30e81494d4990dcc2c92e0be4fc10
 ARG GAMESCOPE_PKG=ghcr.io/armada-os/armada-packages/gamescope@sha256:23af205c48cb5bd48190f825614d4bc0f29af5d99eb9a9f00026a202c2f12ecb
 ARG GAMESCOPE_SESSION_PKG=ghcr.io/armada-os/armada-packages/gamescope-session@sha256:f778b6def98b813d24f2a40ef038d40e8a85dc60be41d17efafbb9d4baff345b

--- a/build_files/30-install-steam-session.sh
+++ b/build_files/30-install-steam-session.sh
@@ -133,6 +133,6 @@ rm -f "/tmp/${PROTON_TAR}" "/tmp/${PROTON_ARCHIVE_NAME}.sha512sum"
 # user.component xattr) so a system_files change doesn't re-pull them every OTA.
 python3 -c 'import os,sys; os.setxattr(sys.argv[1],"user.component",b"steam")' "${STEAM_HOME}"
 python3 -c 'import os,sys; os.setxattr(sys.argv[1],"user.component",b"proton")' "${PROTON_DIR}/${PROTON_TOOL_NAME}"
-python3 -c 'import os,sys; os.setxattr(sys.argv[1],"user.component",b"fex-rootfs")' /usr/share/fex-emu/RootFS
+python3 -c 'import os,sys; os.setxattr(sys.argv[1],"user.component",b"fex-rootfs")' /usr/share/fex-emu/RootFS/ArchLinux.sqsh
 
 echo "Pre-staged: ARM64 Steam bootstrap + CachyOS Proton 11 ${PROTON_VER}"

--- a/build_files/40-vendor-system-files.sh
+++ b/build_files/40-vendor-system-files.sh
@@ -10,9 +10,10 @@ update-desktop-database -q /usr/share/applications
 
 cp -a /packages/mesa-android/waydroid/vendor /usr/share/armada/waydroid/
 
-# x86 Turnip payload for the guestos overlay; the rootfs's driver lacks armada's mesa patches
-mkdir -p /usr/share/armada/guestos-x86-mesa
-cp -a /packages/mesa-x86/guestos-x86-mesa/usr /usr/share/armada/guestos-x86-mesa/
+mesa_sqsh=/usr/share/fex-emu/RootFS/ArmadaMesa.sqsh
+install -Dm0644 /packages/mesa-x86/ArmadaMesa.sqsh "${mesa_sqsh}"
+# A separate rechunk component keeps Mesa-only updates from invalidating ArchLinux.sqsh.
+python3 -c 'import os,sys; os.setxattr(sys.argv[1],"user.component",b"fex-mesa")' "${mesa_sqsh}"
 
 # Status text font for armada-splash (falls back to its embedded bitmap font
 # if this link dangles). Static face: stb_truetype renders a VF's default

--- a/system_files/usr/lib/systemd/system/armada-guestos.service
+++ b/system_files/usr/lib/systemd/system/armada-guestos.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Present the FEX x86 rootfs at the path Steam's FEX compat tool expects
 ConditionPathExists=/usr/share/fex-emu/RootFS/ArchLinux.sqsh
+ConditionPathExists=/usr/share/fex-emu/RootFS/ArmadaMesa.sqsh
 Before=systemd-user-sessions.service graphical.target
 
 [Service]

--- a/system_files/usr/libexec/armada/armada-guestos-mount
+++ b/system_files/usr/libexec/armada/armada-guestos-mount
@@ -3,27 +3,45 @@
 # path Steam's FEX compat tool hardcodes for the x86 Proton chain.
 set -u
 
-SQSH=/usr/share/fex-emu/RootFS/ArchLinux.sqsh
+ROOTFS_SQSH=/usr/share/fex-emu/RootFS/ArchLinux.sqsh
+MESA_SQSH=/usr/share/fex-emu/RootFS/ArmadaMesa.sqsh
+# /run keeps both lower mounts outside OSTree's overlay-backed /usr.
 RUN=/run/armada/guestos
 TARGET=/usr/share/guestos/fex-mesa
-# rootfs-shaped tree (contains usr/) shadowing the rootfs's driver
-PAYLOAD=/usr/share/armada/guestos-x86-mesa
+ROOTFS_MOUNT=${RUN}/rootfs
+MESA_MOUNT=${RUN}/mesa
+
+mount_ro() {
+  mountpoint -q "$2" || mount -t squashfs -o ro,loop "$1" "$2"
+}
+
+unmount_if_mounted() {
+  if mountpoint -q "$1"; then
+    umount "$1"
+  fi
+}
+
+rollback() {
+  unmount_if_mounted "${MESA_MOUNT}"
+  unmount_if_mounted "${ROOTFS_MOUNT}"
+  exit 1
+}
 
 case "${1:-start}" in
   start)
-    [ -f "${SQSH}" ] || exit 0
-    mkdir -p "${RUN}/lower"
-    mountpoint -q "${RUN}/lower" || mount -t squashfs -o ro,loop "${SQSH}" "${RUN}/lower" || exit 1
+    [ -f "${ROOTFS_SQSH}" ] || exit 0
+    [ -f "${MESA_SQSH}" ] || exit 0
+    mkdir -p "${ROOTFS_MOUNT}" "${MESA_MOUNT}"
+
+    mount_ro "${ROOTFS_SQSH}" "${ROOTFS_MOUNT}" || rollback
+    mount_ro "${MESA_SQSH}" "${MESA_MOUNT}" || rollback
     mountpoint -q "${TARGET}" || mount -t overlay overlay \
-      -o "lowerdir=${PAYLOAD}:${RUN}/lower" "${TARGET}" || exit 1
+      -o "lowerdir=${MESA_MOUNT}:${ROOTFS_MOUNT}" "${TARGET}" || rollback
     ;;
   stop)
-    if mountpoint -q "${TARGET}"; then
-      umount "${TARGET}" || exit 1
-    fi
-    if mountpoint -q "${RUN}/lower"; then
-      umount "${RUN}/lower" || exit 1
-    fi
+    unmount_if_mounted "${TARGET}" || exit 1
+    unmount_if_mounted "${MESA_MOUNT}" || exit 1
+    unmount_if_mounted "${ROOTFS_MOUNT}" || exit 1
     ;;
 esac
 exit 0

--- a/tests/guestos-mount-test.sh
+++ b/tests/guestos-mount-test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+MOUNT_HELPER="$ROOT/system_files/usr/libexec/armada/armada-guestos-mount"
+SERVICE="$ROOT/system_files/usr/lib/systemd/system/armada-guestos.service"
+STEAM_BUILD="$ROOT/build_files/30-install-steam-session.sh"
+VENDOR_BUILD="$ROOT/build_files/40-vendor-system-files.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+assert_contains() {
+    [[ "$1" == *"$2"* ]] || fail "expected output to contain ${2@Q}, got ${1@Q}"
+}
+
+mkdir -p "$WORK/root/usr/share/fex-emu/RootFS" "$WORK/root/usr/share/guestos/fex-mesa" \
+    "$WORK/bin" "$WORK/run"
+touch "$WORK/root/usr/share/fex-emu/RootFS/ArchLinux.sqsh" \
+    "$WORK/root/usr/share/fex-emu/RootFS/ArmadaMesa.sqsh"
+sed \
+    -e "s|/usr/share/fex-emu/RootFS|$WORK/root/usr/share/fex-emu/RootFS|g" \
+    -e "s|/usr/share/guestos/fex-mesa|$WORK/root/usr/share/guestos/fex-mesa|g" \
+    -e "s|/run/armada/guestos|$WORK/run|g" \
+    "$MOUNT_HELPER" > "$WORK/helper"
+chmod +x "$WORK/helper"
+
+cat > "$WORK/bin/mountpoint" <<'EOF'
+#!/usr/bin/env bash
+[[ -f "$MOUNT_STATE/$(printf '%s' "$2" | sed 's|/|_|g')" ]]
+EOF
+cat > "$WORK/bin/mount" <<'EOF'
+#!/usr/bin/env bash
+printf 'mount %s\n' "$*" >> "$MOUNT_LOG"
+if [[ -n "${FAIL_MATCH:-}" && "$*" == *"${FAIL_MATCH}"* ]]; then
+    exit 1
+fi
+target="${!#}"
+touch "$MOUNT_STATE/$(printf '%s' "$target" | sed 's|/|_|g')"
+EOF
+cat > "$WORK/bin/umount" <<'EOF'
+#!/usr/bin/env bash
+printf 'umount %s\n' "$*" >> "$MOUNT_LOG"
+rm -f "$MOUNT_STATE/$(printf '%s' "$1" | sed 's|/|_|g')"
+EOF
+chmod +x "$WORK/bin"/*
+
+export MOUNT_LOG="$WORK/mount.log" MOUNT_STATE="$WORK/state"
+mkdir -p "$MOUNT_STATE"
+
+assert_failed_start_cleans_up() {
+    local fail_match="$1"
+
+    rm -f "$MOUNT_STATE"/* "$MOUNT_LOG"
+    if FAIL_MATCH="$fail_match" PATH="$WORK/bin:/usr/bin:/bin" "$WORK/helper" start; then
+        fail "start succeeded with injected failure ${fail_match@Q}"
+    fi
+    if find "$MOUNT_STATE" -type f -print -quit | grep -q .; then
+        fail "start left mounts behind after injected failure ${fail_match@Q}"
+    fi
+}
+
+assert_failed_start_cleans_up 'ArchLinux.sqsh'
+assert_failed_start_cleans_up 'ArmadaMesa.sqsh'
+assert_failed_start_cleans_up '-t overlay'
+
+: > "$MOUNT_LOG"
+PATH="$WORK/bin:/usr/bin:/bin" "$WORK/helper" start
+
+log="$(<"$MOUNT_LOG")"
+rootfs_sqsh="$WORK/root/usr/share/fex-emu/RootFS/ArchLinux.sqsh"
+mesa_sqsh="$WORK/root/usr/share/fex-emu/RootFS/ArmadaMesa.sqsh"
+assert_contains "$log" "mount -t squashfs -o ro,loop $rootfs_sqsh $WORK/run/rootfs"
+assert_contains "$log" "mount -t squashfs -o ro,loop $mesa_sqsh $WORK/run/mesa"
+assert_contains "$log" "mount -t overlay overlay -o lowerdir=$WORK/run/mesa:$WORK/run/rootfs $WORK/root/usr/share/guestos/fex-mesa"
+
+before="$(wc -l < "$MOUNT_LOG")"
+PATH="$WORK/bin:/usr/bin:/bin" "$WORK/helper" start
+[[ "$(wc -l < "$MOUNT_LOG")" -eq "$before" ]] || fail 'start is not idempotent'
+
+PATH="$WORK/bin:/usr/bin:/bin" "$WORK/helper" stop
+tail -n 3 "$MOUNT_LOG" > "$WORK/unmount.log"
+expected=$(printf 'umount %s\numount %s\numount %s' \
+    "$WORK/root/usr/share/guestos/fex-mesa" "$WORK/run/mesa" "$WORK/run/rootfs")
+[[ "$(<"$WORK/unmount.log")" == "$expected" ]] || fail 'mounts were not removed in reverse order'
+
+grep -qx 'ConditionPathExists=/usr/share/fex-emu/RootFS/ArchLinux.sqsh' "$SERVICE" ||
+    fail 'service does not require ArchLinux.sqsh'
+grep -qx 'ConditionPathExists=/usr/share/fex-emu/RootFS/ArmadaMesa.sqsh' "$SERVICE" ||
+    fail 'service does not require ArmadaMesa.sqsh'
+
+# Separate components keep Mesa-only updates from invalidating ArchLinux.sqsh.
+grep -F 'b"fex-rootfs"' "$STEAM_BUILD" | grep -Fq '/ArchLinux.sqsh' ||
+    fail 'ArchLinux.sqsh does not have its own rechunk component'
+grep -F 'b"fex-mesa"' "$VENDOR_BUILD" | grep -Fq '"${mesa_sqsh}"' ||
+    fail 'ArmadaMesa.sqsh does not have its own rechunk component'
+grep -Fq 'install -Dm0644 /packages/mesa-x86/ArmadaMesa.sqsh "${mesa_sqsh}"' "$VENDOR_BUILD" ||
+    fail 'Armada regenerates rather than consumes the packaged Mesa image'
+if grep -q 'mksquashfs' "$VENDOR_BUILD"; then
+    fail 'Armada regenerates the packaged Mesa image'
+fi
+
+echo 'guestos mount test passed'


### PR DESCRIPTION
- Install ArmadaMesa.sqsh alongside the FEX RootFS instead of vendoring the unpacked x86 Mesa files.
- Mount both SquashFS images under /run and overlay Mesa on RootFS at /usr/share/guestos/fex-mesa.