### PR TITLE
chore(ci): speed up image builds with chunkah

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
           # ubuntu-24.04 dropped these from the runner image; the build action,
           # validation, and push all need them.
           need=""
-          for t in buildah jq podman skopeo systemd-container; do
+          for t in buildah jq skopeo; do
             command -v "$t" >/dev/null || need="$need $t"
           done
           [ -z "$need" ] || { sudo apt-get update && sudo apt-get install -y $need; }
@@ -154,16 +154,16 @@ jobs:
             ARMADA_VERSION=${{ steps.version.outputs.version }}
             BASE_IMAGE=${{ steps.chunkah_config.outputs.base_image }}
             CHUNKAH_CONFIG_STR=${{ steps.chunkah_config.outputs.config }}
+          # armada-rootfs is consumed through RUN --mount, so retain otherwise-unused stages.
           extra-args: |
             --skip-unused-stages=false
-            --target=${{ github.event_name == 'pull_request' && 'armada-rootfs' || 'chunkah' }}
+            --target=chunkah
             --volume=${{ runner.temp }}:/run/src
             --security-opt=label=disable
           oci: false
 
       - name: Validate Chunkah output
         id: chunkah_output
-        if: github.event_name != 'pull_request'
         run: |
           set -euxo pipefail
           CHUNKAH_LOG_FILE="${RUNNER_TEMP}/chunkah.log"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ on:
 env:
   ARMADA_CANONICAL_IMAGE: "ghcr.io/armada-os/armada"
   ARMADA_LEGACY_IMAGE: "ghcr.io/virtudude/armada"
+  BASE_IMAGE: "quay.io/fedora/fedora-bootc:44"
   IMAGE_DESC: "Armada: a gaming-focused, SteamOS-like Fedora bootc image for ARM64 handhelds"
   IMAGE_NAME: "${{ github.event.repository.name }}"
   IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"
@@ -122,18 +123,22 @@ jobs:
 
       - name: Prepare Chunkah config
         id: chunkah_config
-        if: github.event_name != 'pull_request'
         env:
           METADATA_JSON: ${{ steps.metadata.outputs.json }}
         run: |
           set -euo pipefail
+          base_digest=$(skopeo inspect --override-arch arm64 --format '{{.Digest}}' \
+            "docker://${BASE_IMAGE}")
+          base_image="${BASE_IMAGE%:*}@${base_digest}"
           config=$(skopeo inspect --override-arch arm64 --config \
-            docker://quay.io/fedora/fedora-bootc:44 |
+            "docker://${base_image}" |
             jq -c --argjson metadata "${METADATA_JSON}" '
               .config |
               .Labels = ((.Labels // {}) + ($metadata.labels // {})) |
               del(.Labels["ostree.commit"]) |
               del(.Labels["ostree.final-diffid"])')
+          printf '%s\n' "${config}" > "${RUNNER_TEMP}/chunkah-config.json"
+          echo "base_image=${base_image}" >> "${GITHUB_OUTPUT}"
           echo "config=${config}" >> "${GITHUB_OUTPUT}"
 
       - name: Build Image
@@ -147,6 +152,7 @@ jobs:
           labels: ${{ steps.metadata.outputs.labels }}
           build-args: |
             ARMADA_VERSION=${{ steps.version.outputs.version }}
+            BASE_IMAGE=${{ steps.chunkah_config.outputs.base_image }}
             CHUNKAH_CONFIG_STR=${{ steps.chunkah_config.outputs.config }}
           extra-args: |
             --skip-unused-stages=false
@@ -162,6 +168,7 @@ jobs:
           set -euxo pipefail
           CHUNKAH_LOG_FILE="${RUNNER_TEMP}/chunkah.log"
           CHUNKAH_MANIFEST_FILE="${RUNNER_TEMP}/chunkah-manifest.json"
+          CHUNKAH_IMAGE_CONFIG_FILE="${RUNNER_TEMP}/chunkah-image-config.json"
           for component in steam proton fex-rootfs; do
             if ! grep -Eq "creating tar layer .*\"xattr/${component}\"" "${CHUNKAH_LOG_FILE}"; then
               echo "::error::Chunkah did not emit an xattr/${component} component layer"
@@ -182,13 +189,19 @@ jobs:
               echo "::error::Chunkah output retained OSTree manifest annotations"
               exit 1
             }
-          skopeo inspect --config "${CHUNKED_REF}" |
-            jq -e '.architecture == "arm64" and .os == "linux" and
+          skopeo inspect --config "${CHUNKED_REF}" > "${CHUNKAH_IMAGE_CONFIG_FILE}"
+          jq -e --slurpfile expected "${RUNNER_TEMP}/chunkah-config.json" \
+            '.config == $expected[0]' "${CHUNKAH_IMAGE_CONFIG_FILE}" || {
+              echo "::error::Chunkah output did not preserve the prepared runtime config"
+              exit 1
+            }
+          jq -e '.architecture == "arm64" and .os == "linux" and
               .config.Cmd == ["/sbin/init"] and
               .config.Labels["containers.bootc"] == "1" and
               .config.Labels["ostree.bootable"] == "true" and
               (.config.Labels | has("ostree.commit") | not) and
-              (.config.Labels | has("ostree.final-diffid") | not)'
+              (.config.Labels | has("ostree.final-diffid") | not)' \
+            "${CHUNKAH_IMAGE_CONFIG_FILE}"
           jq '{layers: (.layers | length), compressed_bytes: ([.layers[].size] | add)}' \
             "${CHUNKAH_MANIFEST_FILE}"
           echo "ref=${CHUNKED_REF}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,11 +42,6 @@ jobs:
       id-token: write
 
     steps:
-      - name: Maximize build space
-        uses: ublue-os/remove-unwanted-software@cc0becac701cf642c8f0a6613bbdaf5dc36b259e # v9
-        with:
-          remove-codeql: true
-
       - name: Prepare environment
         run: |
           echo "IMAGE_REGISTRY=${IMAGE_REGISTRY,,}" >> ${GITHUB_ENV}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ on:
 env:
   ARMADA_CANONICAL_IMAGE: "ghcr.io/armada-os/armada"
   ARMADA_LEGACY_IMAGE: "ghcr.io/virtudude/armada"
+  CHUNKAH_IMAGE: "quay.io/coreos/chunkah@sha256:ff8b8b466a942ec6000445d4001fc661e2fc5a952ad9ee29b4de9ab09d1d1708"
   IMAGE_DESC: "Armada: a gaming-focused, SteamOS-like Fedora bootc image for ARM64 handhelds"
   IMAGE_NAME: "${{ github.event.repository.name }}"
   IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"
@@ -143,31 +144,66 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           set -euxo pipefail
-          # build-chunked-oci runs rpm-ostree from inside the image against root
-          # containers-storage, so bridge the rootless-built image over first.
-          sudo podman image scp ${USER}@localhost::${IMAGE_NAME}:raw root@localhost::raw-img
-          sudo podman run --rm --privileged \
-            --volume /var/lib/containers:/var/lib/containers \
-            localhost/raw-img \
-            rpm-ostree compose build-chunked-oci --bootc --max-layers 127 \
-            --format-version 2 \
-            --from localhost/raw-img --output containers-storage:localhost/chunked-img
+          CHUNKAH_CONFIG_FILE="${RUNNER_TEMP}/chunkah-config.json"
+          CHUNKAH_LOG_FILE="${RUNNER_TEMP}/chunkah.log"
+          CHUNKAH_MANIFEST_FILE="${RUNNER_TEMP}/chunkah-manifest.json"
+          CHUNKAH_OUTPUT_DIR="${RUNNER_TEMP}/chunkah-output"
+          mkdir -p "${CHUNKAH_OUTPUT_DIR}"
+          podman image inspect "${IMAGE_NAME}:raw" > "${CHUNKAH_CONFIG_FILE}"
+          start=${SECONDS}
+          podman run --rm \
+            --mount="type=image,src=${IMAGE_NAME}:raw,target=/chunkah" \
+            --volume="${CHUNKAH_CONFIG_FILE}:/chunkah-config.json:ro" \
+            --volume="${CHUNKAH_OUTPUT_DIR}:/run/out" \
+            "${CHUNKAH_IMAGE}" \
+            build --verbose --compressed --compression-level 6 \
+            --max-layers 128 --prune /sysroot/ \
+            --label ostree.commit- --label ostree.final-diffid- \
+            --config /chunkah-config.json --output oci:/run/out/chunked 2>&1 |
+            tee "${CHUNKAH_LOG_FILE}"
+          echo "Chunkah completed in $((SECONDS - start)) seconds"
+          for component in steam proton fex-rootfs; do
+            if ! grep -Eq "creating tar layer .*\"xattr/${component}\"" "${CHUNKAH_LOG_FILE}"; then
+              echo "::error::Chunkah did not emit an xattr/${component} component layer"
+              exit 1
+            fi
+          done
+
+          CHUNKED_REF="oci:${CHUNKAH_OUTPUT_DIR}/chunked"
+          skopeo inspect --raw "${CHUNKED_REF}" > "${CHUNKAH_MANIFEST_FILE}"
+          jq -e '(.layers | length) > 1 and (.layers | length) <= 128' \
+            "${CHUNKAH_MANIFEST_FILE}" || {
+              echo "::error::Chunkah output has an invalid layer count"
+              exit 1
+            }
+          jq -e '((.annotations // {}) | has("ostree.commit") | not) and
+            ((.annotations // {}) | has("ostree.final-diffid") | not)' \
+            "${CHUNKAH_MANIFEST_FILE}" || {
+              echo "::error::Chunkah output retained OSTree manifest annotations"
+              exit 1
+            }
+          skopeo inspect "${CHUNKED_REF}" |
+            jq -e '.Labels["containers.bootc"] == "1" and .Labels["ostree.bootable"] == "true" and
+              (.Labels | has("ostree.commit") | not) and
+              (.Labels | has("ostree.final-diffid") | not)'
+          jq '{layers: (.layers | length), compressed_bytes: ([.layers[].size] | add)}' \
+            "${CHUNKAH_MANIFEST_FILE}"
+          echo "ref=${CHUNKED_REF}" >> "${GITHUB_OUTPUT}"
 
       - name: Push to GHCR
         id: push
         if: github.event_name != 'pull_request'
         run: |
           set -euxo pipefail
-          echo "${{ secrets.GITHUB_TOKEN }}" | sudo skopeo login ghcr.io -u "${{ github.actor }}" --password-stdin
+          echo "${{ secrets.GITHUB_TOKEN }}" | skopeo login ghcr.io -u "${{ github.actor }}" --password-stdin
           IMAGE_FULL="${IMAGE_REGISTRY}/${IMAGE_NAME}"
           BUILD_TAG="build-${{ steps.version.outputs.version }}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           n=0
-          until sudo skopeo copy \
-                containers-storage:localhost/chunked-img "docker://${IMAGE_FULL}:${BUILD_TAG}"; do
+          until skopeo copy --all \
+                "${{ steps.rechunk.outputs.ref }}" "docker://${IMAGE_FULL}:${BUILD_TAG}"; do
             n=$((n + 1)); [ "${n}" -ge 3 ] && exit 1; sleep 15
           done
-          # skopeo --digestfile can't write under sudo's userns remap; read it back.
-          digest=$(sudo skopeo inspect --format '{{.Digest}}' "docker://${IMAGE_FULL}:${BUILD_TAG}")
+          digest=$(skopeo inspect --format '{{.Digest}}' "docker://${IMAGE_FULL}:${BUILD_TAG}")
           echo "digest=${digest}" >> "${GITHUB_OUTPUT}"
 
       - name: Install Cosign
@@ -184,8 +220,7 @@ jobs:
           set -euo pipefail
           IMAGE_FULL="${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}"
           IMAGE_REF="${IMAGE_FULL}@${{ steps.push.outputs.digest }}"
-          # cosign runs rootless and has its own auth store — the push step's
-          # `sudo skopeo login` only authenticated root, so log cosign in too.
+          # Cosign and Skopeo use separate registry auth stores.
           echo "${{ secrets.GITHUB_TOKEN }}" | cosign login ghcr.io -u "${{ github.actor }}" --password-stdin
           # Sign the digest, not a tag (a concurrent run could re-point the tag).
           # --new-bundle-format=false: bootc's verifier expects the legacy .sig; the
@@ -224,9 +259,14 @@ jobs:
           SRC="docker://${IMAGE_FULL}@${{ steps.push.outputs.digest }}"
           for tag in ${{ steps.metadata.outputs.tags }}; do
             n=0
-            until sudo skopeo copy --all "${SRC}" "docker://${IMAGE_FULL}:${tag}"; do
+            until skopeo copy --all "${SRC}" "docker://${IMAGE_FULL}:${tag}"; do
               n=$((n + 1)); [ "${n}" -ge 3 ] && exit 1; sleep 15
             done
+            tag_digest=$(skopeo inspect --format '{{.Digest}}' "docker://${IMAGE_FULL}:${tag}")
+            if [ "${tag_digest}" != "${{ steps.push.outputs.digest }}" ]; then
+              echo "::error::${tag} resolved to ${tag_digest}, not the signed digest ${{ steps.push.outputs.digest }}"
+              exit 1
+            fi
           done
         env:
           HAVE_SIGNING_SECRET: ${{ secrets.SIGNING_SECRET != '' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,6 @@ on:
 env:
   ARMADA_CANONICAL_IMAGE: "ghcr.io/armada-os/armada"
   ARMADA_LEGACY_IMAGE: "ghcr.io/virtudude/armada"
-  CHUNKAH_IMAGE: "quay.io/coreos/chunkah@sha256:ff8b8b466a942ec6000445d4001fc661e2fc5a952ad9ee29b4de9ab09d1d1708"
   IMAGE_DESC: "Armada: a gaming-focused, SteamOS-like Fedora bootc image for ARM64 handhelds"
   IMAGE_NAME: "${{ github.event.repository.name }}"
   IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"
@@ -70,7 +69,7 @@ jobs:
         run: |
           set -euxo pipefail
           # ubuntu-24.04 dropped these from the runner image; the build action,
-          # rechunk, and push all need them.
+          # validation, and push all need them.
           need=""
           for t in buildah jq podman skopeo systemd-container; do
             command -v "$t" >/dev/null || need="$need $t"
@@ -121,6 +120,22 @@ jobs:
           sep-tags: " "
           sep-annotations: " "
 
+      - name: Prepare Chunkah config
+        id: chunkah_config
+        if: github.event_name != 'pull_request'
+        env:
+          METADATA_JSON: ${{ steps.metadata.outputs.json }}
+        run: |
+          set -euo pipefail
+          config=$(skopeo inspect --override-arch arm64 --config \
+            docker://quay.io/fedora/fedora-bootc:44 |
+            jq -c --argjson metadata "${METADATA_JSON}" '
+              .config |
+              .Labels = ((.Labels // {}) + ($metadata.labels // {})) |
+              del(.Labels["ostree.commit"]) |
+              del(.Labels["ostree.final-diffid"])')
+          echo "config=${config}" >> "${GITHUB_OUTPUT}"
+
       - name: Build Image
         id: build_image
         uses: redhat-actions/buildah-build@5d8479758cc72ed82df28daba521d27e20ff8c8a # v3.0.0
@@ -128,35 +143,25 @@ jobs:
           containerfiles: |
             ./Containerfile
           image: ${{ env.IMAGE_NAME }}
-          tags: raw
+          tags: build-output
           labels: ${{ steps.metadata.outputs.labels }}
           build-args: |
             ARMADA_VERSION=${{ steps.version.outputs.version }}
+            CHUNKAH_CONFIG_STR=${{ steps.chunkah_config.outputs.config }}
+          extra-args: |
+            --skip-unused-stages=false
+            --target=${{ github.event_name == 'pull_request' && 'armada-rootfs' || 'chunkah' }}
+            --volume=${{ runner.temp }}:/run/src
+            --security-opt=label=disable
           oci: false
 
-      - name: Rechunk for small OTA deltas
-        id: rechunk
+      - name: Validate Chunkah output
+        id: chunkah_output
         if: github.event_name != 'pull_request'
         run: |
           set -euxo pipefail
-          CHUNKAH_CONFIG_FILE="${RUNNER_TEMP}/chunkah-config.json"
           CHUNKAH_LOG_FILE="${RUNNER_TEMP}/chunkah.log"
           CHUNKAH_MANIFEST_FILE="${RUNNER_TEMP}/chunkah-manifest.json"
-          CHUNKAH_OUTPUT_DIR="${RUNNER_TEMP}/chunkah-output"
-          mkdir -p "${CHUNKAH_OUTPUT_DIR}"
-          podman image inspect "${IMAGE_NAME}:raw" > "${CHUNKAH_CONFIG_FILE}"
-          start=${SECONDS}
-          podman run --rm \
-            --mount="type=image,src=${IMAGE_NAME}:raw,target=/chunkah" \
-            --volume="${CHUNKAH_CONFIG_FILE}:/chunkah-config.json:ro" \
-            --volume="${CHUNKAH_OUTPUT_DIR}:/run/out" \
-            "${CHUNKAH_IMAGE}" \
-            build --verbose --compressed --compression-level 6 \
-            --max-layers 128 --prune /sysroot/ \
-            --label ostree.commit- --label ostree.final-diffid- \
-            --config /chunkah-config.json --output oci:/run/out/chunked 2>&1 |
-            tee "${CHUNKAH_LOG_FILE}"
-          echo "Chunkah completed in $((SECONDS - start)) seconds"
           for component in steam proton fex-rootfs; do
             if ! grep -Eq "creating tar layer .*\"xattr/${component}\"" "${CHUNKAH_LOG_FILE}"; then
               echo "::error::Chunkah did not emit an xattr/${component} component layer"
@@ -164,7 +169,7 @@ jobs:
             fi
           done
 
-          CHUNKED_REF="oci:${CHUNKAH_OUTPUT_DIR}/chunked"
+          CHUNKED_REF="oci:${RUNNER_TEMP}/chunked"
           skopeo inspect --raw "${CHUNKED_REF}" > "${CHUNKAH_MANIFEST_FILE}"
           jq -e '(.layers | length) > 1 and (.layers | length) <= 128' \
             "${CHUNKAH_MANIFEST_FILE}" || {
@@ -177,10 +182,13 @@ jobs:
               echo "::error::Chunkah output retained OSTree manifest annotations"
               exit 1
             }
-          skopeo inspect "${CHUNKED_REF}" |
-            jq -e '.Labels["containers.bootc"] == "1" and .Labels["ostree.bootable"] == "true" and
-              (.Labels | has("ostree.commit") | not) and
-              (.Labels | has("ostree.final-diffid") | not)'
+          skopeo inspect --config "${CHUNKED_REF}" |
+            jq -e '.architecture == "arm64" and .os == "linux" and
+              .config.Cmd == ["/sbin/init"] and
+              .config.Labels["containers.bootc"] == "1" and
+              .config.Labels["ostree.bootable"] == "true" and
+              (.config.Labels | has("ostree.commit") | not) and
+              (.config.Labels | has("ostree.final-diffid") | not)'
           jq '{layers: (.layers | length), compressed_bytes: ([.layers[].size] | add)}' \
             "${CHUNKAH_MANIFEST_FILE}"
           echo "ref=${CHUNKED_REF}" >> "${GITHUB_OUTPUT}"
@@ -195,7 +203,7 @@ jobs:
           BUILD_TAG="build-${{ steps.version.outputs.version }}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           n=0
           until skopeo copy --all \
-                "${{ steps.rechunk.outputs.ref }}" "docker://${IMAGE_FULL}:${BUILD_TAG}"; do
+                "${{ steps.chunkah_output.outputs.ref }}" "docker://${IMAGE_FULL}:${BUILD_TAG}"; do
             n=$((n + 1)); [ "${n}" -ge 3 ] && exit 1; sleep 15
           done
           digest=$(skopeo inspect --format '{{.Digest}}' "docker://${IMAGE_FULL}:${BUILD_TAG}")

--- a/Containerfile
+++ b/Containerfile
@@ -17,6 +17,7 @@ ARG ARMADA_SPLASH_PKG=ghcr.io/armada-os/armada-packages/armada-splash@sha256:6b0
 ARG ARMADA_RGB_PKG=ghcr.io/armada-os/armada-packages/armada-rgb@sha256:a7b66324d7bf8030e260d5f2fc9074ad9ced7c47852187783f5e3e082d0ebc25
 ARG UMTP_RESPONDER_PKG=ghcr.io/armada-os/armada-packages/umtp-responder@sha256:b0fe59bf87bccdde7273d7ade9f824171a5b4ac5f132b4670b32a73bb1f871b3
 ARG CHUNKAH_IMAGE=quay.io/coreos/chunkah@sha256:ff8b8b466a942ec6000445d4001fc661e2fc5a952ad9ee29b4de9ab09d1d1708
+ARG BASE_IMAGE=quay.io/fedora/fedora-bootc:44
 
 FROM ${FEX_PKG} AS fex
 FROM ${MESA_PKG} AS mesa
@@ -55,7 +56,7 @@ COPY build_files /build_files/
 COPY decky /decky/
 COPY system_files /system_files/
 
-FROM quay.io/fedora/fedora-bootc:44 AS armada-rootfs
+FROM ${BASE_IMAGE} AS armada-rootfs
 ARG ARMADA_VERSION=unknown
 LABEL org.opencontainers.image.version="${ARMADA_VERSION}"
 
@@ -91,12 +92,13 @@ RUN bootc container lint
 
 FROM ${CHUNKAH_IMAGE} AS chunkah
 ARG CHUNKAH_CONFIG_STR
-RUN --mount=type=bind,target=/run/src,rw \
-    --mount=from=armada-rootfs,target=/chunkah,ro \
+RUN --mount=from=armada-rootfs,target=/chunkah,ro \
     /bin/bash -o pipefail -c ' \
+        set -e; \
         start=${SECONDS}; \
         chunkah build --verbose --compressed --compression-level 6 \
-            --arch arm64 --max-layers 128 --prune /sysroot/ \
+            --arch arm64 --max-layers 128 --source-date-epoch 0 \
+            --prune /sysroot/ \
             --label ostree.commit- --label ostree.final-diffid- \
             --config-str "${CHUNKAH_CONFIG_STR}" \
             --output oci:/run/src/chunked 2>&1 | tee /run/src/chunkah.log; \

--- a/Containerfile
+++ b/Containerfile
@@ -16,6 +16,7 @@ ARG JUPITER_HW_SUPPORT_PKG=ghcr.io/armada-os/armada-packages/jupiter-hw-support@
 ARG ARMADA_SPLASH_PKG=ghcr.io/armada-os/armada-packages/armada-splash@sha256:6b018ab61218ad5b760fc93b27f7f6af4af4fb6301cb1ed4711cd33ded8c0ea0
 ARG ARMADA_RGB_PKG=ghcr.io/armada-os/armada-packages/armada-rgb@sha256:a7b66324d7bf8030e260d5f2fc9074ad9ced7c47852187783f5e3e082d0ebc25
 ARG UMTP_RESPONDER_PKG=ghcr.io/armada-os/armada-packages/umtp-responder@sha256:b0fe59bf87bccdde7273d7ade9f824171a5b4ac5f132b4670b32a73bb1f871b3
+ARG CHUNKAH_IMAGE=quay.io/coreos/chunkah@sha256:ff8b8b466a942ec6000445d4001fc661e2fc5a952ad9ee29b4de9ab09d1d1708
 
 FROM ${FEX_PKG} AS fex
 FROM ${MESA_PKG} AS mesa
@@ -54,7 +55,7 @@ COPY build_files /build_files/
 COPY decky /decky/
 COPY system_files /system_files/
 
-FROM quay.io/fedora/fedora-bootc:44
+FROM quay.io/fedora/fedora-bootc:44 AS armada-rootfs
 ARG ARMADA_VERSION=unknown
 LABEL org.opencontainers.image.version="${ARMADA_VERSION}"
 
@@ -87,3 +88,19 @@ RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
     /ctx/build_files/build.sh
 
 RUN bootc container lint
+
+FROM ${CHUNKAH_IMAGE} AS chunkah
+ARG CHUNKAH_CONFIG_STR
+RUN --mount=type=bind,target=/run/src,rw \
+    --mount=from=armada-rootfs,target=/chunkah,ro \
+    /bin/bash -o pipefail -c ' \
+        start=${SECONDS}; \
+        chunkah build --verbose --compressed --compression-level 6 \
+            --arch arm64 --max-layers 128 --prune /sysroot/ \
+            --label ostree.commit- --label ostree.final-diffid- \
+            --config-str "${CHUNKAH_CONFIG_STR}" \
+            --output oci:/run/src/chunked 2>&1 | tee /run/src/chunkah.log; \
+        echo "Chunkah completed in $((SECONDS - start)) seconds" \
+    '
+
+FROM armada-rootfs AS armada

--- a/Justfile
+++ b/Justfile
@@ -120,6 +120,7 @@ build $target_image=image_name $tag=default_tag:
         "${SECRET_ARGS[@]}" \
         --platform linux/arm64 \
         --pull="${PULL_POLICY}" \
+        --target armada-rootfs \
         --tag "${target_image}:${tag}" \
         .
 

--- a/build_files/30-install-steam-session.sh
+++ b/build_files/30-install-steam-session.sh
@@ -129,8 +129,7 @@ python3 /ctx/build_files/patch-proton-cachyos-dxvk-probe.py \
 python3 /ctx/build_files/set-steam-default-compat.py "${STEAM_HOME}" "${PROTON_TOOL_NAME}" "${PROTON_DIR}"
 rm -f "/tmp/${PROTON_TAR}" "/tmp/${PROTON_ARCHIVE_NAME}.sha512sum"
 
-# Pin Steam, Proton, and the FEX rootfs to their own rechunk layers (build-chunked-oci reads the
-# user.component xattr) so a system_files change doesn't re-pull them every OTA.
+# Identify large independently updated components for content-aware layer packing.
 python3 -c 'import os,sys; os.setxattr(sys.argv[1],"user.component",b"steam")' "${STEAM_HOME}"
 python3 -c 'import os,sys; os.setxattr(sys.argv[1],"user.component",b"proton")' "${PROTON_DIR}/${PROTON_TOOL_NAME}"
 python3 -c 'import os,sys; os.setxattr(sys.argv[1],"user.component",b"fex-rootfs")' /usr/share/fex-emu/RootFS/ArchLinux.sqsh

--- a/build_files/55-generate-initramfs.sh
+++ b/build_files/55-generate-initramfs.sh
@@ -22,8 +22,7 @@ dracut \
 
 # dracut drops modules silently: fail the build rather than ship without.
 # Exact match: a substring test lets armada-splash-launcher pass for the binary.
-contents="$(lsinitrd "${IMG}")"
-for required in \
+required=(
     usr/lib/systemd/system/armada-splash-initrd.service \
     usr/lib/systemd/system/dracut-pre-mount.service.d/armada-splash.conf \
     usr/libexec/armada/armada-splash \
@@ -32,12 +31,31 @@ for required in \
     usr/share/armada/splash/splash.asp \
     usr/libexec/armada/armada-ostree-fallback \
     usr/lib/systemd/system/ostree-prepare-root.service.d/armada-fallback.conf \
-    usr/lib/ostree/ostree-prepare-root; do
-    if ! awk -v p="${required}" '$NF == p { found=1 } END { exit !found }' <<<"${contents}"; then
-        echo "ERROR: ${required} missing from initramfs"
-        dracut --list-modules --kver "${KVER}" | grep -i armada || true
-        exit 1
-    fi
-done
+    usr/lib/ostree/ostree-prepare-root
+)
+
+if ! lsinitrd "${IMG}" | awk '
+    BEGIN {
+        count = ARGC - 1
+        for (i = 1; i <= count; i++) {
+            paths[i] = ARGV[i]
+            required[ARGV[i]] = 1
+        }
+        ARGC = 1
+    }
+    $NF in required { found[$NF] = 1 }
+    END {
+        for (i = 1; i <= count; i++) {
+            if (!(paths[i] in found)) {
+                print "ERROR: " paths[i] " missing from initramfs" > "/dev/stderr"
+                missing = 1
+            }
+        }
+        exit missing
+    }
+' "${required[@]}"; then
+    dracut --list-modules --kver "${KVER}" | grep -i armada || true
+    exit 1
+fi
 
 echo "initramfs generated for ${KVER} with armada-splash"

--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -3,13 +3,21 @@ set -euxo pipefail
 
 cd /ctx/build_files
 
-./10-base-packages.sh
-./20-install-kernel.sh
-./30-install-steam-session.sh
-./40-vendor-system-files.sh
-./45-install-decky-plugins.sh
-./50-create-user.sh
-./55-generate-initramfs.sh
-./60-set-default-target.sh
-./70-cleanup.sh
-./80-finalize-update-state.sh
+run_step() {
+    local step="${1#./}"
+    local start="${SECONDS}"
+
+    "$@"
+    printf '%s completed in %d seconds\n' "${step}" "$((SECONDS - start))"
+}
+
+run_step ./10-base-packages.sh
+run_step ./20-install-kernel.sh
+run_step ./30-install-steam-session.sh
+run_step ./40-vendor-system-files.sh
+run_step ./45-install-decky-plugins.sh
+run_step ./50-create-user.sh
+run_step ./55-generate-initramfs.sh
+run_step ./60-set-default-target.sh
+run_step ./70-cleanup.sh
+run_step ./80-finalize-update-state.sh

--- a/build_files/generate-steam-bootstrap.sh
+++ b/build_files/generate-steam-bootstrap.sh
@@ -160,6 +160,7 @@ find "${STEAM_BOOTSTRAP_HOME}" \
     -delete
 find "${STEAM_BOOTSTRAP_HOME}" \( -type s -o -type p \) -delete
 rm -f \
+    "${STEAM}/package/steam_client_metrics.bin" \
     "${STEAM}/registry.vdf" \
     "${STEAM}/ssfn"* \
     "${DOT_STEAM}/registry.vdf" \


### PR DESCRIPTION
## Summary

Replace the ~20-minute rpm-ostree rechunk step with Chunkah, remove the privileged Podman path, and
stabilize large component layers.

## Results

- Full build: ~40m → 14–16m
- Chunking: ~20m → 107–128s
- Identical builds reuse 123/128 layers
- Changed payload: ~1.84 GB → 108 MB
- Steam, Proton, and FEX layers are stable

PRs now build and validate the Chunkah artifact but do not publish it.

## Before merge

Validate a device upgrade, rollback, and fresh disk-image boot. The first update will require a near-full
download because the layer format changed.
