### PR TITLE
Adds Desktop/Mobile switching logic to Dual-Screen

### DIFF
--- a/system_files/usr/libexec/armada/bottom-screen-session
+++ b/system_files/usr/libexec/armada/bottom-screen-session
@@ -6,6 +6,25 @@ if [[ -z "${DISPLAY:-}" ]]; then
     exit 1
 fi
 
+# Use the same saved configs as session-control before Mobile can write settings.
+config_dir="${XDG_CONFIG_HOME:-$HOME/.config}"
+plasma_config="${config_dir}/plasmashellrc"
+install -d -m 0700 "${config_dir}"
+if [[ -e "${plasma_config}" && ! -L "${plasma_config}" ]]; then
+    if [[ -e "${plasma_config}.desktop" || -L "${plasma_config}.desktop" ]]; then
+        echo "refusing to overwrite existing Desktop Plasma configuration" >&2
+        exit 1
+    fi
+    mv "${plasma_config}" "${plasma_config}.desktop"
+fi
+if [[ ! -e "${plasma_config}.mobile" ]]; then
+    install -m 0600 /dev/null "${plasma_config}.mobile"
+fi
+if [[ ! -L "${plasma_config}" || "$(readlink "${plasma_config}")" != plasmashellrc.mobile ]]; then
+    ln -sfn plasmashellrc.mobile "${plasma_config}.new"
+    mv -Tf "${plasma_config}.new" "${plasma_config}"
+fi
+
 dbus_run_session=${ARMADA_DBUS_RUN_SESSION:-/usr/bin/dbus-run-session}
 kwin_wayland=${ARMADA_KWIN_WAYLAND:-/usr/bin/kwin_wayland}
 

--- a/tests/run-bottom-test.sh
+++ b/tests/run-bottom-test.sh
@@ -77,13 +77,22 @@ inner_args="$tmp/inner-args"
 inner_env="$tmp/inner-env"
 printf '%s\n' \
     '#!/usr/bin/env bash' \
+    '[[ "$(readlink "$XDG_CONFIG_HOME/plasmashellrc")" == plasmashellrc.mobile ]] || exit 1' \
+    '[[ -f "$XDG_CONFIG_HOME/plasmashellrc.mobile" ]] || exit 1' \
     'printf '\''%s\n'\'' "${XDG_CURRENT_DESKTOP-unset}" "${XDG_CONFIG_DIRS-unset}" "${DISABLE_GAMESCOPE_WSI-unset}" "${GAMESCOPE_WAYLAND_DISPLAY-unset}" "${GAMESCOPE_LIMITER_FILE-unset}" >"$INNER_ENV"' \
     'printf '\''%s\0'\'' "$@" >"$INNER_ARGS"' \
     >"$dbus_run_session"
 chmod +x "$dbus_run_session"
+config_dir="$tmp/config"
+mkdir -p "$config_dir"
+printf 'saved desktop settings\n' >"$config_dir/plasmashellrc.desktop"
+printf 'saved mobile settings\n' >"$config_dir/plasmashellrc.mobile"
+ln -s plasmashellrc.desktop "$config_dir/plasmashellrc"
+run_bottom_session() {
 env \
     DISPLAY=gamescope-1 \
     HOME=/test/home \
+    XDG_CONFIG_HOME="$config_dir" \
     XDG_CONFIG_DIRS=/test/config \
     DISABLE_GAMESCOPE_WSI=0 \
     GAMESCOPE_WAYLAND_DISPLAY=gamescope-1 \
@@ -93,6 +102,8 @@ env \
     INNER_ARGS="$inner_args" \
     INNER_ENV="$inner_env" \
     "$BOTTOM_SESSION"
+}
+run_bottom_session
 mapfile -d '' -t actual <"$inner_args"
 expected=(
     /test/kwin_wayland
@@ -108,6 +119,37 @@ done
 [[ "$(<"$inner_env")" == $'KDE\n/test/home/.config/plasma-mobile:/etc/xdg:/test/config\n1\nunset\nunset' ]]
 [[ ! " ${actual[*]} " =~ ' --width ' ]]
 [[ ! " ${actual[*]} " =~ ' --height ' ]]
+
+# Starting from Desktop or restarting Mobile must preserve both saved configs.
+run_bottom_session
+[[ "$(<"$config_dir/plasmashellrc.desktop")" == 'saved desktop settings' ]]
+[[ "$(<"$config_dir/plasmashellrc.mobile")" == 'saved mobile settings' ]]
+
+# Older installations may still have a regular active desktop config.
+config_dir="$tmp/legacy-config"
+mkdir -p "$config_dir"
+printf 'legacy desktop settings\n' >"$config_dir/plasmashellrc"
+run_bottom_session
+[[ "$(<"$config_dir/plasmashellrc.desktop")" == 'legacy desktop settings' ]]
+[[ ! -s "$config_dir/plasmashellrc.mobile" ]]
+
+# A fresh profile must also be ready before Plasma launches.
+config_dir="$tmp/fresh-config"
+run_bottom_session
+[[ ! -s "$config_dir/plasmashellrc.mobile" ]]
+
+# Refuse ambiguous migration rather than discarding either desktop config.
+config_dir="$tmp/conflicting-config"
+mkdir -p "$config_dir"
+printf 'active settings\n' >"$config_dir/plasmashellrc"
+printf 'saved settings\n' >"$config_dir/plasmashellrc.desktop"
+if run_bottom_session 2>"$tmp/config-conflict"; then
+    echo 'conflicting desktop configs unexpectedly succeeded' >&2
+    exit 1
+fi
+grep -q 'refusing to overwrite' "$tmp/config-conflict"
+[[ "$(<"$config_dir/plasmashellrc")" == 'active settings' ]]
+[[ "$(<"$config_dir/plasmashellrc.desktop")" == 'saved settings' ]]
 
 if env -u DISPLAY "$BOTTOM_SESSION" 2>"$tmp/no-display"; then
     echo 'bottom session started without DISPLAY' >&2


### PR DESCRIPTION
When switching to desktop mode `session-control` handles swapping between desktop and mobile configs. When adding the bottom screen mobile feature - there is no such logic. As a result - people are ruining their KDE desktop setups. This PR fixes that by also adding the `session-control` logic into the bottom screen service