### PR TITLE
feat(armada-control): add configurable performance and Proton defaults

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -43,7 +43,7 @@ WORKDIR /build/armada-control
 COPY decky/armada-control/package.json decky/armada-control/package-lock.json ./
 RUN npm ci
 COPY decky/armada-control/ ./
-RUN npm run build
+RUN npm test && npm run build
 WORKDIR /build/armada-store
 COPY decky/armada-store/package.json decky/armada-store/package-lock.json ./
 RUN npm ci

--- a/decky/armada-control/main.py
+++ b/decky/armada-control/main.py
@@ -48,8 +48,8 @@ class Plugin:
     async def get_compat_applied(self):
         return await asyncio.to_thread(load_compat_applied)
 
-    async def save_compat_applied(self, appids):
-        return await asyncio.to_thread(save_compat_applied, appids)
+    async def save_compat_applied(self, appids, proton_default=None):
+        return await asyncio.to_thread(save_compat_applied, appids, proton_default)
 
     async def set_ssh_enabled(self, enabled):
         return await asyncio.to_thread(set_ssh_enabled, enabled)

--- a/decky/armada-control/package.json
+++ b/decky/armada-control/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "shx rm -rf dist && rollup -c",
+    "test": "node --experimental-strip-types --test test/*.test.ts",
     "watch": "rollup -c -w"
   },
   "dependencies": {

--- a/decky/armada-control/py_modules/armada_control/config.py
+++ b/decky/armada-control/py_modules/armada_control/config.py
@@ -28,6 +28,11 @@ def build_config(include_games=True):
         "perf": perf_info(),
         "cpuDeviceClass": env.get("ARMADA_SOC_CLASS", ""),
         "rgbSupported": bool(env.get("ARMADA_RGB_BACKEND")),
+        "protonDefaults": [
+            default.strip()
+            for default in env.get("ARMADA_PROTON_DEFAULTS", "").split(":")
+            if default.strip()
+        ],
         "osVersion": os_version(),
         "ablVersion": abl_version(),
         "ablAutoEnabled": abl_auto_enabled(),

--- a/decky/armada-control/py_modules/armada_control/tweaks.py
+++ b/decky/armada-control/py_modules/armada_control/tweaks.py
@@ -1,10 +1,13 @@
-import copy
 import json
+import os
+import sys
 from pathlib import Path
 
 from .privileged import call
 
-TWEAKS_CONFIG = Path("/etc/armada/game-tweaks.json")
+sys.path.insert(0, os.environ.get("ARMADA_GAME_TWEAKS_LIB", "/usr/lib/armada"))
+import armada_game_tweaks
+
 COMPAT_APPLIED_STATE = Path("/var/lib/armada/compat-applied.json")
 FEX_PROFILES_CONFIG = Path("/usr/share/armada/fex-profiles.json")
 PLUGIN_FEX_PROFILES_CONFIG = Path(__file__).resolve().parent.parent / "fex-profiles.json"
@@ -15,7 +18,7 @@ def load_fex_contract():
     with path.open(encoding="utf-8") as f:
         contract = json.load(f)
     profiles = contract.get("profiles")
-    if not isinstance(contract.get("defaults"), dict) or not isinstance(profiles, dict) or "default" not in profiles:
+    if not isinstance(profiles, dict) or "default" not in profiles:
         raise ValueError("invalid FEX profile contract")
     for profile in profiles.values():
         if not isinstance(profile, dict) or not isinstance(profile.get("config"), dict):
@@ -32,27 +35,7 @@ def fex_profile_labels(contract):
 
 
 def load_tweaks():
-    contract = load_fex_contract()
-    try:
-        with TWEAKS_CONFIG.open(encoding="utf-8") as f:
-            loaded = json.load(f)
-    except (OSError, ValueError):
-        return copy.deepcopy(contract["defaults"])
-    data = copy.deepcopy(contract["defaults"])
-    if isinstance(loaded, dict):
-        if isinstance(loaded.get("global"), dict):
-            data["global"].update(loaded["global"])
-        if isinstance(loaded.get("games"), dict):
-            data["games"] = {
-                str(k): v for k, v in loaded["games"].items()
-                if str(k).isdigit() and isinstance(v, dict)
-            }
-    data["games"] = {
-        gid: {k: v for k, v in game.items() if k != "enabled"}
-        for gid, game in data["games"].items()
-        if isinstance(game, dict) and game.get("enabled") is not False
-    }
-    return data
+    return armada_game_tweaks.load()
 
 
 def sanitize_tweaks(data):
@@ -71,8 +54,14 @@ def sanitize_tweaks(data):
     return clean
 
 
+def tweak_overrides(data):
+    clean = sanitize_tweaks(data)
+    return armada_game_tweaks.remove_factory_values(
+        clean, armada_game_tweaks.load_defaults())
+
+
 def save_tweaks(data):
-    call("write_config", name="tweaks", text=json.dumps(sanitize_tweaks(data), indent=2, sort_keys=True) + "\n")
+    call("write_config", name="tweaks", text=json.dumps(tweak_overrides(data), indent=2, sort_keys=True) + "\n")
 
 
 def load_compat_applied():

--- a/decky/armada-control/py_modules/armada_control/tweaks.py
+++ b/decky/armada-control/py_modules/armada_control/tweaks.py
@@ -69,15 +69,25 @@ def load_compat_applied():
         with COMPAT_APPLIED_STATE.open(encoding="utf-8") as f:
             loaded = json.load(f)
     except (OSError, ValueError):
-        return []
+        loaded = {}
     appids = loaded.get("appids") if isinstance(loaded, dict) else None
     if not isinstance(appids, list):
-        return []
-    return sorted({str(appid) for appid in appids if str(appid).isdigit()}, key=int)
+        appids = []
+    proton_default = loaded.get("protonDefault") if isinstance(loaded, dict) else ""
+    return {
+        "appids": sorted({str(appid) for appid in appids if str(appid).isdigit()}, key=int),
+        "protonDefault": proton_default if isinstance(proton_default, str) else "",
+    }
 
 
-def save_compat_applied(appids):
+def save_compat_applied(appids, proton_default=None):
     clean = sorted({str(appid) for appid in appids if str(appid).isdigit()}, key=int)
-    text = json.dumps({"appids": clean}, indent=2, sort_keys=True) + "\n"
+    if proton_default is None:
+        proton_default = load_compat_applied()["protonDefault"]
+    state = {
+        "appids": clean,
+        "protonDefault": proton_default if isinstance(proton_default, str) else "",
+    }
+    text = json.dumps(state, indent=2, sort_keys=True) + "\n"
     call("write_config", name="compat-applied", text=text)
-    return clean
+    return state

--- a/decky/armada-control/src/backend.ts
+++ b/decky/armada-control/src/backend.ts
@@ -1,18 +1,18 @@
 import { call } from "@decky/api";
-import type { CalibrationState, Capture, Config, CurvesState, FanCurve, FanSettings, InstalledGame, PowerConfig, RgbConfig, Tweaks } from "./types";
+import type { CalibrationState, Capture, CompatAppliedState, Config, CurvesState, FanCurve, FanSettings, InstalledGame, PowerConfig, RgbConfig, Tweaks } from "./types";
 
 export const getConfig = () => call<[], Config>("get_config");
 export const getInstalledGames = () => call<[], InstalledGame[]>("get_installed_games");
 export const getCompatMappedAppids = (tool: string) => call<[string], string[]>("get_compat_mapped_appids", tool);
 export const savePowerConfig = (data: PowerConfig) => call<[PowerConfig], Config>("save_power_config", data);
 export const saveTweaks = (data: Tweaks) => call<[Tweaks], Config>("save_tweaks", data);
-export const getCompatApplied = () => call<[], string[]>("get_compat_applied");
+export const getCompatApplied = () => call<[], CompatAppliedState>("get_compat_applied");
 let compatAppliedSaveChain = Promise.resolve<unknown>(undefined);
-export const saveCompatApplied = (appids: string[]) => {
+export const saveCompatApplied = (appids: string[], protonDefault: string | null = null) => {
   const snapshot = [...appids];
   const request = compatAppliedSaveChain
     .catch(() => {})
-    .then(() => call<[string[]], string[]>("save_compat_applied", snapshot));
+    .then(() => call<[string[], string | null], CompatAppliedState>("save_compat_applied", snapshot, protonDefault));
   compatAppliedSaveChain = request;
   return request;
 };

--- a/decky/armada-control/src/index.tsx
+++ b/decky/armada-control/src/index.tsx
@@ -24,6 +24,7 @@ export default definePlugin(() => {
         config.tweaks?.global?.windowsCompatTool,
         handled.loaded && config.tweaks?.global?.autoApplyCompat !== false,
         handled.appids,
+        config.protonDefaults,
       );
       const persist = handled.loaded ? persistHandledGames : () => {};
       unregisterDownloadWatcher = registerDownloadWatcher(persist);

--- a/decky/armada-control/src/index.tsx
+++ b/decky/armada-control/src/index.tsx
@@ -3,10 +3,14 @@ import { getCompatApplied, getConfig, getInstalledGames, saveCompatApplied } fro
 import { Content } from "./Content";
 import {
   configureCompatPolicy,
+  defaultWindowsCompatTool,
+  getProtonTools,
   handledGameAppids,
+  migrateWindowsCompatTool,
   registerDownloadWatcher,
   sweepInstalledGames,
 } from "./lib/steamCompat";
+import { factoryDefaultTransition } from "./lib/protonPolicy";
 
 export default definePlugin(() => {
   let unregisterDownloadWatcher = () => {};
@@ -15,24 +19,50 @@ export default definePlugin(() => {
   };
   let cancelled = false;
   const handledRequest = getCompatApplied()
-    .then((appids) => ({ appids, loaded: true }))
-    .catch(() => ({ appids: [] as string[], loaded: false }));
+    .then((state) => ({ state, loaded: true }))
+    .catch(() => ({ state: { appids: [] as string[], protonDefault: "" }, loaded: false }));
   Promise.all([getConfig(), getInstalledGames(), handledRequest])
-    .then(([config, games, handled]) => {
+    .then(async ([config, games, handled]) => {
       if (cancelled) return;
+      const explicitTool = config.tweaks?.global?.windowsCompatTool;
       configureCompatPolicy(
-        config.tweaks?.global?.windowsCompatTool,
+        explicitTool,
         handled.loaded && config.tweaks?.global?.autoApplyCompat !== false,
-        handled.appids,
+        handled.state.appids,
         config.protonDefaults,
       );
       const persist = handled.loaded ? persistHandledGames : () => {};
       unregisterDownloadWatcher = registerDownloadWatcher(persist);
       window.setTimeout(() => {
-        if (cancelled) return;
-        sweepInstalledGames(games)
-          .then(persist)
-          .catch(() => {});
+        void (async () => {
+          if (cancelled) return;
+          await sweepInstalledGames(games);
+          if (cancelled) return;
+          if (handled.loaded && !explicitTool) {
+            const tools = await getProtonTools();
+            if (cancelled) return;
+            const nextTool = defaultWindowsCompatTool(tools, config.protonDefaults);
+            const transition = factoryDefaultTransition(
+              explicitTool, handled.loaded, handled.state.protonDefault, nextTool,
+            );
+            if (transition) {
+              try {
+                if (transition.oldTool !== transition.newTool) {
+                  await migrateWindowsCompatTool(
+                    games.filter((game) => !game.nonSteam).map((game) => game.appid),
+                    transition.oldTool,
+                    transition.newTool,
+                  );
+                }
+                if (cancelled) return;
+                await saveCompatApplied(handledGameAppids(), transition.newTool);
+                return;
+              } catch (error) {
+              }
+            }
+          }
+          persist();
+        })().catch(() => {});
       }, 3000);
     })
     .catch(() => {});

--- a/decky/armada-control/src/lib/protonPolicy.ts
+++ b/decky/armada-control/src/lib/protonPolicy.ts
@@ -1,0 +1,12 @@
+export interface CompatTool {
+  id: string;
+  label: string;
+}
+
+export function defaultWindowsCompatTool(
+  tools: CompatTool[],
+  defaults: string[],
+): string {
+  const available = new Set(tools.map((tool) => tool.id));
+  return defaults.find((tool) => available.has(tool)) || "";
+}

--- a/decky/armada-control/src/lib/protonPolicy.ts
+++ b/decky/armada-control/src/lib/protonPolicy.ts
@@ -3,6 +3,22 @@ export interface CompatTool {
   label: string;
 }
 
+const LEGACY_WINDOWS_COMPAT_TOOL = "proton-cachyos-11.0-arm64";
+
+export function factoryDefaultTransition(
+  explicitTool: string | undefined,
+  stateLoaded: boolean,
+  previousTool: string,
+  nextTool: string,
+): { oldTool: string; newTool: string } | null {
+  if (explicitTool || !stateLoaded || !nextTool) return null;
+  if (previousTool === nextTool) return null;
+  return {
+    oldTool: previousTool || LEGACY_WINDOWS_COMPAT_TOOL,
+    newTool: nextTool,
+  };
+}
+
 export function defaultWindowsCompatTool(
   tools: CompatTool[],
   defaults: string[],

--- a/decky/armada-control/src/lib/steamCompat.ts
+++ b/decky/armada-control/src/lib/steamCompat.ts
@@ -1,7 +1,11 @@
-export interface CompatTool {
-  id: string;
-  label: string;
-}
+import {
+  defaultWindowsCompatTool,
+  type CompatTool,
+} from "./protonPolicy";
+export {
+  defaultWindowsCompatTool,
+} from "./protonPolicy";
+export type { CompatTool } from "./protonPolicy";
 
 export interface CompatState {
   tool: string;
@@ -15,11 +19,10 @@ const STEAM_SHORTCUT_APP_TYPE = 1073741824;
 const apps = () => window.SteamClient?.Apps;
 const settings = () => window.SteamClient?.Settings;
 
-// Keep in sync with PROTON_TOOL_NAME (build) and PROTON_11_STABLE (armada-fixups).
-export const DEFAULT_WINDOWS_COMPAT_TOOL = "proton-cachyos-11.0-arm64";
 export const USE_DEFAULT_COMPAT = "__armada_default__";
 export const FOLLOW_STEAM_COMPAT = "__steam_default__";
-let windowsCompatTool = DEFAULT_WINDOWS_COMPAT_TOOL;
+let windowsCompatTool = "";
+let windowsCompatDefaults: string[] = [];
 let autoApplyCompat = true;
 const handledAppids = new Set<string>();
 let protonToolsCache: CompatTool[] = [];
@@ -27,15 +30,15 @@ let protonToolsCachedAt = 0;
 let protonToolsRequest: Promise<CompatTool[]> | null = null;
 
 export function setWindowsCompatTool(toolName: string | undefined): void {
-  windowsCompatTool = toolName || DEFAULT_WINDOWS_COMPAT_TOOL;
+  windowsCompatTool = toolName || "";
 }
 
 // A saved default can name a tool a later release stopped shipping.
 async function effectiveWindowsCompatTool(): Promise<string> {
   const tools = await getProtonTools();
   if (!tools.length) return "";
-  if (tools.some((tool) => tool.id === windowsCompatTool)) return windowsCompatTool;
-  return tools.some((tool) => tool.id === DEFAULT_WINDOWS_COMPAT_TOOL) ? DEFAULT_WINDOWS_COMPAT_TOOL : "";
+  if (windowsCompatTool && tools.some((tool) => tool.id === windowsCompatTool)) return windowsCompatTool;
+  return defaultWindowsCompatTool(tools, windowsCompatDefaults);
 }
 
 // Steam keeps reporting stale details for an app whose tool went missing, so a write
@@ -50,8 +53,14 @@ async function repinToTool(appid: string, tool: string): Promise<boolean> {
   return true;
 }
 
-export function configureCompatPolicy(toolName: string | undefined, autoApply: boolean, appids: string[]): void {
+export function configureCompatPolicy(
+  toolName: string | undefined,
+  autoApply: boolean,
+  appids: string[],
+  defaults: string[] = [],
+): void {
   setWindowsCompatTool(toolName);
+  windowsCompatDefaults = defaults.map(String).filter(Boolean);
   autoApplyCompat = autoApply;
   handledAppids.clear();
   for (const appid of appids) {

--- a/decky/armada-control/src/tabs/Compatibility.tsx
+++ b/decky/armada-control/src/tabs/Compatibility.tsx
@@ -20,10 +20,10 @@ import { getGlobalResolution, setGlobalResolution } from "../lib/steamSettings";
 import { clone } from "../lib/util";
 import { availableGames, editTargetOptions } from "../lib/games";
 import {
-  DEFAULT_WINDOWS_COMPAT_TOOL,
   FOLLOW_STEAM_COMPAT,
   USE_DEFAULT_COMPAT,
   compatSelection,
+  defaultWindowsCompatTool,
   getAppCompatTools,
   getProtonTools,
   handledGameAppids,
@@ -40,6 +40,11 @@ import {
 } from "../lib/steamCompat";
 import type { CompatTool } from "../lib/steamCompat";
 import type { Config } from "../types";
+
+const PERF_KEYS = [
+  "cores", "wineTopology", "nice", "gamescopeCores",
+  "gamescopeNice", "gamescopeRr", "scheduler",
+];
 
 function cpulistError(text: string, cpuCount: number): string {
   const seen = new Set<number>();
@@ -222,11 +227,15 @@ export function Compatibility({ config, setConfig }: { config: Config; setConfig
   const [perGameTools, setPerGameTools] = useState<CompatTool[]>([]);
   const [currentTool, setCurrentTool] = useState("");
   const [globalTool, setGlobalTool] = useState(
-    String(config.tweaks?.global?.windowsCompatTool || DEFAULT_WINDOWS_COMPAT_TOOL),
+    String(config.tweaks?.global?.windowsCompatTool || ""),
+  );
+  const resolvedDefaultTool = defaultWindowsCompatTool(
+    compatTools, config.protonDefaults,
   );
   // The setting is kept rather than rewritten: reinstalling the tool restores the choice.
-  const globalToolMissing = compatTools.length > 0 && !compatTools.some((tool) => tool.id === globalTool);
-  const activeGlobalTool = globalToolMissing ? DEFAULT_WINDOWS_COMPAT_TOOL : globalTool;
+  const globalToolMissing = !!globalTool && compatTools.length > 0
+    && !compatTools.some((tool) => tool.id === globalTool);
+  const activeGlobalTool = !globalTool || globalToolMissing ? resolvedDefaultTool : globalTool;
   const runtimeGame = config.game;
   const games = availableGames(config);
   const selectedGame = config.selectedGame || runtimeGame || null;
@@ -340,11 +349,18 @@ export function Compatibility({ config, setConfig }: { config: Config; setConfig
     setConfig((current) => {
       if (!current) return current;
       const next = clone(current);
+      let target: Record<string, any> | undefined;
       if (editingDefault) {
-        Object.assign(next.tweaks.global, patch);
+        target = next.tweaks.global;
       } else if (game?.appid) {
         const existing = next.tweaks.games[game.appid] || {};
-        next.tweaks.games[game.appid] = { ...existing, name: game.name || "", ...patch };
+        target = next.tweaks.games[game.appid] = { ...existing, name: game.name || "" };
+      }
+      if (target) {
+        for (const [key, value] of Object.entries(patch)) {
+          if (value === undefined) delete target[key];
+          else target[key] = value;
+        }
       }
       return next;
     });
@@ -471,7 +487,7 @@ export function Compatibility({ config, setConfig }: { config: Config; setConfig
   const onSelectGlobalDefault = async (choice: any) => {
     if (switchingDefault) return;
     const name = String(choice);
-    const oldTool = String(tweaks.global.windowsCompatTool || DEFAULT_WINDOWS_COMPAT_TOOL);
+    const oldTool = activeGlobalTool;
     setSwitchingDefault(true);
     try {
       const pinned = await pinnedToMissingTool();
@@ -502,6 +518,7 @@ export function Compatibility({ config, setConfig }: { config: Config; setConfig
   const onSelectPerGameTool = async (choice: any) => {
     if (!game?.appid) return;
     const selection = String(choice);
+    if (selection === USE_DEFAULT_COMPAT && !activeGlobalTool) return;
     const target = selection === USE_DEFAULT_COMPAT
       ? activeGlobalTool
       : selection === FOLLOW_STEAM_COMPAT
@@ -531,9 +548,7 @@ export function Compatibility({ config, setConfig }: { config: Config; setConfig
   const onSelectFex = (id: any) => {
     if (id === "custom") {
       setCustomSelected(true);
-      // First Custom for this target seeds from the Default preset; afterwards the
-      // stored config is kept, including across visits to a preset.
-      patchSettings({ fexProfile: "custom", fexConfig: { ...(ownConfig || presets.default?.config || {}) } });
+      patchSettings({ fexProfile: "custom", fexConfig: { ...(ownConfig || fexConfig) } });
       return;
     }
     setCustomSelected(false);
@@ -580,6 +595,11 @@ export function Compatibility({ config, setConfig }: { config: Config; setConfig
     ...(perf?.corePresets || [{ data: "all", label: "All Cores" }]),
     { data: "custom", label: "Custom" },
   ];
+  const hasGamePerfOverrides = !editingDefault
+    && PERF_KEYS.some((key) => Object.prototype.hasOwnProperty.call(gameSettings, key));
+  const resetGamePerformance = () => patchSettings(
+    Object.fromEntries(PERF_KEYS.map((key) => [key, undefined])),
+  );
   // env merges per-entry; unchecking a default var stores a null tombstone
   const ownEnv = ((editingDefault ? tweaks.global.env : gameSettings.env) || {}) as Record<string, string | null>;
   const globalEnv = ((!editingDefault && tweaks.global.env) || {}) as Record<string, string>;
@@ -634,8 +654,7 @@ export function Compatibility({ config, setConfig }: { config: Config; setConfig
     setConfig((current) => {
       if (!current) return current;
       const nextTweaks = clone(current.tweaks);
-      if (on) nextTweaks.global.gamescopeVulkanRealtime = true;
-      else delete nextTweaks.global.gamescopeVulkanRealtime;
+      nextTweaks.global.gamescopeVulkanRealtime = on;
       return { ...current, tweaks: nextTweaks };
     });
     showModal(
@@ -667,10 +686,10 @@ export function Compatibility({ config, setConfig }: { config: Config; setConfig
         <ToggleField
           label="Wine CPU Topology"
           checked={values.wineTopology !== false}
-          onChange={(on) => patchSettings({ wineTopology: on ? (!editingDefault && tweaks.global.wineTopology === false ? true : undefined) : false })}
+          onChange={(on) => patchSettings({ wineTopology: on })}
         />
       ) : null}
-      <SliderEdit label="Nice" value={values.nice ?? 0} min={-20} max={19} step={1} onChange={(v) => patchSettings({ nice: v !== 0 ? v : !editingDefault && tweaks.global.nice ? 0 : undefined })} />
+      <SliderEdit label="Nice" value={values.nice ?? 0} min={-20} max={19} step={1} onChange={(v) => patchSettings({ nice: v })} />
       <div className="armada-subheader">Gamescope</div>
       <SelectEdit
         label="CPU Cores"
@@ -700,11 +719,11 @@ export function Compatibility({ config, setConfig }: { config: Config; setConfig
         </PanelSectionRow>
       ) : null}
       {gsCoresError && gsCoresText ? <div className="armada-field-note">{gsCoresError}</div> : null}
-      <SliderEdit label="Nice" value={values.gamescopeNice ?? 0} min={-20} max={19} step={1} onChange={(v) => patchSettings({ gamescopeNice: v !== 0 ? v : !editingDefault && tweaks.global.gamescopeNice ? 0 : undefined })} />
+      <SliderEdit label="Nice" value={values.gamescopeNice ?? 0} min={-20} max={19} step={1} onChange={(v) => patchSettings({ gamescopeNice: v })} />
       <ToggleField
         label="CPU Realtime Scheduling"
         checked={!!values.gamescopeRr}
-        onChange={(on) => patchSettings({ gamescopeRr: on ? true : tweaks.global.gamescopeRr ? false : undefined })}
+        onChange={(on) => patchSettings({ gamescopeRr: on })}
       />
       {editingDefault ? (
         <ToggleField
@@ -720,6 +739,11 @@ export function Compatibility({ config, setConfig }: { config: Config; setConfig
         options={schedulerOptions}
         onChange={(v) => patchSettings({ scheduler: String(v) || undefined })}
       />
+      {hasGamePerfOverrides ? (
+        <ButtonItem layout="below" onClick={resetGamePerformance}>
+          Reset Performance to Default
+        </ButtonItem>
+      ) : null}
       {runningSelectedGame ? (
         <ButtonItem layout="below" onClick={() => { void onReapply(); }}>
           Re-apply to Running Game
@@ -770,7 +794,7 @@ export function Compatibility({ config, setConfig }: { config: Config; setConfig
             <SelectEdit
               labelBelow
               label="Default Proton"
-              value={globalTool}
+              value={globalTool || activeGlobalTool}
               options={toolOptions}
               onChange={onSelectGlobalDefault}
               disabled={switchingDefault}

--- a/decky/armada-control/src/types.ts
+++ b/decky/armada-control/src/types.ts
@@ -95,6 +95,7 @@ export interface Config {
   perf?: PerfInfo;
   cpuDeviceClass: string;
   rgbSupported: boolean;
+  protonDefaults: string[];
   osVersion: string;
   ablVersion: string;
   ablAutoEnabled: boolean;

--- a/decky/armada-control/src/types.ts
+++ b/decky/armada-control/src/types.ts
@@ -35,6 +35,11 @@ export interface Tweaks {
   games: Record<string, GameTweak>;
 }
 
+export interface CompatAppliedState {
+  appids: string[];
+  protonDefault: string;
+}
+
 export interface InstalledGame {
   appid: string;
   name: string;

--- a/decky/armada-control/test/protonPolicy.test.ts
+++ b/decky/armada-control/test/protonPolicy.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  defaultWindowsCompatTool,
+} from "../src/lib/protonPolicy.ts";
+
+const tool = (id: string) => ({ id, label: id });
+const experimental = "proton-experimental-arm64";
+const stable = "proton-stable-arm64";
+const cachyos = "proton-cachyos-11.0-arm64";
+const defaults = [experimental, stable, cachyos];
+
+test("candidate order wins over installed-tool order", () => {
+  assert.equal(defaultWindowsCompatTool([
+    tool(cachyos),
+    tool(stable),
+    tool(experimental),
+  ], defaults), experimental);
+});
+
+test("missing candidates are skipped", () => {
+  assert.equal(defaultWindowsCompatTool([
+    tool(stable),
+    tool(cachyos),
+  ], defaults), stable);
+});
+
+test("a device-specific list can require CachyOS", () => {
+  assert.equal(defaultWindowsCompatTool([
+    tool(experimental),
+    tool(cachyos),
+  ], [cachyos]), cachyos);
+});
+
+test("no unavailable candidate is selected", () => {
+  assert.equal(defaultWindowsCompatTool([
+    tool("proton_experimental"),
+    tool("proton-stable"),
+  ], defaults), "");
+});

--- a/decky/armada-control/test/protonPolicy.test.ts
+++ b/decky/armada-control/test/protonPolicy.test.ts
@@ -3,15 +3,16 @@ import test from "node:test";
 
 import {
   defaultWindowsCompatTool,
+  factoryDefaultTransition,
 } from "../src/lib/protonPolicy.ts";
 
 const tool = (id: string) => ({ id, label: id });
 const experimental = "proton-experimental-arm64";
-const stable = "proton-stable-arm64";
+const stable = "proton_11-arm64";
 const cachyos = "proton-cachyos-11.0-arm64";
 const defaults = [experimental, stable, cachyos];
 
-test("candidate order wins over installed-tool order", () => {
+test("candidate order wins over Steam-reported tool order", () => {
   assert.equal(defaultWindowsCompatTool([
     tool(cachyos),
     tool(stable),
@@ -38,4 +39,29 @@ test("no unavailable candidate is selected", () => {
     tool("proton_experimental"),
     tool("proton-stable"),
   ], defaults), "");
+});
+
+test("legacy factory default transitions from CachyOS", () => {
+  assert.deepEqual(
+    factoryDefaultTransition(undefined, true, "", experimental),
+    { oldTool: cachyos, newTool: experimental },
+  );
+  assert.deepEqual(
+    factoryDefaultTransition(undefined, true, "", cachyos),
+    { oldTool: cachyos, newTool: cachyos },
+  );
+});
+
+test("stored factory default is used for later transitions", () => {
+  assert.deepEqual(
+    factoryDefaultTransition(undefined, true, stable, experimental),
+    { oldTool: stable, newTool: experimental },
+  );
+});
+
+test("factory transition requires trusted state and a resolved implicit default", () => {
+  assert.equal(factoryDefaultTransition(cachyos, true, stable, experimental), null);
+  assert.equal(factoryDefaultTransition(undefined, false, stable, experimental), null);
+  assert.equal(factoryDefaultTransition(undefined, true, stable, ""), null);
+  assert.equal(factoryDefaultTransition(undefined, true, experimental, experimental), null);
 });

--- a/system_files/usr/lib/armada/armada_game_tweaks.py
+++ b/system_files/usr/lib/armada/armada_game_tweaks.py
@@ -1,0 +1,71 @@
+import copy
+import json
+import pathlib
+
+
+DEFAULTS_CONFIG = pathlib.Path("/usr/share/armada/game-tweaks.json")
+OVERRIDES_CONFIG = pathlib.Path("/etc/armada/game-tweaks.json")
+
+
+def _read_object(path):
+    try:
+        with path.open(encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _normalize(data):
+    normalized = copy.deepcopy(data)
+    if not isinstance(normalized.get("global"), dict):
+        normalized["global"] = {}
+    games = normalized.get("games")
+    normalized["games"] = {
+        str(appid): settings for appid, settings in games.items()
+        if str(appid).isdigit() and isinstance(settings, dict)
+    } if isinstance(games, dict) else {}
+    return normalized
+
+
+def load_defaults(path=None):
+    return _normalize(_read_object(path or DEFAULTS_CONFIG))
+
+
+def load(defaults_path=None, overrides_path=None):
+    data = load_defaults(defaults_path)
+    overrides = _read_object(overrides_path or OVERRIDES_CONFIG)
+    if isinstance(overrides.get("global"), dict):
+        data["global"].update(overrides["global"])
+    if isinstance(overrides.get("games"), dict):
+        data["games"] = _normalize({"games": overrides["games"]})["games"]
+    return data
+
+
+def merged_settings(tweaks, appid):
+    settings = dict(tweaks.get("global") or {})
+    if not appid:
+        return settings
+    game = (tweaks.get("games") or {}).get(str(appid))
+    if not isinstance(game, dict) or game.get("enabled") is False:
+        return settings
+    global_env = settings.get("env")
+    settings.update(game)
+    if isinstance(global_env, dict) and isinstance(game.get("env"), dict):
+        merged_env = {**global_env, **game["env"]}
+        settings["env"] = {
+            key: value for key, value in merged_env.items() if value is not None
+        }
+    return settings
+
+
+def remove_factory_values(data, defaults):
+    result = copy.deepcopy(data)
+    global_settings = result.get("global")
+    factory_global = defaults.get("global")
+    if isinstance(global_settings, dict) and isinstance(factory_global, dict):
+        result["global"] = {
+            key: value for key, value in global_settings.items()
+            if key not in factory_global or value != factory_global[key]
+        }
+    return result

--- a/system_files/usr/lib/armada/armada_perf.py
+++ b/system_files/usr/lib/armada/armada_perf.py
@@ -1,6 +1,4 @@
-"""Shared perf-settings helpers: cpulist grammar, tweaks merge, the
-STATE_FILE contract (armada-control writes policy, armada-powerd enforces),
-and gamescope thread enforcement."""
+"""Shared performance helpers and armada-control/armada-powerd state contract."""
 import json
 import os
 import pathlib
@@ -8,7 +6,6 @@ import shlex
 import subprocess
 import tempfile
 
-TWEAKS_CONFIG = pathlib.Path("/etc/armada/game-tweaks.json")
 STATE_FILE = pathlib.Path("/run/armada/perf-state.json")
 SESSION_SOCKET = "/run/armada/session.sock"
 DEVICE_ENV_HELPER = "/usr/libexec/armada/device-env"
@@ -108,29 +105,6 @@ def clamp(value, low, high):
     return max(low, min(high, int(value)))
 
 
-def load_tweaks():
-    try:
-        with TWEAKS_CONFIG.open(encoding="utf-8") as f:
-            loaded = json.load(f)
-    except (OSError, ValueError):
-        return {}
-    return loaded if isinstance(loaded, dict) else {}
-
-
-def merged_settings(tweaks, appid):
-    settings = dict(tweaks.get("global") or {})
-    if appid:
-        game = (tweaks.get("games") or {}).get(str(appid))
-        if isinstance(game, dict) and game.get("enabled") is not False:
-            global_env = settings.get("env")
-            settings.update(game)
-            # env merges per-entry (unlike thunks); null = tombstone
-            if isinstance(global_env, dict) and isinstance(game.get("env"), dict):
-                merged_env = {**global_env, **game["env"]}
-                settings["env"] = {k: v for k, v in merged_env.items() if v is not None}
-    return settings
-
-
 def sanitize_perf(settings, env=None):
     # Validated subset of the perf keys, bad values dropped key-by-key.
     clean = {}
@@ -141,8 +115,8 @@ def sanitize_perf(settings, env=None):
                 clean["cores"] = cores
         except ValueError:
             pass
-    if settings.get("wineTopology") is False:
-        clean["wineTopology"] = False
+    if isinstance(settings.get("wineTopology"), bool):
+        clean["wineTopology"] = settings["wineTopology"]
     if isinstance(settings.get("nice"), int):
         clean["nice"] = clamp(settings["nice"], NICE_MIN, NICE_MAX)
     if isinstance(settings.get("gamescopeNice"), int):

--- a/system_files/usr/libexec/armada/armada-control
+++ b/system_files/usr/libexec/armada/armada-control
@@ -13,6 +13,7 @@ import time
 from pathlib import Path
 
 sys.path.insert(0, "/usr/lib/armada")
+import armada_game_tweaks
 import armada_perf
 
 SOCKET = Path("/run/armada/control.sock")
@@ -422,12 +423,12 @@ class PerfManager:
 
     def refresh(self, keep_override=False):
         # recomputed from game-tweaks.json; powerd applies on its next tick
-        tweaks = armada_perf.load_tweaks()
+        tweaks = armada_game_tweaks.load()
         state = {"global": self.gamescope_layer(tweaks.get("global") or {})}
         if keep_override:
             old = armada_perf.read_state().get("override")
             if isinstance(old, dict) and self.pid_alive(old.get("pid")):
-                merged = armada_perf.merged_settings(tweaks, old.get("appid"))
+                merged = armada_game_tweaks.merged_settings(tweaks, old.get("appid"))
                 override = self.gamescope_layer(merged)
                 override.update({"appid": old.get("appid"), "pid": old["pid"]})
                 state["override"] = override
@@ -494,8 +495,8 @@ class PerfManager:
         return match if match is not None else pid
 
     def game_launched(self, appid, pid):
-        tweaks = armada_perf.load_tweaks()
-        merged = armada_perf.merged_settings(tweaks, appid)
+        tweaks = armada_game_tweaks.load()
+        merged = armada_game_tweaks.merged_settings(tweaks, appid)
         clean = armada_perf.sanitize_perf(merged, self.env)
         nice = clean.get("nice", 0)
         if nice < 0:
@@ -521,9 +522,9 @@ class PerfManager:
         override = state.get("override")
         if not isinstance(override, dict) or not self.pid_alive(override.get("pid")):
             raise RuntimeError("no running game to re-apply")
-        tweaks = armada_perf.load_tweaks()
+        tweaks = armada_game_tweaks.load()
         clean = armada_perf.sanitize_perf(
-            armada_perf.merged_settings(tweaks, override.get("appid")), self.env)
+            armada_game_tweaks.merged_settings(tweaks, override.get("appid")), self.env)
         cores = clean.get("cores")
         if clean.get("scheduler") == "cosmos":
             cores = None  # composition: cosmos gets the domain, no hard mask

--- a/system_files/usr/libexec/armada/armada-game-launch
+++ b/system_files/usr/libexec/armada/armada-game-launch
@@ -12,11 +12,11 @@ import sys
 import time
 
 sys.path.insert(0, "/usr/lib/armada")
+import armada_game_tweaks
 import armada_perf
 
 
 BASE_FEX_CONFIG = pathlib.Path("/usr/share/fex-emu/Config.json")
-TWEAKS_CONFIG = pathlib.Path("/etc/armada/game-tweaks.json")
 FEX_PROFILES_CONFIG = pathlib.Path("/usr/share/armada/fex-profiles.json")
 PROTON_INJECT_SRC = pathlib.Path("/usr/share/armada/proton-inject/x86_64-linux-gnu")
 SYSTEM_EXEC_PATHS = ("/usr/bin", "/usr/local/bin", "/bin")
@@ -66,28 +66,12 @@ def load_fex_contract():
     with FEX_PROFILES_CONFIG.open(encoding="utf-8") as f:
         contract = json.load(f)
     profiles = contract.get("profiles")
-    if not isinstance(contract.get("defaults"), dict) or not isinstance(profiles, dict) or "default" not in profiles:
+    if not isinstance(profiles, dict) or "default" not in profiles:
         raise ValueError("invalid FEX profile contract")
     for profile in profiles.values():
         if not isinstance(profile, dict) or not isinstance(profile.get("config"), dict):
             raise ValueError("invalid FEX profile contract")
     return contract
-
-
-def load_tweaks(defaults):
-    data = json.loads(json.dumps(defaults))
-    try:
-        with TWEAKS_CONFIG.open(encoding="utf-8") as f:
-            loaded = json.load(f)
-    except (OSError, ValueError):
-        return data
-    if not isinstance(loaded, dict):
-        return data
-    if isinstance(loaded.get("global"), dict):
-        data["global"].update(loaded["global"])
-    if isinstance(loaded.get("games"), dict):
-        data["games"] = loaded["games"]
-    return data
 
 
 def thunk_settings(settings, modules):
@@ -268,7 +252,8 @@ def main():
     settings = {}
     try:
         contract = load_fex_contract()
-        settings = armada_perf.merged_settings(load_tweaks(contract["defaults"]), game_id)
+        settings = armada_game_tweaks.merged_settings(
+            armada_game_tweaks.load(), game_id)
         apply_fex(settings, game_id, contract["profiles"], os.environ)
     except Exception as exc:
         print(f"armada-game-launch: failed to apply settings: {exc}", file=sys.stderr)

--- a/system_files/usr/libexec/armada/armada-game-tweaks
+++ b/system_files/usr/libexec/armada/armada-game-tweaks
@@ -1,0 +1,44 @@
+#!/usr/bin/python3
+
+import argparse
+import json
+import os
+import pathlib
+import sys
+
+sys.path.insert(0, os.environ.get("ARMADA_GAME_TWEAKS_LIB", "/usr/lib/armada"))
+import armada_game_tweaks
+
+
+def config_path(variable):
+    value = os.environ.get(variable)
+    return pathlib.Path(value) if value else None
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("dump", "get"))
+    parser.add_argument("key", nargs="?")
+    args = parser.parse_args()
+
+    data = armada_game_tweaks.load(
+        config_path("ARMADA_TWEAKS_DEFAULTS_CONFIG"),
+        config_path("ARMADA_TWEAKS_CONFIG"),
+    )
+    if args.command == "dump":
+        if args.key is not None:
+            parser.error("dump does not accept a key")
+        print(json.dumps(data, indent=2, sort_keys=True))
+        return
+    if args.key is None:
+        parser.error("get requires a dotted key")
+    value = data
+    for component in args.key.split("."):
+        if not isinstance(value, dict) or component not in value:
+            return
+        value = value[component]
+    print(json.dumps(value, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    main()

--- a/system_files/usr/libexec/armada/device-env
+++ b/system_files/usr/libexec/armada/device-env
@@ -66,6 +66,14 @@ if [[ "${ARMADA_SUSPEND_MODE:-fake}" == "mem" ]]; then
     fi
 fi
 
+# Proton defaults are tried in order and must match Steam compatibility
+# tool IDs.
+if [[ "${ARMADA_SOC_CLASS:-}" == SM8250 ]]; then
+    ARMADA_PROTON_DEFAULTS=proton-cachyos-11.0-arm64
+else
+    ARMADA_PROTON_DEFAULTS=proton-experimental-arm64:proton-stable-arm64:proton-cachyos-11.0-arm64
+fi
+
 # CPU topology by SoC (device conf may override). Cpulists are ordered:
 # presets expand in host order, WINE_CPU_TOPOLOGY consumers keep the order.
 # BIG includes the prime cores; PRIME is the strict subset. Empty
@@ -103,6 +111,7 @@ vars=(
     ARMADA_DEVICE_ID
     ARMADA_DEVICE_NAME
     ARMADA_SOC_CLASS
+    ARMADA_PROTON_DEFAULTS
     ARMADA_SUSPEND_MODE
     ARMADA_SYNC_SUSPEND
     ARMADA_PRIMARY_CONNECTOR

--- a/system_files/usr/libexec/armada/device-env
+++ b/system_files/usr/libexec/armada/device-env
@@ -71,7 +71,7 @@ fi
 if [[ "${ARMADA_SOC_CLASS:-}" == SM8250 ]]; then
     ARMADA_PROTON_DEFAULTS=proton-cachyos-11.0-arm64
 else
-    ARMADA_PROTON_DEFAULTS=proton-experimental-arm64:proton-stable-arm64:proton-cachyos-11.0-arm64
+    ARMADA_PROTON_DEFAULTS=proton-experimental-arm64:proton_11-arm64:proton-cachyos-11.0-arm64
 fi
 
 # CPU topology by SoC (device conf may override). Cpulists are ordered:

--- a/system_files/usr/share/armada/fex-profiles.json
+++ b/system_files/usr/share/armada/fex-profiles.json
@@ -1,16 +1,4 @@
 {
-  "defaults": {
-    "global": {
-      "thunks": {
-        "Vulkan": true,
-        "GL": true,
-        "drm": true,
-        "WaylandClient": true,
-        "asound": true
-      }
-    },
-    "games": {}
-  },
   "profiles": {
     "default": {
       "label": "Default",

--- a/system_files/usr/share/armada/game-tweaks.json
+++ b/system_files/usr/share/armada/game-tweaks.json
@@ -1,0 +1,20 @@
+{
+  "global": {
+    "cores": null,
+    "fexProfile": "default",
+    "gamescopeCores": null,
+    "gamescopeNice": -20,
+    "gamescopeRr": false,
+    "gamescopeVulkanRealtime": true,
+    "nice": 0,
+    "scheduler": "eevdf",
+    "thunks": {
+      "Vulkan": true,
+      "GL": true,
+      "drm": true,
+      "WaylandClient": true,
+      "asound": true
+    },
+    "wineTopology": true
+  }
+}

--- a/system_files/usr/share/gamescope-session-plus/sessions.d/steam
+++ b/system_files/usr/share/gamescope-session-plus/sessions.d/steam
@@ -32,6 +32,14 @@ export STEAM_USE_MANGOAPP=1
 
 export STEAM_USE_DYNAMIC_VRS=1
 
+# Gamescope selects Vulkan queue priority before the runtime policy is published.
+_armada_game_tweaks="${ARMADA_GAME_TWEAKS_HELPER:-/usr/libexec/armada/armada-game-tweaks}"
+_armada_vulkan_realtime="$("$_armada_game_tweaks" get global.gamescopeVulkanRealtime 2>/dev/null)"
+if [[ "$_armada_vulkan_realtime" == true ]]; then
+    export GAMESCOPE_FORCE_VULKAN_REALTIME=1
+fi
+unset _armada_game_tweaks _armada_vulkan_realtime
+
 # Set up first time bootstrap status
 export STEAM_BOOTSTRAP_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/gamescope/bootstrap.cfg"
 

--- a/tests/odin3-hdr-session-test.sh
+++ b/tests/odin3-hdr-session-test.sh
@@ -1,21 +1,48 @@
 #!/usr/bin/env bash
 
+# HDR advertisement no longer lives in the session file: a nonzero
+# ARMADA_HDR_NITS from the device conf (published by device-env) makes
+# gamescope-session export the panel device id, and the gamescope lua
+# profile supplies the panel capabilities. Steam owns runtime HDR state,
+# so nothing may force ENABLE_GAMESCOPE_HDR.
+
 set -euo pipefail
 
 ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 SESSION="$ROOT/system_files/usr/share/gamescope-session-plus/sessions.d/steam"
+DEVICES="$ROOT/system_files/usr/lib/armada/devices"
+DEVICE_ENV="$ROOT/system_files/usr/libexec/armada/device-env"
+PANEL_LUA="$ROOT/system_files/usr/share/gamescope/scripts/10-armada/ayn.icna3520.oled.lua"
 
 if grep -Fq 'ENABLE_GAMESCOPE_HDR=' "$SESSION"; then
     printf 'Odin 3 session still force-enables HDR output\n' >&2
     exit 1
 fi
 
-for assignment in \
-    'GAMESCOPE_INTERNAL_DEVICE_ID="$ARMADA_DEVICE_ID"' \
-    'GAMESCOPE_EXPOSE_CLIENT_SAMPLEABLE_FORMATS=1' \
-    'GAMESCOPE_HDR_ITM_TARGET_NITS=650'; do
-    if ! grep -Fq "$assignment" "$SESSION"; then
-        printf 'missing Odin 3 HDR session assignment: %s\n' "$assignment" >&2
+for device in ayn-odin-3 ayn-thor; do
+    if ! grep -Fxq 'ARMADA_HDR_NITS=650' "$DEVICES/$device.conf"; then
+        printf '%s.conf does not advertise ARMADA_HDR_NITS=650\n' "$device" >&2
+        exit 1
+    fi
+done
+
+if ! grep -Fxq 'ARMADA_HDR_NITS=0' "$DEVICES/defaults.conf"; then
+    printf 'defaults.conf no longer disables HDR by default\n' >&2
+    exit 1
+fi
+
+if ! grep -Fq 'ARMADA_HDR_NITS' "$DEVICE_ENV"; then
+    printf 'device-env does not publish ARMADA_HDR_NITS\n' >&2
+    exit 1
+fi
+
+for needle in \
+    'display.device_id == "ayn-odin-3"' \
+    'display.device_id == "ayn-thor"' \
+    'supported = true' \
+    'max_content_light_level = 650'; do
+    if ! grep -Fq "$needle" "$PANEL_LUA"; then
+        printf 'ICNA3520 panel profile missing: %s\n' "$needle" >&2
         exit 1
     fi
 done

--- a/tests/perf-settings-test.sh
+++ b/tests/perf-settings-test.sh
@@ -14,12 +14,24 @@ ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
+# Pin the tweaks key published by the plugin for the session consumer.
+grep -Fq 'nextTweaks.global.gamescopeVulkanRealtime = on' \
+    "$ROOT/decky/armada-control/src/tabs/Compatibility.tsx" || {
+    printf 'FAIL: plugin no longer writes global.gamescopeVulkanRealtime\n' >&2
+    exit 1
+}
+
 TWEAKS_FIXTURE="$WORK/game-tweaks.json"
+TWEAKS_DEFAULTS_FIXTURE="$ROOT/system_files/usr/share/armada/game-tweaks.json"
+TWEAKS_HELPER="$ROOT/system_files/usr/libexec/armada/armada-game-tweaks"
 SESSION_FILE="$ROOT/system_files/usr/share/gamescope-session-plus/sessions.d/steam"
-SESSION_REALTIME_BLOCK="$(sed -n '/^_armada_tweaks_config=/,/^unset _armada_tweaks_config$/p' "$SESSION_FILE")"
+SESSION_REALTIME_BLOCK="$(sed -n '/^_armada_game_tweaks=/,/^unset _armada_game_tweaks/p' "$SESSION_FILE")"
 
 session_realtime_value() {
     env -u GAMESCOPE_FORCE_VULKAN_REALTIME ARMADA_TWEAKS_CONFIG="$TWEAKS_FIXTURE" \
+        ARMADA_TWEAKS_DEFAULTS_CONFIG="$TWEAKS_DEFAULTS_FIXTURE" \
+        ARMADA_GAME_TWEAKS_HELPER="$TWEAKS_HELPER" \
+        ARMADA_GAME_TWEAKS_LIB="$ROOT/system_files/usr/lib/armada" \
         bash -c "$SESSION_REALTIME_BLOCK"$'\n''printf "%s" "${GAMESCOPE_FORCE_VULKAN_REALTIME:-}"'
 }
 
@@ -34,8 +46,8 @@ printf '{"global":{"gamescopeVulkanRealtime":false}}\n' > "$TWEAKS_FIXTURE"
     exit 1
 }
 printf '{"global":{}}\n' > "$TWEAKS_FIXTURE"
-[[ -z "$(session_realtime_value)" ]] || {
-    printf 'FAIL: absent session setting exported realtime queue request\n' >&2
+[[ "$(session_realtime_value)" == 1 ]] || {
+    printf 'FAIL: absent session setting did not inherit factory realtime policy\n' >&2
     exit 1
 }
 
@@ -54,9 +66,14 @@ import time
 ROOT, WORK = sys.argv[1], sys.argv[2]
 LIB = os.path.join(ROOT, "system_files/usr/lib/armada")
 LIBEXEC = os.path.join(ROOT, "system_files/usr/libexec/armada")
+TWEAKS_DEFAULTS = os.path.join(ROOT, "system_files/usr/share/armada/game-tweaks.json")
 sys.path.insert(0, LIB)
 
 import armada_perf as ap
+import armada_game_tweaks as gt
+
+gt.DEFAULTS_CONFIG = pathlib.Path(TWEAKS_DEFAULTS)
+gt.OVERRIDES_CONFIG = pathlib.Path(WORK) / "missing-game-tweaks.json"
 
 failures = []
 
@@ -111,6 +128,7 @@ check("nice clamped", clean["nice"] == ap.NICE_MIN)
 check("gamescope nice clamped", clean["gamescopeNice"] == ap.GAMESCOPE_NICE_MAX)
 check("bad cores dropped", "cores" not in clean)
 check("wineTopology false kept", clean["wineTopology"] is False)
+check("wineTopology true kept", ap.sanitize_perf({"wineTopology": True})["wineTopology"] is True)
 check("unset keys stay absent", ap.sanitize_perf({}, ENV) == {})
 
 state = {"global": {"gamescopeNice": -5, "gamescopeCores": [3, 4, 5, 6, 7]},
@@ -119,23 +137,72 @@ eff = ap.effective_state(state)
 check("override all clears restrictive global", eff["gamescopeCores"] == ALL)
 check("global survives where override silent", eff["gamescopeNice"] == -5)
 check("override wins", eff["gamescopeRr"] is True)
+factory_tweaks = gt.load()
+factory_global = factory_tweaks["global"]
+check("factory declares every displayed default", set(factory_global) == {
+    "cores", "fexProfile", "gamescopeCores", "gamescopeNice", "gamescopeRr",
+    "gamescopeVulkanRealtime", "nice", "scheduler", "thunks", "wineTopology",
+})
+check("factory FEX profile loaded", factory_global["fexProfile"] == "default")
+check("factory core masks are unset",
+      factory_global["cores"] is None and factory_global["gamescopeCores"] is None)
+check("factory game policy loaded",
+      factory_global["nice"] == 0 and factory_global["wineTopology"] is True)
+check("factory gamescope policy loaded",
+      factory_global["gamescopeNice"] == -20 and factory_global["gamescopeRr"] is False and
+      factory_global["gamescopeVulkanRealtime"] is True)
+check("factory scheduler loaded", factory_global["scheduler"] == "eevdf")
+check("factory thunk defaults loaded",
+      set(factory_global["thunks"]) == {"Vulkan", "GL", "drm", "WaylandClient", "asound"} and
+      all(factory_global["thunks"].values()))
+factory_perf = ap.sanitize_perf(factory_tweaks["global"], ENV)
+check("gamescope nice defaults to -20",
+      factory_perf["gamescopeNice"] == -20)
+helper_env = {
+    **os.environ,
+    "ARMADA_GAME_TWEAKS_LIB": LIB,
+    "ARMADA_TWEAKS_DEFAULTS_CONFIG": TWEAKS_DEFAULTS,
+    "ARMADA_TWEAKS_CONFIG": os.path.join(WORK, "game-tweaks.json"),
+}
+helper_dump = json.loads(subprocess.check_output(
+    [os.path.join(LIBEXEC, "armada-game-tweaks"), "dump"],
+    env=helper_env, text=True))
+check("game-tweaks helper uses shared merge", helper_dump == factory_tweaks)
+
+gt.OVERRIDES_CONFIG.write_text(json.dumps({
+    "global": {
+        "fexProfile": "fast",
+        "gamescopeNice": 0,
+        "gamescopeVulkanRealtime": False,
+    },
+}), encoding="utf-8")
+overlaid_global = gt.load()["global"]
+check("user values override factory defaults",
+      overlaid_global["fexProfile"] == "fast" and
+      overlaid_global["gamescopeNice"] == 0 and
+      overlaid_global["gamescopeVulkanRealtime"] is False)
+check("absent user values inherit factory defaults",
+      overlaid_global["scheduler"] == "eevdf" and
+      overlaid_global["gamescopeRr"] is False and
+      overlaid_global["wineTopology"] is True)
+gt.OVERRIDES_CONFIG.unlink()
 
 tweaks = {"global": {"fexProfile": "default", "nice": -3},
           "games": {"620": {"nice": 0, "cores": "big"},
                     "999": {"enabled": False, "nice": -9}}}
-merged = ap.merged_settings(tweaks, "620")
+merged = gt.merged_settings(tweaks, "620")
 check("per-game overrides global", merged["nice"] == 0 and merged["cores"] == "big")
 check("global key survives merge", merged["fexProfile"] == "default")
-check("enabled:false game skipped", ap.merged_settings(tweaks, "999")["nice"] == -3)
+check("enabled:false game skipped", gt.merged_settings(tweaks, "999")["nice"] == -3)
 
 # env is additive per-entry with null tombstones (lib AND wrapper copies)
 env_tweaks = {"global": {"env": {"A": "1", "B": "2"}},
               "games": {"620": {"env": {"B": "override", "C": "3", "A": None}}}}
-merged_env = ap.merged_settings(env_tweaks, "620")["env"]
+merged_env = gt.merged_settings(env_tweaks, "620")["env"]
 check("env additive: game adds", merged_env.get("C") == "3")
 check("env additive: game overrides entry", merged_env.get("B") == "override")
 check("env tombstone removes global var", "A" not in merged_env)
-check("env global-only view intact", ap.merged_settings(env_tweaks, None)["env"] == {"A": "1", "B": "2"})
+check("env global-only view intact", gt.merged_settings(env_tweaks, None)["env"] == {"A": "1", "B": "2"})
 
 # --- armada-game-launch: FEX path unchanged by perf keys --------------------
 os.environ["XDG_CACHE_HOME"] = WORK
@@ -154,15 +221,15 @@ saved_path = os.environ.get("PATH")
 try:
     os.environ["PATH"] = "/steam/runtime/bin"
     launch.prepare_appimage_path(["/steam-launch-wrapper", "--", str(appimage)])
-    check("AppImage command chain gets standard PATH",
-          os.environ["PATH"] == "/steam/runtime/bin:/usr/local/bin:/usr/bin:/bin")
+    check("AppImage command chain gets system PATH first",
+          os.environ["PATH"] == "/usr/bin:/usr/local/bin:/bin:/steam/runtime/bin")
     os.environ["PATH"] = "/steam/runtime/bin"
     launch.prepare_appimage_path(["/steam-launch-wrapper", "--", str(not_appimage)])
     check("non-AppImage PATH unchanged", os.environ["PATH"] == "/steam/runtime/bin")
-    os.environ["PATH"] = "/usr/bin:/steam/runtime/bin:/bin"
+    os.environ["PATH"] = "/steam/runtime/bin:/bin"
     launch.prepare_appimage_path([str(appimage)])
-    check("existing PATH order preserved",
-          os.environ["PATH"] == "/usr/bin:/steam/runtime/bin:/bin:/usr/local/bin")
+    check("existing PATH preserved as suffix",
+          os.environ["PATH"] == "/usr/bin:/usr/local/bin:/bin:/steam/runtime/bin:/bin")
 finally:
     if saved_path is None:
         os.environ.pop("PATH", None)
@@ -173,7 +240,10 @@ base_fex = os.path.join(WORK, "base-fex.json")
 with open(base_fex, "w") as f:
     json.dump({"Config": {"TSOEnabled": "1"}, "ThunksDB": {"Vulkan": 1, "GL": 1}}, f)
 launch.BASE_FEX_CONFIG = __import__("pathlib").Path(base_fex)
-profiles = {"default": {"config": {"Multiblock": "0"}}}
+profiles = {
+    "default": {"config": {"Multiblock": "0"}},
+    "fast": {"config": {"Multiblock": "1"}},
+}
 
 
 def fex_result(settings):
@@ -190,6 +260,8 @@ _, with_perf = fex_result({"fexProfile": "default", "cores": "big", "nice": -5,
                            "env": {"X": "1"}, "wineTopology": False})
 check("FEX config unaffected by perf keys", plain == with_perf)
 check("FEX config content sane", plain["Config"]["Multiblock"] == "0")
+check("missing profile uses safety fallback",
+      launch.resolve_fex_config({}, profiles)["Multiblock"] == "0")
 
 # --- armada-game-launch: explicit affinity reset ----------------------------
 saved = os.sched_getaffinity(0)
@@ -231,6 +303,9 @@ odin3 = run_device_env("AYN Odin 3")
 check("device-env SM8750 big", odin3.get("ARMADA_BIG_CORES") == "0-7")
 check("device-env SM8750 prime", odin3.get("ARMADA_PRIME_CORES") == "6-7")
 check("device-env SM8750 irq unrestricted", odin3.get("ARMADA_IRQ_CORES") == "''")
+check("device-env non-SM8250 Proton defaults",
+      odin3.get("ARMADA_PROTON_DEFAULTS") ==
+      "proton-experimental-arm64:proton-stable-arm64:proton-cachyos-11.0-arm64")
 thor = run_device_env("AYN Thor")
 check("device-env SM8550 irq littles", thor.get("ARMADA_IRQ_CORES") == "0-2")
 thor_override = run_device_env("AYN Thor", {"ARMADA_IRQ_CORES": ""})
@@ -239,6 +314,10 @@ check("device-env explicit-empty override honored",
 pocket_ds = run_device_env("AYANEO Pocket DS")
 check("device-env Pocket DS enables sync suspend",
       pocket_ds.get("ARMADA_SYNC_SUSPEND") == "1")
+pocket5 = run_device_env("Retroid Pocket 5")
+check("device-env SM8250 Proton defaults",
+      pocket5.get("ARMADA_PROTON_DEFAULTS") ==
+      "proton-cachyos-11.0-arm64")
 
 # --- armada-powerd: config parsing ------------------------------------------
 powerd = load_script("armada-powerd")
@@ -272,7 +351,7 @@ check("irq bad falls back to all", power.irq_mask() == full_mask)
 
 # --- armada-control: PerfManager lifecycle ----------------------------------
 control = load_script("armada-control")
-ap.TWEAKS_CONFIG = ap.pathlib.Path(os.path.join(WORK, "game-tweaks.json"))
+gt.OVERRIDES_CONFIG = pathlib.Path(os.path.join(WORK, "game-tweaks.json"))
 ap.STATE_FILE = ap.pathlib.Path(os.path.join(WORK, "perf-state.json"))
 ap.device_env = lambda: dict(ENV)
 
@@ -286,7 +365,7 @@ try:
 finally:
     control.run = real_control_run
 
-with ap.TWEAKS_CONFIG.open("w") as f:
+with gt.OVERRIDES_CONFIG.open("w") as f:
     json.dump({"global": {"gamescopeNice": -5},
                "games": {"620": {"gamescopeRr": True, "scheduler": "cosmos",
                                  "cores": "big", "nice": -4}}}, f)
@@ -308,7 +387,7 @@ try:
     check("pidfd armed", manager.pidfd is not None)
 
     # live tweaks edit rebuilds the override instead of dropping it
-    with ap.TWEAKS_CONFIG.open("w") as f:
+    with gt.OVERRIDES_CONFIG.open("w") as f:
         json.dump({"global": {"gamescopeNice": -5},
                    "games": {"620": {"gamescopeRr": False, "scheduler": "lavd"}}}, f)
     manager.refresh(keep_override=True)
@@ -509,6 +588,35 @@ check("perf_tick contains exceptions", True)
 # --- plugin: tweaks sanitize keeps the flat perf keys -----------------------
 sys.path.insert(0, os.path.join(ROOT, "decky/armada-control/py_modules"))
 from armada_control import tweaks as plugin_tweaks
+
+gt.OVERRIDES_CONFIG = pathlib.Path(WORK) / "missing-plugin-tweaks.json"
+plugin_defaults = plugin_tweaks.load_tweaks()
+check("plugin loads factory gamescope nice", plugin_defaults["global"]["gamescopeNice"] == -20)
+check("plugin loads factory Vulkan realtime",
+      plugin_defaults["global"]["gamescopeVulkanRealtime"] is True)
+gt.OVERRIDES_CONFIG.write_text(json.dumps({
+    "games": {"620": {"enabled": False, "nice": -5}},
+}), encoding="utf-8")
+disabled_game = plugin_tweaks.load_tweaks()["games"]["620"]
+check("plugin preserves disabled games",
+      disabled_game == {"enabled": False, "nice": -5})
+check("plugin saves disabled games unchanged",
+      plugin_tweaks.tweak_overrides(plugin_tweaks.load_tweaks())["games"]["620"] ==
+      {"enabled": False, "nice": -5})
+gt.OVERRIDES_CONFIG.unlink()
+overrides = plugin_tweaks.tweak_overrides({
+    "global": factory_global,
+    "games": {},
+})
+check("factory values stay out of user overrides", overrides["global"] == {})
+overrides = plugin_tweaks.tweak_overrides({
+    "global": {**factory_global, "fexProfile": "fast", "gamescopeNice": 0,
+               "gamescopeVulkanRealtime": False},
+    "games": {},
+})
+check("factory deviations remain explicit",
+      overrides["global"] == {"fexProfile": "fast", "gamescopeNice": 0,
+                              "gamescopeVulkanRealtime": False})
 
 clean = plugin_tweaks.sanitize_tweaks({
     "global": {"gamescopeNice": -5, "cores": "big"},

--- a/tests/perf-settings-test.sh
+++ b/tests/perf-settings-test.sh
@@ -305,7 +305,7 @@ check("device-env SM8750 prime", odin3.get("ARMADA_PRIME_CORES") == "6-7")
 check("device-env SM8750 irq unrestricted", odin3.get("ARMADA_IRQ_CORES") == "''")
 check("device-env non-SM8250 Proton defaults",
       odin3.get("ARMADA_PROTON_DEFAULTS") ==
-      "proton-experimental-arm64:proton-stable-arm64:proton-cachyos-11.0-arm64")
+      "proton-experimental-arm64:proton_11-arm64:proton-cachyos-11.0-arm64")
 thor = run_device_env("AYN Thor")
 check("device-env SM8550 irq littles", thor.get("ARMADA_IRQ_CORES") == "0-2")
 thor_override = run_device_env("AYN Thor", {"ARMADA_IRQ_CORES": ""})
@@ -631,6 +631,44 @@ try:
     check("oversize tweaks rejected", False)
 except ValueError:
     pass
+
+plugin_tweaks.COMPAT_APPLIED_STATE = pathlib.Path(WORK) / "compat-applied.json"
+legacy_state = plugin_tweaks.load_compat_applied()
+check("missing compat state is normalized",
+      legacy_state == {"appids": [], "protonDefault": ""})
+plugin_tweaks.COMPAT_APPLIED_STATE.write_text(
+    json.dumps({"appids": ["620"]}), encoding="utf-8")
+legacy_state = plugin_tweaks.load_compat_applied()
+check("legacy compat state has no recorded factory default",
+      legacy_state == {"appids": ["620"], "protonDefault": ""})
+plugin_tweaks.COMPAT_APPLIED_STATE.write_text(json.dumps({
+    "appids": ["620", 620, "bad"],
+    "protonDefault": "proton-cachyos-11.0-arm64",
+}), encoding="utf-8")
+loaded_state = plugin_tweaks.load_compat_applied()
+check("compat state loads appids and factory default",
+      loaded_state == {"appids": ["620"],
+                       "protonDefault": "proton-cachyos-11.0-arm64"})
+compat_writes = []
+real_plugin_call = plugin_tweaks.call
+plugin_tweaks.call = lambda action, **payload: compat_writes.append((action, payload))
+try:
+    saved_state = plugin_tweaks.save_compat_applied(["9", "2", "bad"])
+    saved_payload = json.loads(compat_writes[-1][1]["text"])
+    check("appid-only save preserves factory default",
+          saved_state == saved_payload == {
+              "appids": ["2", "9"],
+              "protonDefault": "proton-cachyos-11.0-arm64",
+          })
+    saved_state = plugin_tweaks.save_compat_applied(["9"], "proton-experimental-arm64")
+    saved_payload = json.loads(compat_writes[-1][1]["text"])
+    check("startup save advances factory default",
+          saved_state == saved_payload == {
+              "appids": ["9"],
+              "protonDefault": "proton-experimental-arm64",
+          })
+finally:
+    plugin_tweaks.call = real_plugin_call
 
 # --- plugin: power render with editable governor ----------------------------
 sys.path.insert(0, os.path.join(ROOT, "decky/armada-control/py_modules"))


### PR DESCRIPTION
- New system for shipping defaults to game tweaks, including performance setttings.
- Default Vulkan Realtime on and Gamescope to nice -20.
- Add ARMADA_PROTON_DEFAULTS to device quirks and change default for non-SM8250 devices to Proton Experimental.