### PR TITLE
fix(installer): rename internal ESP from ROCKNIX to ARMADA

### DIFF
--- a/build_files/40-vendor-system-files.sh
+++ b/build_files/40-vendor-system-files.sh
@@ -88,6 +88,7 @@ systemctl enable armada-control.service
 systemctl enable armada-steamos-manager.service
 systemctl --global enable armada-steamos-manager.service
 systemctl enable armada-bootimg-sync.service
+systemctl enable armada-esp-rename.service
 systemctl enable armada-flatpak-setup.service
 systemctl enable armada-waydroid-input.path
 systemctl enable armada-splash-stall.service

--- a/system_files/usr/lib/systemd/system/armada-esp-rename.service
+++ b/system_files/usr/lib/systemd/system/armada-esp-rename.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Rename the legacy internal Armada ESP before it is mounted
+ConditionPathExists=/run/ostree-booted
+DefaultDependencies=no
+Before=boot-efi.mount local-fs.target
+
+[Service]
+Type=oneshot
+TimeoutStartSec=30
+ExecStart=-/usr/libexec/armada/armada-esp-rename
+
+[Install]
+WantedBy=local-fs.target

--- a/system_files/usr/lib/systemd/system/systemd-fsck@.service.d/10-armada-esp-rename.conf
+++ b/system_files/usr/lib/systemd/system/systemd-fsck@.service.d/10-armada-esp-rename.conf
@@ -1,0 +1,2 @@
+[Unit]
+After=armada-esp-rename.service

--- a/system_files/usr/libexec/armada/armada-esp-rename
+++ b/system_files/usr/libexec/armada/armada-esp-rename
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Runs before the ESP mount because fatlabel cannot safely modify a mounted filesystem.
+set -euo pipefail
+
+source "${ARMADA_STORAGE_LIB:-/usr/lib/armada/storage-lib}"
+
+OLD_LABEL="ROCKNIX"
+NEW_LABEL="ARMADA"
+
+# Root-disk scoping and sibling labels exclude SD cards and unrelated GPTs.
+parent=$(armada_root_device 2>/dev/null || true)
+parent=$(readlink -f -- "$parent" 2>/dev/null || true)
+[[ -b $parent ]] || { echo "armada-esp-rename: cannot resolve the root disk; skipping" >&2; exit 0; }
+
+layout=$(lsblk --json --paths --output NAME,PTTYPE,PARTLABEL,PARTN "$parent" 2>/dev/null) \
+    || { echo "armada-esp-rename: cannot inspect $parent; skipping" >&2; exit 0; }
+candidate=$(jq -r --arg old "$OLD_LABEL" --arg new "$NEW_LABEL" '
+    .blockdevices[0]? as $disk
+    | ($disk.children // []) as $parts
+    | select($disk.pttype == "gpt")
+    | select(any($parts[]; .partlabel == "ARMADA_BOOT"))
+    | select(any($parts[]; .partlabel == "ARMADA_ROOT"))
+    | [$parts[] | select(.partlabel == $old or .partlabel == $new)]
+    | select(length == 1)
+    | .[0]
+    | [.name, .partlabel, ((.partn // "") | tostring)]
+    | @tsv
+' <<<"$layout" 2>/dev/null || true)
+[[ -n $candidate ]] || exit 0
+IFS=$'\t' read -r esp partlabel partnum <<<"$candidate"
+esp=$(readlink -f -- "$esp" 2>/dev/null || true)
+[[ $partnum =~ ^[0-9]+$ ]] \
+    || { echo "armada-esp-rename: candidate has no partition number; skipping" >&2; exit 0; }
+[[ -b $esp ]] || { echo "armada-esp-rename: candidate is not a block device; skipping" >&2; exit 0; }
+
+fstype=$(blkid -p -s TYPE -o value "$esp" 2>/dev/null || true)
+fslabel=$(blkid -p -s LABEL -o value "$esp" 2>/dev/null || true)
+[[ $fstype == vfat ]] || { echo "armada-esp-rename: $esp is not vfat; skipping" >&2; exit 0; }
+[[ $fslabel == "$OLD_LABEL" || $fslabel == "$NEW_LABEL" ]] \
+    || { echo "armada-esp-rename: $esp has unexpected filesystem label; skipping" >&2; exit 0; }
+[[ $partlabel == "$NEW_LABEL" && $fslabel == "$NEW_LABEL" ]] && exit 0
+
+# Keep manual starts safe; unit ordering normally leaves the ESP unmounted.
+if findmnt -rn --source "$esp" >/dev/null 2>&1; then
+    echo "armada-esp-rename: $esp is mounted; skipping" >&2
+    exit 0
+fi
+
+if [[ $fslabel == "$OLD_LABEL" ]]; then
+    fatlabel "$esp" "$NEW_LABEL"
+fi
+if [[ $partlabel == "$OLD_LABEL" ]]; then
+    sgdisk --change-name="${partnum}:${NEW_LABEL}" "$parent" >/dev/null
+fi
+sync
+
+# Labels are durable retry markers for any partial failure.
+echo "armada-esp-rename: internal ESP filesystem and GPT labels are now $NEW_LABEL"

--- a/system_files/usr/libexec/armada/armada-installer
+++ b/system_files/usr/libexec/armada/armada-installer
@@ -6,6 +6,7 @@ source /usr/lib/armada/update-lib
 
 DEVICE="${ARMADA_INTERNAL_DEVICE:-$(armada_internal_device || true)}"
 ESP_GUID="c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
+ESP_PARTLABEL="ARMADA"
 ESP_MIB=512
 BOOT_MIB=1024
 # Floor, not target: enough for two bootc deployments plus OTA staging headroom.
@@ -28,18 +29,18 @@ cleanup() {
     [[ -n "$INHIBIT_PID" ]] && kill "$INHIBIT_PID" 2>/dev/null || true
     [[ -n "$TARGET" ]] && { umount -R "$TARGET" 2>/dev/null || true; rmdir "$TARGET" 2>/dev/null || true; }
     # A half-done operation is recoverable from the SD card (re-run the installer);
-    # PC recovery is the last resort for a device that won't boot the SD at all. On
-    # a replace, Android was never touched, so it's safe to say so.
+    # UNINSTALL CFW in ABL is the fallback. On a replace, Android was never touched,
+    # so it's safe to say so.
     if (( rc != 0 && destructive == 1 )); then
         case $OPERATION in
             reset)
-                echo "ERROR: reset did not finish after internal storage was modified. Re-run the installer from the SD card to finish. Only if the device won't boot the SD: recover with a PC (fastboot erase ROCKNIX)." >&2
+                echo "ERROR: reset did not finish after internal storage was modified. To finish the removal, select UNINSTALL CFW in ABL." >&2
                 ;;
             replace)
-                echo "ERROR: install did not finish after internal storage was modified, but Android is unchanged. Do NOT boot internal storage; re-run the installer from the SD card to finish. Only if the device won't boot the SD: recover with a PC (fastboot erase ROCKNIX)." >&2
+                echo "ERROR: install did not finish after internal storage was modified, but Android is unchanged. Do NOT boot internal storage; re-run the installer from the SD card to finish, or select UNINSTALL CFW in ABL to abandon the installation." >&2
                 ;;
             *)
-                echo "ERROR: install did not finish after internal storage was modified. Do NOT boot internal storage. Re-run the installer from the SD card; only if the device won't boot the SD, recover with a PC (fastboot erase ROCKNIX, then reflash the SD card)." >&2
+                echo "ERROR: install did not finish after internal storage was modified. Do NOT boot internal storage. Re-run the installer from the SD card to finish, or select UNINSTALL CFW in ABL to abandon the installation." >&2
                 ;;
         esac
     fi
@@ -160,6 +161,7 @@ partition_names() {
 detect_mode() {
     local name
     has_rocknix=0
+    has_armada=0
     has_armada_boot=0
     has_armada_root=0
     has_storage=0
@@ -167,13 +169,14 @@ detect_mode() {
     while IFS= read -r name; do
         case "$name" in
             ROCKNIX) has_rocknix=1 ;;
+            ARMADA) has_armada=1 ;;
             ARMADA_BOOT) has_armada_boot=1 ;;
             ARMADA_ROOT) has_armada_root=1 ;;
             STORAGE) has_storage=1 ;;
         esac
     done < <(partition_names)
 
-    if (( has_rocknix || has_armada_boot || has_armada_root || has_storage )); then
+    if (( has_rocknix || has_armada || has_armada_boot || has_armada_root || has_storage )); then
         mode=occupied
     else
         mode=fresh
@@ -222,7 +225,7 @@ collect_our_tail() {
     while IFS=$'\t' read -r num start_b end_b name; do
         (( num == UD_NUM )) && continue
         case "$name" in
-            ROCKNIX|ARMADA_BOOT|ARMADA_ROOT|STORAGE)
+            ROCKNIX|ARMADA|ARMADA_BOOT|ARMADA_ROOT|STORAGE)
                 OUR_NUMS+=("$num")
                 OUR_LABELS+=("$name")
                 LINUX_BYTES=$((LINUX_BYTES + end_b - start_b))
@@ -274,7 +277,7 @@ choose_userdata_size() {
     done
 }
 
-# Fills [esp_start_mib .. region_end_mib] with ROCKNIX/ARMADA_BOOT/ARMADA_ROOT and
+# Fills [esp_start_mib .. region_end_mib] with ARMADA/ARMADA_BOOT/ARMADA_ROOT and
 # resolves them by label. userdata is the last existing partition either way (fresh
 # recreates it, replace leaves it), so the three claim slots UD_NUM+1..+3.
 create_linux_partitions() {
@@ -289,7 +292,7 @@ create_linux_partitions() {
     root_num=$((UD_NUM + 3))
 
     parted -a optimal -s "$DEVICE" mkpart primary fat32 "${esp_start_mib}MiB" "${esp_end_mib}MiB"
-    parted -s "$DEVICE" name "$esp_num" ROCKNIX
+    parted -s "$DEVICE" name "$esp_num" "$ESP_PARTLABEL"
     parted -s "$DEVICE" set "$esp_num" boot on
     sgdisk --typecode="${esp_num}:${ESP_GUID}" "$DEVICE" >/dev/null
 
@@ -306,7 +309,7 @@ create_linux_partitions() {
     udevadm settle
 
     # Resolve by the labels just set, not by assumed device-node numbers.
-    ESP_PART=$(resolve_partlabel ROCKNIX)
+    ESP_PART=$(resolve_partlabel "$ESP_PARTLABEL")
     BOOT_PART=$(resolve_partlabel ARMADA_BOOT)
     ROOT_PART=$(resolve_partlabel ARMADA_ROOT)
     for part in "$ESP_PART" "$BOOT_PART" "$ROOT_PART"; do
@@ -359,7 +362,7 @@ install_replace() {
         echo "       Use 'armada-installer reset' to return the disk to Android, then install fresh." >&2
         exit 1
     fi
-    if (( has_armada_boot || has_armada_root )); then installed="Armada"; else installed="ROCKNIX"; fi
+    if (( has_armada || has_armada_boot || has_armada_root )); then installed="Armada"; else installed="ROCKNIX"; fi
 
     cat <<EOF
 
@@ -539,7 +542,7 @@ deploy_to_internal() {
     destructive=1
     # The working SD ESP (BIB-made) is FAT16, and the ABL reads FAT16, not FAT32.
     # -S 4096 = device 4 KiB sectors; -s 4 keeps the 512 MiB ESP in FAT16 cluster range.
-    mkfs.vfat -F 16 -S 4096 -s 4 -n ROCKNIX "$ESP_PART" >/dev/null
+    mkfs.vfat -F 16 -S 4096 -s 4 -n "$ESP_PARTLABEL" "$ESP_PART" >/dev/null
     mkfs.ext4 -F -L boot "$BOOT_PART" >/dev/null
     ROOT_UUID=$(blkid -s UUID -o value "$ROOT_PART")
     BOOT_UUID=$(blkid -s UUID -o value "$BOOT_PART")
@@ -582,7 +585,7 @@ cmd_detect() {
         find_userdata
         collect_our_tail
         local installed
-        if (( has_armada_boot || has_armada_root )); then
+        if (( has_armada || has_armada_boot || has_armada_root )); then
             installed=armada
         elif (( has_rocknix || has_storage )); then
             installed=rocknix
@@ -651,7 +654,7 @@ No internal Armada install was found.
 Current Android userdata: ${UD_ORIG_GIB} GiB (${UD_START_MIB}MiB .. ${UD_END_MIB}MiB)
 
 Fresh install will shrink Android userdata, wipe Android user data, create
-ROCKNIX/ARMADA_BOOT/ARMADA_ROOT, and install the running Armada image.
+ARMADA/ARMADA_BOOT/ARMADA_ROOT, and install the running Armada image.
 
 After install, internal storage boots before SD. To remove it later and give
 the space back to Android, run: armada-installer reset
@@ -705,7 +708,7 @@ cmd_reset() {
     local new_ud_end_mib new_ud_gib installed n p
     new_ud_end_mib=$(( OUR_MAX_END / 1048576 ))
     new_ud_gib=$(( (new_ud_end_mib - UD_START_MIB) / 1024 ))
-    if (( has_armada_boot || has_armada_root )); then installed="Armada"; else installed="ROCKNIX"; fi
+    if (( has_armada || has_armada_boot || has_armada_root )); then installed="Armada"; else installed="ROCKNIX"; fi
 
     cat <<EOF
 
@@ -795,7 +798,7 @@ gui_install_flow() {
 
     zenity --question --title="$GUI_TITLE" --icon="$GUI_ICON" --width=480 --no-wrap \
         --ok-label="Continue" --cancel-label="Cancel" \
-        --text="<b>Install Armada alongside Android?</b>\n\nThis <b>factory-resets Android</b>: you lose installed Android apps and data\n(the Android system itself is kept). Your SD card is not touched.\n\nRecovery from a failed install needs a PC." \
+        --text="<b>Install Armada alongside Android?</b>\n\nThis <b>factory-resets Android</b>: you lose installed Android apps and data\n(the Android system itself is kept). Your SD card is not touched." \
         || exit 0
 
     # Default Android to a usable size when there's room, else the floor
@@ -809,11 +812,11 @@ gui_install_flow() {
 
     zenity --question --title="$GUI_TITLE" --icon="$GUI_ICON" --width=480 --no-wrap \
         --ok-label="Install" --cancel-label="Cancel" \
-        --text="<b>Ready to install</b>\n\nAndroid:  <b>${ud} GB</b>\nArmada:  <b>$((acur - ud)) GB</b>\n\nResizing Android <b>factory-resets it</b>: you lose installed apps and data (the Android system is kept).\n\nThis <b>can't be undone</b> without a PC." \
+        --text="<b>Ready to install</b>\n\nAndroid:  <b>${ud} GB</b>\nArmada:  <b>$((acur - ud)) GB</b>\n\nResizing Android <b>factory-resets it</b>: you lose installed apps and data (the Android system is kept)." \
         || exit 0
 
     gui_run "Installing Armada, do not power off…" install --assume-yes --userdata-gib "$ud" \
-        || gui_die "Install failed (details in ${GUI_LOG}).\n\nIf internal storage was modified, recover with a PC:\n  fastboot erase ROCKNIX"
+        || gui_die "Install failed (details in ${GUI_LOG}).\n\nIf internal storage was modified, select UNINSTALL CFW in ABL to abandon the installation."
     gui_offer_poweroff "<b>Install complete.</b>\n\nPower off, remove the SD card, then power on."
 }
 
@@ -825,7 +828,7 @@ gui_manage_flow() {
     case "$installed" in
         armada) name="Armada";  primary="Reinstall Armada" ;;
         rocknix) name="ROCKNIX"; primary="Switch to Armada" ;;
-        *) gui_die "Internal storage has an unrecognized Linux layout.\n\nThis tool only manages installs it created. Recover from a PC." ;;
+        *) gui_die "Internal storage has an unrecognized Linux layout.\n\nThis tool only manages installs it created. To remove it, select UNINSTALL CFW in ABL." ;;
     esac
     remove="Remove & Restore Android"
     local name_e remove_e primary_e
@@ -839,7 +842,7 @@ gui_manage_flow() {
 
     if (( rc == 0 )); then
         gui_run "Installing Armada, do not power off…" install --assume-yes \
-            || gui_die "Install failed (details in ${GUI_LOG}).\n\nIf internal storage was modified, recover with a PC:\n  fastboot erase ROCKNIX"
+            || gui_die "Install failed (details in ${GUI_LOG}).\n\nIf internal storage was modified, select UNINSTALL CFW in ABL to abandon the installation."
         gui_offer_poweroff "<b>Armada installed.</b> Your Android is unchanged.\n\nPower off, remove the SD card, then power on."
     elif [[ "$out" == "$remove" ]]; then
         zenity --question --title="$GUI_TITLE" --icon="$GUI_ICON" --width=500 --no-wrap \
@@ -847,7 +850,7 @@ gui_manage_flow() {
             --text="<b>Remove ${name_e} and give all storage back to Android?</b>\n\nThis ERASES ${name_e} and factory-resets Android. <b>It can't be undone.</b>" \
             || exit 0
         gui_run "Removing ${name}, do not power off…" reset --assume-yes \
-            || gui_die "Remove failed (details in ${GUI_LOG})."
+            || gui_die "Remove failed (details in ${GUI_LOG}).\n\nTo finish removing ${name_e}, select UNINSTALL CFW in ABL."
         gui_offer_poweroff "<b>${name_e} removed.</b> Android has the full internal disk again.\n\nPower off and remove the SD card to boot Android, or relaunch to install Armada."
     fi
 }

--- a/tests/esp-rename-test.sh
+++ b/tests/esp-rename-test.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+RENAME="$ROOT/system_files/usr/libexec/armada/armada-esp-rename"
+UNIT="$ROOT/system_files/usr/lib/systemd/system/armada-esp-rename.service"
+FSCK_DROPIN="$ROOT/system_files/usr/lib/systemd/system/systemd-fsck@.service.d/10-armada-esp-rename.conf"
+INSTALLER="$ROOT/system_files/usr/libexec/armada/armada-installer"
+VENDOR_BUILD="$ROOT/build_files/40-vendor-system-files.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+assert_eq() {
+    [[ "$2" == "$3" ]] || fail "$1: expected ${3@Q}, got ${2@Q}"
+}
+
+STATE="$WORK/state"
+BIN="$WORK/bin"
+mkdir -p "$STATE" "$BIN"
+export STATE
+
+# Replace only block-device guards so the shipped logic runs against fakes.
+sed -e 's/\[\[ -b \$parent \]\]/true/' \
+    -e 's/\[\[ -b \$esp \]\]/true/' \
+    "$RENAME" > "$WORK/rename.sh"
+
+cat > "$WORK/storage-lib" <<'EOF'
+armada_root_device() { echo /dev/fakedisk; }
+EOF
+cat > "$BIN/readlink" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "${@: -1}"
+EOF
+cat > "$BIN/lsblk" <<'EOF'
+#!/usr/bin/env bash
+root=OTHER_ROOT
+[[ $(cat "$STATE/has_root") == 1 ]] && root=ARMADA_ROOT
+extra=
+[[ $(cat "$STATE/duplicate") == 0 ]] || extra=',{"name":"/dev/fake4","partlabel":"ARMADA","partn":4}'
+printf '{"blockdevices":[{"name":"/dev/fakedisk","pttype":"%s","children":[{"name":"/dev/fake1","partlabel":"%s","partn":1},{"name":"/dev/fake2","partlabel":"ARMADA_BOOT","partn":2},{"name":"/dev/fake3","partlabel":"%s","partn":3}%s]}]}\n' \
+    "$(cat "$STATE/table")" "$(cat "$STATE/partlabel")" "$root" "$extra"
+EOF
+cat > "$BIN/blkid" <<'EOF'
+#!/usr/bin/env bash
+if [[ " $* " == *" -s TYPE "* ]]; then
+    cat "$STATE/fstype"
+else
+    cat "$STATE/fslabel"
+fi
+EOF
+cat > "$BIN/findmnt" <<'EOF'
+#!/usr/bin/env bash
+[[ "$*" == "-rn --source /dev/fake1" ]] || exit 0
+[[ $(cat "$STATE/mounted") == 1 ]]
+EOF
+cat > "$BIN/fatlabel" <<'EOF'
+#!/usr/bin/env bash
+[[ ! -e "$STATE/fail_fatlabel" ]] || exit 1
+printf 'fatlabel:%s\n' "$2" >> "$STATE/log"
+printf '%s\n' "$2" > "$STATE/fslabel"
+EOF
+cat > "$BIN/sgdisk" <<'EOF'
+#!/usr/bin/env bash
+[[ ! -e "$STATE/fail_sgdisk" ]] || exit 1
+change=${1#--change-name=}
+printf 'sgdisk:%s:%s\n' "$change" "$2" >> "$STATE/log"
+printf '%s\n' "${change#*:}" > "$STATE/partlabel"
+EOF
+cat > "$BIN/sync" <<'EOF'
+#!/usr/bin/env bash
+echo sync >> "$STATE/log"
+EOF
+chmod +x "$BIN"/*
+
+reset_state() {
+    printf '%s\n' "${1:-ROCKNIX}" > "$STATE/partlabel"
+    printf '%s\n' "${2:-ROCKNIX}" > "$STATE/fslabel"
+    printf '%s\n' "${3:-gpt}" > "$STATE/table"
+    printf '%s\n' "${4:-1}" > "$STATE/has_root"
+    echo 0 > "$STATE/duplicate"
+    echo 0 > "$STATE/mounted"
+    echo vfat > "$STATE/fstype"
+    : > "$STATE/log"
+    rm -f "$STATE"/fail_*
+}
+run_rename() {
+    ARMADA_STORAGE_LIB="$WORK/storage-lib" PATH="$BIN:$PATH" bash "$WORK/rename.sh"
+}
+
+reset_state
+run_rename >/dev/null
+assert_eq "GPT label" "$(cat "$STATE/partlabel")" ARMADA
+assert_eq "filesystem label" "$(cat "$STATE/fslabel")" ARMADA
+assert_eq "migration order" "$(tr '\n' ' ' < "$STATE/log")" \
+    "fatlabel:ARMADA sgdisk:1:ARMADA:/dev/fakedisk sync "
+
+reset_state ARMADA ARMADA
+run_rename >/dev/null
+[[ ! -s "$STATE/log" ]] || fail "already-renamed ESP was modified"
+
+reset_state ROCKNIX ARMADA
+run_rename >/dev/null
+[[ $(cat "$STATE/log") != *fatlabel* ]] || fail "current FAT label was rewritten"
+assert_eq "partial GPT label" "$(cat "$STATE/partlabel")" ARMADA
+
+reset_state ARMADA ROCKNIX
+run_rename >/dev/null
+[[ $(cat "$STATE/log") != *sgdisk* ]] || fail "current GPT name was rewritten"
+assert_eq "partial filesystem label" "$(cat "$STATE/fslabel")" ARMADA
+
+reset_state ROCKNIX ROCKNIX dos
+run_rename >/dev/null
+[[ ! -s "$STATE/log" ]] || fail "MBR disk was modified"
+reset_state ROCKNIX ROCKNIX gpt 0
+run_rename >/dev/null
+[[ ! -s "$STATE/log" ]] || fail "unrelated GPT was modified"
+reset_state
+echo 1 > "$STATE/duplicate"
+run_rename >/dev/null
+[[ ! -s "$STATE/log" ]] || fail "ambiguous ESP candidates were modified"
+reset_state
+echo 1 > "$STATE/mounted"
+run_rename >/dev/null 2>&1
+[[ ! -s "$STATE/log" ]] || fail "mounted ESP was modified"
+reset_state
+echo ext4 > "$STATE/fstype"
+run_rename >/dev/null 2>&1
+[[ ! -s "$STATE/log" ]] || fail "non-vfat ESP was modified"
+
+reset_state
+touch "$STATE/fail_fatlabel"
+if run_rename >/dev/null 2>&1; then
+    fail "fatlabel failure returned success"
+fi
+[[ ! -s "$STATE/log" ]] || fail "GPT rename followed failed FAT rename"
+
+reset_state
+touch "$STATE/fail_sgdisk"
+if run_rename >/dev/null 2>&1; then
+    fail "sgdisk failure returned success"
+fi
+assert_eq "failed GPT write filesystem label" "$(cat "$STATE/fslabel")" ARMADA
+assert_eq "failed GPT write partition label" "$(cat "$STATE/partlabel")" ROCKNIX
+
+grep -q '^DefaultDependencies=no$' "$UNIT" || fail "unit has default boot dependencies"
+grep -q '^Before=boot-efi.mount local-fs.target$' "$UNIT" || fail "unit is not before the ESP mount"
+grep -q '^TimeoutStartSec=30$' "$UNIT" || fail "unit has no bounded timeout"
+grep -q '^ExecStart=-/usr/libexec/armada/armada-esp-rename$' "$UNIT" || fail "unit is not best effort"
+grep -q '^After=armada-esp-rename.service$' "$FSCK_DROPIN" || fail "fsck can race the rename"
+grep -q '^systemctl enable armada-esp-rename.service$' "$VENDOR_BUILD" || fail "unit is not enabled"
+[[ -x "$RENAME" ]] || fail "rename helper is not executable"
+
+grep -q 'ESP_PARTLABEL="ARMADA"' "$INSTALLER" || fail "new ESP label is not ARMADA"
+grep -q 'ROCKNIX|ARMADA|ARMADA_BOOT|ARMADA_ROOT' "$INSTALLER" || fail "legacy ESP is not removable"
+eval "$(sed -n '/^detect_mode()/,/^}/p' "$INSTALLER")"
+eval "$(sed -n '/^cmd_detect()/,/^}/p' "$INSTALLER")"
+partition_names() { echo ARMADA; }
+need_root() { :; }
+check_device() { :; }
+find_userdata() { UD_ORIG_GIB=8; }
+collect_our_tail() { LINUX_BYTES=536870912; }
+detected=$(cmd_detect)
+assert_eq "new ESP mode" "$(sed -n 's/^mode=//p' <<<"$detected")" occupied
+assert_eq "new ESP owner" "$(sed -n 's/^installed=//p' <<<"$detected")" armada
+
+echo "ESP rename tests passed"


### PR DESCRIPTION
- Use ARMADA for the GPT partition name and FAT filesystem label on new internal installations while retaining support for legacy ROCKNIX layouts.

- Migrate existing installations at boot before the ESP is checked or mounted. Scope the best effort migration to the running GPT disk with a complete Armada layout, and use the labels as idempotent retry markers.

- Update installer detection, recovery guidance, and tests for both names.