### PR TITLE
fix(installer): preserve bootc refs during local install

### DIFF
--- a/system_files/usr/lib/armada/update-lib
+++ b/system_files/usr/lib/armada/update-lib
@@ -40,7 +40,11 @@ armada_tag_from_ref() {
 
 # Exact repository matches prevent lookalike names from being trusted.
 armada_registry_from_ref() {
-    local r="${1##*://}"
+    local r="$1"
+    case "$r" in
+        ostree-unverified-registry:*) r="${r#ostree-unverified-registry:}" ;;
+    esac
+    r="${r##*://}"
     r="${r%%@*}"
     [[ "${r##*/}" == *:* ]] && r="${r%:*}"
     case "$r" in
@@ -52,9 +56,11 @@ armada_registry_from_ref() {
 armada_repository_from_ref() {
     local r
     case "$1" in
+        ostree-unverified-registry:*) r="${1#ostree-unverified-registry:}" ;;
         *docker://*) r="${1##*docker://}" ;;
         *) return 1 ;;
     esac
+    r="${r##*docker://}"
     r="${r%%@*}"
     [[ "${r##*/}" == *:* ]] && r="${r%:*}"
     [[ -n "$r" && "$r" == */* && "$r" != *[[:space:]]* ]] || return 1

--- a/system_files/usr/libexec/armada/armada-installer
+++ b/system_files/usr/libexec/armada/armada-installer
@@ -424,25 +424,109 @@ set_origin() {
 }
 
 copy_bootc_ref() {
-    local ref="$1" target_commit="$2"
-    ostree refs --repo="$TARGET/ostree/repo" --force --create="$ref" "$target_commit"
+    local ref="$1"
+    ostree pull-local --repo="$TARGET/ostree/repo" /sysroot/ostree/repo "$ref"
 }
 
 copy_current_bootc_deployment() {
-    local parent ref target_commit
+    local parent ref target_commit manifest blob_refs image_refs
+    local image_ref_count=0
+    local -a required_refs=("$commit")
 
-    ostree pull-local --repo="$TARGET/ostree/repo" /sysroot/ostree/repo "$commit"
+    copy_bootc_ref "$commit" || {
+        echo "ERROR: could not copy booted deployment commit $commit" >&2
+        return 1
+    }
 
     parent=$(ostree show --repo=/sysroot/ostree/repo "$commit" |
         sed -n 's/^Parent:[[:space:]]*//p' | head -n1)
-    [[ -n $parent ]] && ostree pull-local --repo="$TARGET/ostree/repo" /sysroot/ostree/repo "$parent"
+    if [[ -n $parent ]]; then
+        copy_bootc_ref "$parent" || {
+            echo "ERROR: could not copy container-image parent commit $parent" >&2
+            return 1
+        }
+        required_refs+=("$parent")
+    fi
 
+    # Generic OCI layers are cached as independent commits. The final image commit
+    # does not reference them through OSTree history, but bootc still requires each
+    # manifest layer's blob ref to read deployment metadata and reuse cached layers.
+    if ! manifest=$(ostree show --repo=/sysroot/ostree/repo \
+        --print-metadata-key=ostree.manifest "$commit" 2>/dev/null); then
+        [[ -n $parent ]] || {
+            echo "ERROR: booted commit has no container manifest" >&2
+            return 1
+        }
+        manifest=$(ostree show --repo=/sysroot/ostree/repo \
+            --print-metadata-key=ostree.manifest "$parent") || {
+            echo "ERROR: container-image parent has no manifest" >&2
+            return 1
+        }
+    fi
+    # ostree prints string metadata in GVariant form, including outer quotes.
+    manifest=${manifest#\'}
+    manifest=${manifest%\'}
+    blob_refs=$(jq -er '
+        .layers as $layers
+        | if ($layers | type) != "array" or ($layers | length) == 0 then
+              error("container manifest has no layers")
+          else
+              $layers
+              | map(
+                  .digest
+                  | if type == "string" and test("^sha256:[0-9a-f]{64}$") then
+                        "ostree/container/blob/" + sub(":"; "_3A_")
+                    else
+                        error("invalid container layer digest")
+                    end
+                )
+              | unique[]
+          end
+    ' <<<"$manifest") || {
+        echo "ERROR: could not read container layer refs from booted commit" >&2
+        return 1
+    }
     while IFS= read -r ref; do
+        copy_bootc_ref "$ref" || {
+            echo "ERROR: could not copy bootc layer ref $ref" >&2
+            return 1
+        }
+        required_refs+=("$ref")
+    done <<<"$blob_refs"
+
+    # A source with a staged update may have image refs for multiple commits. Copy
+    # only refs for the deployment being installed (or its container-image parent).
+    image_refs=$(ostree refs --repo=/sysroot/ostree/repo |
+        sed -n 's#^\(ostree/container/image/.*\)#\1#p') || {
+        echo "ERROR: could not list container image refs" >&2
+        return 1
+    }
+    while IFS= read -r ref; do
+        [[ -n $ref ]] || continue
         target_commit=$(ostree rev-parse --repo=/sysroot/ostree/repo "$ref" 2>/dev/null || true)
         if [[ $target_commit == "$commit" || ( -n $parent && $target_commit == "$parent" ) ]]; then
-            copy_bootc_ref "$ref" "$target_commit"
+            copy_bootc_ref "$ref" || {
+                echo "ERROR: could not copy bootc image ref $ref" >&2
+                return 1
+            }
+            required_refs+=("$ref")
+            image_ref_count=$((image_ref_count + 1))
         fi
-    done < <(ostree refs --repo=/sysroot/ostree/repo | sed -n 's#^\(ostree/container/\(image\|blob\)/.*\)#\1#p')
+    done <<<"$image_refs"
+
+    if (( image_ref_count == 0 )); then
+        echo "ERROR: no container image ref matches the booted deployment" >&2
+        return 1
+    fi
+
+    # Do not create a boot entry for a partial copy. In particular, a deployment
+    # can boot without these layer refs while `bootc status` and upgrades are broken.
+    for ref in "${required_refs[@]}"; do
+        ostree rev-parse --repo="$TARGET/ostree/repo" "$ref" >/dev/null 2>&1 || {
+            echo "ERROR: copied bootc ref is missing from target repository: $ref" >&2
+            return 1
+        }
+    done
 }
 
 seed_kernel() {

--- a/tests/installer-bootc-refs-test.sh
+++ b/tests/installer-bootc-refs-test.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALLER="$ROOT/system_files/usr/libexec/armada/armada-installer"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+assert_logged() {
+    grep -Fxq "$1" "$WORK/log" || fail "missing operation: $1"
+}
+assert_not_logged() {
+    grep -Fxq "$1" "$WORK/log" && fail "unexpected operation: $1"
+    return 0
+}
+pulled_marker() {
+    printf '%s/pulled-%s' "$WORK" "${1//\//_}"
+}
+
+commit=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+layer_one=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+layer_two=cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+unrelated=dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+blob_one="ostree/container/blob/sha256_3A_${layer_one}"
+blob_two="ostree/container/blob/sha256_3A_${layer_two}"
+image_ref=ostree/container/image/docker_3A__2F__2F_ghcr_2E_io/armada-os/armada_3A_testing
+other_image=ostree/container/image/docker_3A__2F__2F_example_2E_invalid/os_3A_latest
+TARGET="$WORK/target"
+mkdir -p "$TARGET/ostree/repo"
+: > "$WORK/log"
+
+ostree() {
+    local command="$1" ref
+    shift
+    case "$command" in
+        pull-local)
+            ref="${*: -1}"
+            printf 'pull %s\n' "$ref" >> "$WORK/log"
+            [[ $ref != "$blob_two" || ! -e $WORK/fail-layer-two ]] || return 1
+            [[ $ref != "$blob_two" || ! -e $WORK/drop-layer-two ]] || return 0
+            touch "$(pulled_marker "$ref")"
+            ;;
+        show)
+            if [[ " $* " == *" --print-metadata-key=ostree.manifest "* ]]; then
+                printf "'{\"schemaVersion\":2,\"layers\":[{\"digest\":\"sha256:%s\"},{\"digest\":\"sha256:%s\"}]}'\n" \
+                    "$layer_one" "$layer_two"
+            else
+                printf 'commit %s\n' "$commit"
+            fi
+            ;;
+        refs)
+            [[ ! -e $WORK/no-image-ref ]] || return 0
+            printf '%s\n' "$blob_one" "$blob_two" "$image_ref" "$other_image"
+            ;;
+        rev-parse)
+            ref="${*: -1}"
+            if [[ " $* " == *" --repo=$TARGET/ostree/repo "* ]]; then
+                [[ -e $(pulled_marker "$ref") ]] || return 1
+                printf '%s\n' "$ref"
+                return 0
+            fi
+            case "$ref" in
+                "$image_ref") printf '%s\n' "$commit" ;;
+                "$other_image") printf '%s\n' "$unrelated" ;;
+                *) return 1 ;;
+            esac
+            ;;
+        *) fail "unexpected ostree command: $command $*" ;;
+    esac
+}
+
+# Exercise the shipped functions without running the installer's command dispatch.
+eval "$(sed -n '/^copy_bootc_ref()/,/^seed_kernel()/p' "$INSTALLER" | sed '$d')"
+
+copy_current_bootc_deployment
+assert_logged "pull $commit"
+assert_logged "pull $blob_one"
+assert_logged "pull $blob_two"
+assert_logged "pull $image_ref"
+assert_not_logged "pull $other_image"
+
+# A missing layer commit must abort rather than leave a bootc deployment that boots
+# but cannot compute status or upgrade.
+rm -f "$WORK"/pulled-*
+: > "$WORK/log"
+touch "$WORK/fail-layer-two"
+if copy_current_bootc_deployment >/dev/null 2>&1; then
+    fail "missing manifest layer unexpectedly succeeded"
+fi
+assert_not_logged "pull $image_ref"
+rm -f "$WORK/fail-layer-two"
+
+# Successful pull output is not enough: verify that every expected ref actually
+# resolves in the destination before allowing the install to continue.
+rm -f "$WORK"/pulled-*
+: > "$WORK/log"
+touch "$WORK/drop-layer-two"
+if copy_current_bootc_deployment >/dev/null 2>&1; then
+    fail "missing target layer ref unexpectedly succeeded validation"
+fi
+rm -f "$WORK/drop-layer-two"
+
+# Without the image ref, the copied commit is not a complete bootc deployment.
+rm -f "$WORK"/pulled-*
+: > "$WORK/log"
+touch "$WORK/no-image-ref"
+if copy_current_bootc_deployment >/dev/null 2>&1; then
+    fail "deployment without a matching image ref unexpectedly succeeded"
+fi
+rm -f "$WORK/no-image-ref"
+
+printf 'installer bootc ref tests passed\n'

--- a/tests/update-migration-test.sh
+++ b/tests/update-migration-test.sh
@@ -21,6 +21,8 @@ assert_registry "$ARMADA_CANONICAL_REGISTRY" \
     "ostree-image-signed:docker://${ARMADA_CANONICAL_REGISTRY}@sha256:deadbeef"
 assert_registry "$ARMADA_CANONICAL_REGISTRY" \
     "docker://${ARMADA_CANONICAL_REGISTRY}:testing"
+assert_registry "$ARMADA_CANONICAL_REGISTRY" \
+    "ostree-unverified-registry:${ARMADA_CANONICAL_REGISTRY}:testing"
 assert_registry "" \
     "ostree-image-signed:docker://example.invalid/${ARMADA_LEGACY_REGISTRY}:stable"
 
@@ -36,6 +38,8 @@ assert_repository() {
 
 assert_repository "local.armadaos.dev/armada" \
     "ostree-unverified-registry:docker://local.armadaos.dev/armada:feature-a"
+assert_repository "$ARMADA_CANONICAL_REGISTRY" \
+    "ostree-unverified-registry:${ARMADA_CANONICAL_REGISTRY}:testing"
 assert_repository "example.invalid/${ARMADA_LEGACY_REGISTRY}" \
     "ostree-image-signed:docker://example.invalid/${ARMADA_LEGACY_REGISTRY}:stable"
 assert_repository "" "containers-storage:localhost/armada:latest"


### PR DESCRIPTION
- Chunkah stores OCI layers as independent OSTree commits that are not reachable through the final deployment commit. The installer previously omitted their blob refs, producing systems that booted but failed bootc status, switch, and upgrade with a missing base image ref.

- Read the booted image manifest, strip OSTree's GVariant quoting, and pull every referenced layer plus the matching container image ref into the target repository. Verify all required refs before creating the deployment so incomplete transfers fail the install.

- Also recognize native ostree-unverified-registry origins when normalizing Armada update references, and add regression coverage for incomplete Chunkah transfers and quoted manifest metadata.