### PR TITLE
fix(ci): build with native OverlayFS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ env:
   ARMADA_CANONICAL_IMAGE: "ghcr.io/armada-os/armada"
   ARMADA_LEGACY_IMAGE: "ghcr.io/virtudude/armada"
   BASE_IMAGE: "quay.io/fedora/fedora-bootc:44"
+  CHUNKAH_IMAGE: "quay.io/coreos/chunkah@sha256:ff8b8b466a942ec6000445d4001fc661e2fc5a952ad9ee29b4de9ab09d1d1708"
   IMAGE_DESC: "Armada: a gaming-focused, SteamOS-like Fedora bootc image for ARM64 handhelds"
   IMAGE_NAME: "${{ github.event.repository.name }}"
   IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"
@@ -69,10 +70,10 @@ jobs:
       - name: Ensure container tools
         run: |
           set -euxo pipefail
-          # ubuntu-24.04 dropped these from the runner image; the build action,
-          # validation, and push all need them.
+          # ubuntu-24.04 dropped these from the runner image; build, chunking,
+          # validation, and push need them.
           need=""
-          for t in buildah jq skopeo; do
+          for t in buildah jq podman skopeo; do
             command -v "$t" >/dev/null || need="$need $t"
           done
           [ -z "$need" ] || { sudo apt-get update && sudo apt-get install -y $need; }
@@ -153,14 +154,39 @@ jobs:
           build-args: |
             ARMADA_VERSION=${{ steps.version.outputs.version }}
             BASE_IMAGE=${{ steps.chunkah_config.outputs.base_image }}
-            CHUNKAH_CONFIG_STR=${{ steps.chunkah_config.outputs.config }}
-          # armada-rootfs is consumed through RUN --mount, so retain otherwise-unused stages.
           extra-args: |
-            --skip-unused-stages=false
-            --target=chunkah
-            --volume=${{ runner.temp }}:/run/src
-            --security-opt=label=disable
+            --target=armada
           oci: false
+
+      - name: Verify Chunkah source image
+        run: |
+          set -euxo pipefail
+          podman images --format '{{.Repository}}:{{.Tag}} {{.Digest}}'
+          podman image exists "localhost/${IMAGE_NAME}:build-output"
+
+      - name: Chunk image
+        env:
+          CHUNKAH_CONFIG_STR: ${{ steps.chunkah_config.outputs.config }}
+        run: |
+          set -euxo pipefail
+          start=${SECONDS}
+          podman run --rm --pull=missing \
+            --mount type=image,src="localhost/${IMAGE_NAME}:build-output",target=/chunkah \
+            --volume "${RUNNER_TEMP}:/run/src" \
+            --security-opt label=disable \
+            --env CHUNKAH_CONFIG_STR \
+            --entrypoint /bin/bash \
+            "${CHUNKAH_IMAGE}" \
+            -o pipefail -c '
+              set -e
+              chunkah build --verbose --compressed --compression-level 6 \
+                --arch arm64 --max-layers 128 --source-date-epoch 0 \
+                --prune /sysroot/ \
+                --label ostree.commit- --label ostree.final-diffid- \
+                --config-str "${CHUNKAH_CONFIG_STR}" \
+                --output oci:/run/src/chunked 2>&1 | tee /run/src/chunkah.log
+            '
+          echo "Chunkah completed in $((SECONDS - start)) seconds"
 
       - name: Validate Chunkah output
         id: chunkah_output
@@ -168,7 +194,7 @@ jobs:
           set -euxo pipefail
           CHUNKAH_LOG_FILE="${RUNNER_TEMP}/chunkah.log"
           CHUNKAH_MANIFEST_FILE="${RUNNER_TEMP}/chunkah-manifest.json"
-          CHUNKAH_IMAGE_CONFIG_FILE="${RUNNER_TEMP}/chunkah-image-config.json"
+          CHUNKED_IMAGE_CONFIG_FILE="${RUNNER_TEMP}/chunkah-image-config.json"
           for component in steam proton fex-rootfs; do
             if ! grep -Eq "creating tar layer .*\"xattr/${component}\"" "${CHUNKAH_LOG_FILE}"; then
               echo "::error::Chunkah did not emit an xattr/${component} component layer"
@@ -189,9 +215,9 @@ jobs:
               echo "::error::Chunkah output retained OSTree manifest annotations"
               exit 1
             }
-          skopeo inspect --config "${CHUNKED_REF}" > "${CHUNKAH_IMAGE_CONFIG_FILE}"
+          skopeo inspect --config "${CHUNKED_REF}" > "${CHUNKED_IMAGE_CONFIG_FILE}"
           jq -e --slurpfile expected "${RUNNER_TEMP}/chunkah-config.json" \
-            '.config == $expected[0]' "${CHUNKAH_IMAGE_CONFIG_FILE}" || {
+            '.config == $expected[0]' "${CHUNKED_IMAGE_CONFIG_FILE}" || {
               echo "::error::Chunkah output did not preserve the prepared runtime config"
               exit 1
             }
@@ -201,7 +227,9 @@ jobs:
               .config.Labels["ostree.bootable"] == "true" and
               (.config.Labels | has("ostree.commit") | not) and
               (.config.Labels | has("ostree.final-diffid") | not)' \
-            "${CHUNKAH_IMAGE_CONFIG_FILE}"
+            "${CHUNKED_IMAGE_CONFIG_FILE}"
+          python3 build_files/verify-steam-bootstrap.py --oci "${RUNNER_TEMP}/chunked"
+          echo "Steam bootstrap manifest verified in Chunkah output"
           jq '{layers: (.layers | length), compressed_bytes: ([.layers[].size] | add)}' \
             "${CHUNKAH_MANIFEST_FILE}"
           echo "ref=${CHUNKED_REF}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,6 @@ env:
   ARMADA_CANONICAL_IMAGE: "ghcr.io/armada-os/armada"
   ARMADA_LEGACY_IMAGE: "ghcr.io/virtudude/armada"
   BASE_IMAGE: "quay.io/fedora/fedora-bootc:44"
-  CHUNKAH_IMAGE: "quay.io/coreos/chunkah@sha256:ff8b8b466a942ec6000445d4001fc661e2fc5a952ad9ee29b4de9ab09d1d1708"
   IMAGE_DESC: "Armada: a gaming-focused, SteamOS-like Fedora bootc image for ARM64 handhelds"
   IMAGE_NAME: "${{ github.event.repository.name }}"
   IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"
@@ -70,10 +69,10 @@ jobs:
       - name: Ensure container tools
         run: |
           set -euxo pipefail
-          # ubuntu-24.04 dropped these from the runner image; build, chunking,
-          # validation, and push need them.
+          # ubuntu-24.04 dropped these from the runner image; the build action,
+          # validation, and push all need them.
           need=""
-          for t in buildah jq podman skopeo; do
+          for t in buildah jq skopeo; do
             command -v "$t" >/dev/null || need="$need $t"
           done
           [ -z "$need" ] || { sudo apt-get update && sudo apt-get install -y $need; }
@@ -154,39 +153,14 @@ jobs:
           build-args: |
             ARMADA_VERSION=${{ steps.version.outputs.version }}
             BASE_IMAGE=${{ steps.chunkah_config.outputs.base_image }}
+            CHUNKAH_CONFIG_STR=${{ steps.chunkah_config.outputs.config }}
+          # armada-rootfs is consumed through RUN --mount, so retain otherwise-unused stages.
           extra-args: |
-            --target=armada
+            --skip-unused-stages=false
+            --target=chunkah
+            --volume=${{ runner.temp }}:/run/src
+            --security-opt=label=disable
           oci: false
-
-      - name: Verify Chunkah source image
-        run: |
-          set -euxo pipefail
-          podman images --format '{{.Repository}}:{{.Tag}} {{.Digest}}'
-          podman image exists "localhost/${IMAGE_NAME}:build-output"
-
-      - name: Chunk image
-        env:
-          CHUNKAH_CONFIG_STR: ${{ steps.chunkah_config.outputs.config }}
-        run: |
-          set -euxo pipefail
-          start=${SECONDS}
-          podman run --rm --pull=missing \
-            --mount type=image,src="localhost/${IMAGE_NAME}:build-output",target=/chunkah \
-            --volume "${RUNNER_TEMP}:/run/src" \
-            --security-opt label=disable \
-            --env CHUNKAH_CONFIG_STR \
-            --entrypoint /bin/bash \
-            "${CHUNKAH_IMAGE}" \
-            -o pipefail -c '
-              set -e
-              chunkah build --verbose --compressed --compression-level 6 \
-                --arch arm64 --max-layers 128 --source-date-epoch 0 \
-                --prune /sysroot/ \
-                --label ostree.commit- --label ostree.final-diffid- \
-                --config-str "${CHUNKAH_CONFIG_STR}" \
-                --output oci:/run/src/chunked 2>&1 | tee /run/src/chunkah.log
-            '
-          echo "Chunkah completed in $((SECONDS - start)) seconds"
 
       - name: Validate Chunkah output
         id: chunkah_output
@@ -194,7 +168,7 @@ jobs:
           set -euxo pipefail
           CHUNKAH_LOG_FILE="${RUNNER_TEMP}/chunkah.log"
           CHUNKAH_MANIFEST_FILE="${RUNNER_TEMP}/chunkah-manifest.json"
-          CHUNKED_IMAGE_CONFIG_FILE="${RUNNER_TEMP}/chunkah-image-config.json"
+          CHUNKAH_IMAGE_CONFIG_FILE="${RUNNER_TEMP}/chunkah-image-config.json"
           for component in steam proton fex-rootfs; do
             if ! grep -Eq "creating tar layer .*\"xattr/${component}\"" "${CHUNKAH_LOG_FILE}"; then
               echo "::error::Chunkah did not emit an xattr/${component} component layer"
@@ -215,9 +189,9 @@ jobs:
               echo "::error::Chunkah output retained OSTree manifest annotations"
               exit 1
             }
-          skopeo inspect --config "${CHUNKED_REF}" > "${CHUNKED_IMAGE_CONFIG_FILE}"
+          skopeo inspect --config "${CHUNKED_REF}" > "${CHUNKAH_IMAGE_CONFIG_FILE}"
           jq -e --slurpfile expected "${RUNNER_TEMP}/chunkah-config.json" \
-            '.config == $expected[0]' "${CHUNKED_IMAGE_CONFIG_FILE}" || {
+            '.config == $expected[0]' "${CHUNKAH_IMAGE_CONFIG_FILE}" || {
               echo "::error::Chunkah output did not preserve the prepared runtime config"
               exit 1
             }
@@ -227,7 +201,7 @@ jobs:
               .config.Labels["ostree.bootable"] == "true" and
               (.config.Labels | has("ostree.commit") | not) and
               (.config.Labels | has("ostree.final-diffid") | not)' \
-            "${CHUNKED_IMAGE_CONFIG_FILE}"
+            "${CHUNKAH_IMAGE_CONFIG_FILE}"
           python3 build_files/verify-steam-bootstrap.py --oci "${RUNNER_TEMP}/chunked"
           echo "Steam bootstrap manifest verified in Chunkah output"
           jq '{layers: (.layers | length), compressed_bytes: ([.layers[].size] | add)}' \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,6 +141,12 @@ jobs:
           echo "base_image=${base_image}" >> "${GITHUB_OUTPUT}"
           echo "config=${config}" >> "${GITHUB_OUTPUT}"
 
+      - name: Require native OverlayFS
+        run: |
+          set -euxo pipefail
+          buildah info --storage-opt=overlay.mount_program= |
+            jq -e '.store.GraphStatus["Native Overlay Diff"] == "true"'
+
       - name: Build Image
         id: build_image
         uses: redhat-actions/buildah-build@5d8479758cc72ed82df28daba521d27e20ff8c8a # v3.0.0
@@ -160,7 +166,7 @@ jobs:
             --target=chunkah
             --volume=${{ runner.temp }}:/run/src
             --security-opt=label=disable
-            --no-hostname
+            --storage-opt=overlay.mount_program=
           oci: false
 
       - name: Validate Chunkah output

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,6 +160,7 @@ jobs:
             --target=chunkah
             --volume=${{ runner.temp }}:/run/src
             --security-opt=label=disable
+            --no-hostname
           oci: false
 
       - name: Validate Chunkah output

--- a/Containerfile
+++ b/Containerfile
@@ -37,6 +37,7 @@ FROM ${EXTEST_PKG} AS extest
 FROM ${ARMADA_SPLASH_PKG} AS armada-splash
 FROM ${ARMADA_RGB_PKG} AS armada-rgb
 FROM ${UMTP_RESPONDER_PKG} AS umtp-responder
+FROM ${CHUNKAH_IMAGE} AS chunkah-tools
 
 FROM docker.io/library/node:22-slim AS decky-build
 WORKDIR /build/armada-control
@@ -90,19 +91,33 @@ RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
 
 RUN bootc container lint
 
-FROM ${CHUNKAH_IMAGE} AS chunkah
+# Chunk directly from the live rootfs because cross-stage mounts can omit recent writes.
 ARG CHUNKAH_CONFIG_STR
-RUN --mount=from=armada-rootfs,target=/chunkah,ro \
+RUN --network=none \
+    --mount=type=bind,from=chunkah-tools,source=/,target=/run/chunkah-tools,ro \
+    --mount=type=bind,from=ctx,source=/,target=/ctx \
     /bin/bash -o pipefail -c ' \
         set -e; \
+        [ -n "${CHUNKAH_CONFIG_STR}" ] || { echo "CHUNKAH_CONFIG_STR unset; skipping chunking"; exit 0; }; \
+        if grep -Eq "[[:space:]]/etc/(hosts|resolv\.conf|hostname)[[:space:]]" /proc/self/mounts; then \
+            echo "ERROR: runtime binds shadow /etc; refusing to pack them" >&2; exit 1; \
+        fi; \
+        python3 /ctx/build_files/verify-steam-bootstrap.py \
+            /var/home/armada/.local/share/Steam/package/steam_client_steamdeck_publicbeta_linuxarm64.installed \
+            /var/home/armada/.local/share/Steam; \
         start=${SECONDS}; \
-        chunkah build --verbose --compressed --compression-level 6 \
+        /run/chunkah-tools/usr/bin/chunkah build --verbose --compressed --compression-level 6 \
             --arch arm64 --max-layers 128 --source-date-epoch 0 \
+            --rootfs / \
             --prune /sysroot/ \
+            --prune /proc/ --prune /sys/ --prune /dev/ --prune /run/ --prune /tmp/ --prune /ctx/ \
             --label ostree.commit- --label ostree.final-diffid- \
             --config-str "${CHUNKAH_CONFIG_STR}" \
             --output oci:/run/src/chunked 2>&1 | tee /run/src/chunkah.log; \
         echo "Chunkah completed in $((SECONDS - start)) seconds" \
     '
+
+FROM chunkah-tools AS chunkah
+RUN test -s /run/src/chunked/index.json
 
 FROM armada-rootfs AS armada

--- a/Containerfile
+++ b/Containerfile
@@ -16,6 +16,7 @@ ARG JUPITER_HW_SUPPORT_PKG=ghcr.io/armada-os/armada-packages/jupiter-hw-support@
 ARG ARMADA_SPLASH_PKG=ghcr.io/armada-os/armada-packages/armada-splash@sha256:6b018ab61218ad5b760fc93b27f7f6af4af4fb6301cb1ed4711cd33ded8c0ea0
 ARG ARMADA_RGB_PKG=ghcr.io/armada-os/armada-packages/armada-rgb@sha256:a7b66324d7bf8030e260d5f2fc9074ad9ced7c47852187783f5e3e082d0ebc25
 ARG UMTP_RESPONDER_PKG=ghcr.io/armada-os/armada-packages/umtp-responder@sha256:b0fe59bf87bccdde7273d7ade9f824171a5b4ac5f132b4670b32a73bb1f871b3
+ARG CHUNKAH_IMAGE=quay.io/coreos/chunkah@sha256:ff8b8b466a942ec6000445d4001fc661e2fc5a952ad9ee29b4de9ab09d1d1708
 ARG BASE_IMAGE=quay.io/fedora/fedora-bootc:44
 
 FROM ${FEX_PKG} AS fex
@@ -88,5 +89,20 @@ RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
     /ctx/build_files/build.sh
 
 RUN bootc container lint
+
+FROM ${CHUNKAH_IMAGE} AS chunkah
+ARG CHUNKAH_CONFIG_STR
+RUN --mount=from=armada-rootfs,target=/chunkah,ro \
+    /bin/bash -o pipefail -c ' \
+        set -e; \
+        start=${SECONDS}; \
+        chunkah build --verbose --compressed --compression-level 6 \
+            --arch arm64 --max-layers 128 --source-date-epoch 0 \
+            --prune /sysroot/ \
+            --label ostree.commit- --label ostree.final-diffid- \
+            --config-str "${CHUNKAH_CONFIG_STR}" \
+            --output oci:/run/src/chunked 2>&1 | tee /run/src/chunkah.log; \
+        echo "Chunkah completed in $((SECONDS - start)) seconds" \
+    '
 
 FROM armada-rootfs AS armada

--- a/Containerfile
+++ b/Containerfile
@@ -37,7 +37,6 @@ FROM ${EXTEST_PKG} AS extest
 FROM ${ARMADA_SPLASH_PKG} AS armada-splash
 FROM ${ARMADA_RGB_PKG} AS armada-rgb
 FROM ${UMTP_RESPONDER_PKG} AS umtp-responder
-FROM ${CHUNKAH_IMAGE} AS chunkah-tools
 
 FROM docker.io/library/node:22-slim AS decky-build
 WORKDIR /build/armada-control
@@ -91,33 +90,19 @@ RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
 
 RUN bootc container lint
 
-# Chunk directly from the live rootfs because cross-stage mounts can omit recent writes.
+FROM ${CHUNKAH_IMAGE} AS chunkah
 ARG CHUNKAH_CONFIG_STR
-RUN --network=none \
-    --mount=type=bind,from=chunkah-tools,source=/,target=/run/chunkah-tools,ro \
-    --mount=type=bind,from=ctx,source=/,target=/ctx \
+RUN --mount=from=armada-rootfs,target=/chunkah,ro \
     /bin/bash -o pipefail -c ' \
         set -e; \
-        [ -n "${CHUNKAH_CONFIG_STR}" ] || { echo "CHUNKAH_CONFIG_STR unset; skipping chunking"; exit 0; }; \
-        if grep -Eq "[[:space:]]/etc/(hosts|resolv\.conf|hostname)[[:space:]]" /proc/self/mounts; then \
-            echo "ERROR: runtime binds shadow /etc; refusing to pack them" >&2; exit 1; \
-        fi; \
-        python3 /ctx/build_files/verify-steam-bootstrap.py \
-            /var/home/armada/.local/share/Steam/package/steam_client_steamdeck_publicbeta_linuxarm64.installed \
-            /var/home/armada/.local/share/Steam; \
         start=${SECONDS}; \
-        /run/chunkah-tools/usr/bin/chunkah build --verbose --compressed --compression-level 6 \
+        chunkah build --verbose --compressed --compression-level 6 \
             --arch arm64 --max-layers 128 --source-date-epoch 0 \
-            --rootfs / \
             --prune /sysroot/ \
-            --prune /proc/ --prune /sys/ --prune /dev/ --prune /run/ --prune /tmp/ --prune /ctx/ \
             --label ostree.commit- --label ostree.final-diffid- \
             --config-str "${CHUNKAH_CONFIG_STR}" \
             --output oci:/run/src/chunked 2>&1 | tee /run/src/chunkah.log; \
         echo "Chunkah completed in $((SECONDS - start)) seconds" \
     '
-
-FROM chunkah-tools AS chunkah
-RUN test -s /run/src/chunked/index.json
 
 FROM armada-rootfs AS armada

--- a/Containerfile
+++ b/Containerfile
@@ -16,7 +16,6 @@ ARG JUPITER_HW_SUPPORT_PKG=ghcr.io/armada-os/armada-packages/jupiter-hw-support@
 ARG ARMADA_SPLASH_PKG=ghcr.io/armada-os/armada-packages/armada-splash@sha256:6b018ab61218ad5b760fc93b27f7f6af4af4fb6301cb1ed4711cd33ded8c0ea0
 ARG ARMADA_RGB_PKG=ghcr.io/armada-os/armada-packages/armada-rgb@sha256:a7b66324d7bf8030e260d5f2fc9074ad9ced7c47852187783f5e3e082d0ebc25
 ARG UMTP_RESPONDER_PKG=ghcr.io/armada-os/armada-packages/umtp-responder@sha256:b0fe59bf87bccdde7273d7ade9f824171a5b4ac5f132b4670b32a73bb1f871b3
-ARG CHUNKAH_IMAGE=quay.io/coreos/chunkah@sha256:ff8b8b466a942ec6000445d4001fc661e2fc5a952ad9ee29b4de9ab09d1d1708
 ARG BASE_IMAGE=quay.io/fedora/fedora-bootc:44
 
 FROM ${FEX_PKG} AS fex
@@ -89,20 +88,5 @@ RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
     /ctx/build_files/build.sh
 
 RUN bootc container lint
-
-FROM ${CHUNKAH_IMAGE} AS chunkah
-ARG CHUNKAH_CONFIG_STR
-RUN --mount=from=armada-rootfs,target=/chunkah,ro \
-    /bin/bash -o pipefail -c ' \
-        set -e; \
-        start=${SECONDS}; \
-        chunkah build --verbose --compressed --compression-level 6 \
-            --arch arm64 --max-layers 128 --source-date-epoch 0 \
-            --prune /sysroot/ \
-            --label ostree.commit- --label ostree.final-diffid- \
-            --config-str "${CHUNKAH_CONFIG_STR}" \
-            --output oci:/run/src/chunked 2>&1 | tee /run/src/chunkah.log; \
-        echo "Chunkah completed in $((SECONDS - start)) seconds" \
-    '
 
 FROM armada-rootfs AS armada

--- a/build_files/generate-steam-bootstrap.sh
+++ b/build_files/generate-steam-bootstrap.sh
@@ -127,6 +127,53 @@ verify_installed_manifest() {
         "${installed_manifest}" "${STEAM}"
 }
 
+steam_processes() {
+    local pid state
+    # The full bootstrap path avoids matching unrelated Steam-named processes.
+    while read -r pid; do
+        state=$(ps -o stat= -p "${pid}" 2>/dev/null) || continue
+        state=${state//[[:space:]]/}
+        [[ "${state}" == Z* ]] || echo "${pid}"
+    done < <(pgrep -f "${STEAM_BOOTSTRAP_HOME}" || true)
+}
+
+show_steam_processes() {
+    local pid_list
+    printf -v pid_list '%s,' "$@"
+    ps -o pid=,ppid=,stat=,args= -p "${pid_list%,}" >&2 || true
+}
+
+quiesce_steam_processes() {
+    local -a steam_pids
+    mapfile -t steam_pids < <(steam_processes)
+    if ((${#steam_pids[@]} == 0)); then
+        echo "No Steam bootstrap helpers remained after updater exit"
+        return
+    fi
+
+    echo "Stopping Steam bootstrap helpers after updater exit:" >&2
+    show_steam_processes "${steam_pids[@]}"
+    kill "${steam_pids[@]}" 2>/dev/null || true
+    for _ in {1..50}; do
+        mapfile -t steam_pids < <(steam_processes)
+        ((${#steam_pids[@]} == 0)) && return 0
+        sleep 0.1
+    done
+
+    echo "Steam bootstrap helpers survived SIGTERM; sending SIGKILL:" >&2
+    show_steam_processes "${steam_pids[@]}"
+    kill -KILL "${steam_pids[@]}" 2>/dev/null || true
+    for _ in {1..20}; do
+        mapfile -t steam_pids < <(steam_processes)
+        ((${#steam_pids[@]} == 0)) && return 0
+        sleep 0.1
+    done
+
+    echo "ERROR: Steam bootstrap helpers survived SIGKILL" >&2
+    show_steam_processes "${steam_pids[@]}"
+    return 1
+}
+
 steam_verified=false
 bootstrap_deadline=$((SECONDS + STEAM_BOOTSTRAP_TIMEOUT))
 for attempt in {1..3}; do
@@ -143,6 +190,7 @@ for attempt in {1..3}; do
         2>/tmp/armada-steam-bootstrap.stderr
     steam_rc=$?
     set -e
+    quiesce_steam_processes
 
     if [[ "${steam_rc}" == "124" ]]; then
         echo "ERROR: Steam bootstrap exhausted its ${STEAM_BOOTSTRAP_TIMEOUT}-second timeout" >&2

--- a/build_files/generate-steam-bootstrap.sh
+++ b/build_files/generate-steam-bootstrap.sh
@@ -127,53 +127,6 @@ verify_installed_manifest() {
         "${installed_manifest}" "${STEAM}"
 }
 
-steam_processes() {
-    local pid state
-    # The full bootstrap path avoids matching unrelated Steam-named processes.
-    while read -r pid; do
-        state=$(ps -o stat= -p "${pid}" 2>/dev/null) || continue
-        state=${state//[[:space:]]/}
-        [[ "${state}" == Z* ]] || echo "${pid}"
-    done < <(pgrep -f "${STEAM_BOOTSTRAP_HOME}" || true)
-}
-
-show_steam_processes() {
-    local pid_list
-    printf -v pid_list '%s,' "$@"
-    ps -o pid=,ppid=,stat=,args= -p "${pid_list%,}" >&2 || true
-}
-
-quiesce_steam_processes() {
-    local -a steam_pids
-    mapfile -t steam_pids < <(steam_processes)
-    if ((${#steam_pids[@]} == 0)); then
-        echo "No Steam bootstrap helpers remained after updater exit"
-        return
-    fi
-
-    echo "Stopping Steam bootstrap helpers after updater exit:" >&2
-    show_steam_processes "${steam_pids[@]}"
-    kill "${steam_pids[@]}" 2>/dev/null || true
-    for _ in {1..50}; do
-        mapfile -t steam_pids < <(steam_processes)
-        ((${#steam_pids[@]} == 0)) && return 0
-        sleep 0.1
-    done
-
-    echo "Steam bootstrap helpers survived SIGTERM; sending SIGKILL:" >&2
-    show_steam_processes "${steam_pids[@]}"
-    kill -KILL "${steam_pids[@]}" 2>/dev/null || true
-    for _ in {1..20}; do
-        mapfile -t steam_pids < <(steam_processes)
-        ((${#steam_pids[@]} == 0)) && return 0
-        sleep 0.1
-    done
-
-    echo "ERROR: Steam bootstrap helpers survived SIGKILL" >&2
-    show_steam_processes "${steam_pids[@]}"
-    return 1
-}
-
 steam_verified=false
 bootstrap_deadline=$((SECONDS + STEAM_BOOTSTRAP_TIMEOUT))
 for attempt in {1..3}; do
@@ -190,7 +143,6 @@ for attempt in {1..3}; do
         2>/tmp/armada-steam-bootstrap.stderr
     steam_rc=$?
     set -e
-    quiesce_steam_processes
 
     if [[ "${steam_rc}" == "124" ]]; then
         echo "ERROR: Steam bootstrap exhausted its ${STEAM_BOOTSTRAP_TIMEOUT}-second timeout" >&2

--- a/build_files/generate-steam-bootstrap.sh
+++ b/build_files/generate-steam-bootstrap.sh
@@ -19,6 +19,7 @@ STEAM_ARM_CDN="https://client-update.steamstatic.com"
 STEAM_ARM_MANIFEST_NAME="steam_client_${STEAM_ARM_CHANNEL}_linuxarm64"
 STEAM_ARM_MANIFEST_URL="${STEAM_ARM_CDN}/${STEAM_ARM_MANIFEST_NAME}"
 STEAM_BOOTSTRAP_TIMEOUT="${STEAM_BOOTSTRAP_TIMEOUT:-900}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 rm -rf "${STEAM_BOOTSTRAP_HOME}"
 mkdir -p "${STEAM}/package" "${DOT_STEAM}"
@@ -122,84 +123,8 @@ export LD_LIBRARY_PATH="${STEAM}/steamrtarm64:${STEAM}/lib/aarch64-linux-gnu"
 installed_manifest="${STEAM}/package/${STEAM_ARM_MANIFEST_NAME}.installed"
 
 verify_installed_manifest() {
-    python3 - "${installed_manifest}" "${STEAM}" <<'PY'
-import pathlib
-import re
-import stat
-import sys
-
-manifest = pathlib.Path(sys.argv[1])
-steam = pathlib.Path(sys.argv[2])
-missing = []
-mismatched = []
-not_directories = []
-not_symlinks = []
-file_entries = 0
-directory_entries = 0
-symlink_entries = 0
-
-for line in manifest.read_text(errors="ignore").splitlines():
-    if re.fullmatch(r"(?:OSVER=-?\d+|VERSION=\d+|SHA1=[0-9A-Fa-f]{40})", line):
-        continue
-    match = re.fullmatch(r"(.+),(-?\d+);\d+;\d+", line)
-    if not match:
-        continue
-    relative = pathlib.Path(match.group(1))
-    path = steam / relative
-    expected = int(match.group(2))
-    if expected == -1:
-        directory_entries += 1
-        try:
-            path_stat = path.lstat()
-        except OSError as error:
-            missing.append(f"{relative}: {error.strerror}")
-            continue
-        if not stat.S_ISDIR(path_stat.st_mode):
-            not_directories.append(str(relative))
-        continue
-    if expected == -2:
-        symlink_entries += 1
-        try:
-            path_stat = path.lstat()
-        except OSError as error:
-            missing.append(f"{relative}: {error.strerror}")
-            continue
-        if not stat.S_ISLNK(path_stat.st_mode):
-            not_symlinks.append(str(relative))
-        continue
-    if expected < 0:
-        continue
-    file_entries += 1
-    try:
-        path_stat = path.stat()
-    except OSError as error:
-        missing.append(f"{relative}: {error.strerror}")
-        continue
-    if path_stat.st_size != expected:
-        mismatched.append(
-            f"{relative}: expected {expected}, got {path_stat.st_size}"
-        )
-
-if not file_entries + directory_entries + symlink_entries:
-    raise SystemExit("Steam manifest contains no entries")
-if missing or mismatched or not_directories or not_symlinks:
-    for item in missing[:20]:
-        print(f"missing: {item}", file=sys.stderr)
-    for item in mismatched[:20]:
-        print(f"size mismatch: {item}", file=sys.stderr)
-    for item in not_directories[:20]:
-        print(f"not a directory: {item}", file=sys.stderr)
-    for item in not_symlinks[:20]:
-        print(f"not a symlink: {item}", file=sys.stderr)
-    print(
-        f"Steam manifest check failed: {len(missing)} missing, "
-        f"{len(mismatched)} size mismatches, "
-        f"{len(not_directories)} invalid directories, "
-        f"{len(not_symlinks)} invalid symlinks",
-        file=sys.stderr,
-    )
-    raise SystemExit(1)
-PY
+    python3 "${script_dir}/verify-steam-bootstrap.py" \
+        "${installed_manifest}" "${STEAM}"
 }
 
 steam_verified=false

--- a/build_files/verify-steam-bootstrap.py
+++ b/build_files/verify-steam-bootstrap.py
@@ -89,7 +89,7 @@ def find_steam_layer(layout):
         raise SystemExit("OCI index does not reference an image manifest")
     manifest_member_name = f"{STEAM_PREFIX}/package/{MANIFEST_NAME}"
 
-    # Chunkah packs the xattr-defined Steam component atomically into one layer.
+    # The Steam component xattr keeps its manifest and content in one layer.
     for layer in image_manifest["layers"]:
         members = {}
         manifest_contents = None

--- a/build_files/verify-steam-bootstrap.py
+++ b/build_files/verify-steam-bootstrap.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import pathlib
+import re
+import stat
+import sys
+import tarfile
+
+
+MANIFEST_NAME = "steam_client_steamdeck_publicbeta_linuxarm64.installed"
+STEAM_PREFIX = "var/home/armada/.local/share/Steam"
+
+
+def parse_manifest(contents):
+    entries = []
+    for line in contents.splitlines():
+        if re.fullmatch(r"(?:OSVER=-?\d+|VERSION=\d+|SHA1=[0-9A-Fa-f]{40})", line):
+            continue
+        match = re.fullmatch(r"(.+),(-?\d+);\d+;\d+", line)
+        if match:
+            entries.append((match.group(1), int(match.group(2))))
+    if not entries:
+        raise SystemExit("Steam manifest contains no entries")
+    return entries
+
+
+def report_failures(missing, mismatched, not_directories, not_symlinks):
+    if not (missing or mismatched or not_directories or not_symlinks):
+        return
+    for item in missing[:20]:
+        print(f"missing: {item}", file=sys.stderr)
+    for item in mismatched[:20]:
+        print(f"size mismatch: {item}", file=sys.stderr)
+    for item in not_directories[:20]:
+        print(f"not a directory: {item}", file=sys.stderr)
+    for item in not_symlinks[:20]:
+        print(f"not a symlink: {item}", file=sys.stderr)
+    print(
+        f"Steam manifest check failed: {len(missing)} missing, "
+        f"{len(mismatched)} size mismatches, "
+        f"{len(not_directories)} invalid directories, "
+        f"{len(not_symlinks)} invalid symlinks",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+
+
+def verify_filesystem(manifest, steam):
+    missing = []
+    mismatched = []
+    not_directories = []
+    not_symlinks = []
+    entries = parse_manifest(manifest.read_text(errors="ignore"))
+
+    for relative_name, expected in entries:
+        if expected < -2:
+            continue
+        relative = pathlib.Path(relative_name)
+        path = steam / relative
+        try:
+            path_stat = path.lstat() if expected < 0 else path.stat()
+        except OSError as error:
+            missing.append(f"{relative}: {error.strerror}")
+            continue
+        if expected == -1 and not stat.S_ISDIR(path_stat.st_mode):
+            not_directories.append(str(relative))
+        elif expected == -2 and not stat.S_ISLNK(path_stat.st_mode):
+            not_symlinks.append(str(relative))
+        elif expected >= 0 and path_stat.st_size != expected:
+            mismatched.append(
+                f"{relative}: expected {expected}, got {path_stat.st_size}"
+            )
+
+    report_failures(missing, mismatched, not_directories, not_symlinks)
+
+
+def blob_path(layout, digest):
+    algorithm, value = digest.split(":", 1)
+    return layout / "blobs" / algorithm / value
+
+
+def find_steam_layer(layout):
+    index = json.loads((layout / "index.json").read_text())
+    manifest_path = blob_path(layout, index["manifests"][0]["digest"])
+    image_manifest = json.loads(manifest_path.read_text())
+    if "layers" not in image_manifest:
+        raise SystemExit("OCI index does not reference an image manifest")
+    manifest_member_name = f"{STEAM_PREFIX}/package/{MANIFEST_NAME}"
+
+    # The Steam component xattr keeps its manifest and content in one layer.
+    for layer in image_manifest["layers"]:
+        members = {}
+        manifest_contents = None
+        layer_path = blob_path(layout, layer["digest"])
+        with tarfile.open(layer_path, "r:*") as archive:
+            for member in archive:
+                name = member.name.removeprefix("./").lstrip("/")
+                if name == manifest_member_name:
+                    manifest_file = archive.extractfile(member)
+                    if manifest_file is None:
+                        raise SystemExit("Steam manifest is not a regular file")
+                    manifest_contents = manifest_file.read().decode(errors="ignore")
+                if name == STEAM_PREFIX or name.startswith(f"{STEAM_PREFIX}/"):
+                    relative = name.removeprefix(STEAM_PREFIX).lstrip("/").rstrip("/")
+                    members[relative] = member
+        if manifest_contents is not None:
+            return manifest_contents, members
+
+    raise SystemExit("Steam manifest not found in Chunkah output")
+
+
+def verify_oci(layout):
+    manifest_contents, members = find_steam_layer(layout)
+    missing = []
+    mismatched = []
+    not_directories = []
+    not_symlinks = []
+
+    for relative, expected in parse_manifest(manifest_contents):
+        if expected < -2:
+            continue
+        member = members.get(relative.rstrip("/"))
+        if member is None:
+            missing.append(relative)
+        elif expected == -1 and not member.isdir():
+            not_directories.append(relative)
+        elif expected == -2 and not member.issym():
+            not_symlinks.append(relative)
+        elif expected >= 0 and (not member.isfile() or member.size != expected):
+            actual = member.size if member.isfile() else "non-file"
+            mismatched.append(f"{relative}: expected {expected}, got {actual}")
+
+    report_failures(missing, mismatched, not_directories, not_symlinks)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--oci", type=pathlib.Path)
+    parser.add_argument("manifest", nargs="?", type=pathlib.Path)
+    parser.add_argument("steam", nargs="?", type=pathlib.Path)
+    args = parser.parse_args()
+
+    if args.oci:
+        if args.manifest or args.steam:
+            parser.error("--oci cannot be combined with filesystem paths")
+        verify_oci(args.oci)
+    elif args.manifest and args.steam:
+        verify_filesystem(args.manifest, args.steam)
+    else:
+        parser.error("provide --oci or MANIFEST STEAM")
+
+
+if __name__ == "__main__":
+    main()

--- a/build_files/verify-steam-bootstrap.py
+++ b/build_files/verify-steam-bootstrap.py
@@ -89,7 +89,7 @@ def find_steam_layer(layout):
         raise SystemExit("OCI index does not reference an image manifest")
     manifest_member_name = f"{STEAM_PREFIX}/package/{MANIFEST_NAME}"
 
-    # The Steam component xattr keeps its manifest and content in one layer.
+    # Chunkah packs the xattr-defined Steam component atomically into one layer.
     for layer in image_manifest["layers"]:
         members = {}
         manifest_contents = None


### PR DESCRIPTION
- Disable the Buildah action’s fuse-overlayfs mount program so rootless builds use the kernel’s native OverlayFS implementation.
- This prevents Chunkah from omitting Steam files while scanning the rootfs. Require native overlay support before building and verify the Steam manifest in the final OCI layout before publication.
