### PR TITLE
feat(recovery): boot time hotkey service

### DIFF
--- a/build_files/40-vendor-system-files.sh
+++ b/build_files/40-vendor-system-files.sh
@@ -105,6 +105,7 @@ systemctl enable armada-steamos-manager.service
 systemctl --global enable armada-steamos-manager.service
 systemctl enable armada-bootimg-sync.service
 systemctl enable armada-esp-rename.service
+systemctl enable armada-boot-hotkeys.service
 systemctl enable armada-flatpak-setup.service
 systemctl enable armada-waydroid-input.path
 systemctl enable armada-splash-stall.service

--- a/system_files/usr/lib/armada/input-lib
+++ b/system_files/usr/lib/armada/input-lib
@@ -29,3 +29,19 @@ armada_lid_closed() {
     evtest --query "$dev" EV_SW SW_LID >/dev/null 2>&1; rc=$?
     [[ "$rc" -eq 10 ]]
 }
+
+# True if $1 (a /dev/input/eventN path) reports key code $2 in its EV_KEY
+# capability bitmap. The bitmap prints 64-bit groups, most significant first.
+armada_dev_has_key() {
+    local input_class="${ARMADA_INPUT_CLASS:-/sys/class/input}"
+    local cap line words idx
+
+    cap="${input_class}/$(basename "$1")/device/capabilities/key"
+    [[ -r "$cap" ]] || return 1
+    read -r line < "$cap" || return 1
+    read -r -a words <<<"$line"
+    idx=$(( ${#words[@]} - 1 - $2 / 64 ))
+    (( idx >= 0 )) || return 1
+    [[ "${words[idx]}" =~ ^[0-9a-fA-F]+$ ]] || return 1
+    (( 0x${words[idx]} >> ($2 % 64) & 1 ))
+}

--- a/system_files/usr/lib/systemd/system/armada-boot-hotkeys.service
+++ b/system_files/usr/lib/systemd/system/armada-boot-hotkeys.service
@@ -1,7 +1,9 @@
 [Unit]
-Description=Boot-time hotkeys
-After=basic.target armada-session-default.service
+Description=Boot-time hotkeys (hold Select for Desktop Mode)
+DefaultDependencies=no
+After=local-fs.target
 Before=display-manager.service
+Conflicts=shutdown.target
 ConditionPathExists=/usr/libexec/armada/armada-boot-hotkeys
 ConditionPathExists=!/etc/armada/boot-hotkeys-disabled
 
@@ -11,4 +13,4 @@ ExecStart=/usr/libexec/armada/armada-boot-hotkeys
 TimeoutStopSec=5
 
 [Install]
-WantedBy=graphical.target
+WantedBy=sysinit.target

--- a/system_files/usr/lib/systemd/system/armada-boot-hotkeys.service
+++ b/system_files/usr/lib/systemd/system/armada-boot-hotkeys.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Boot-time hotkeys
+After=basic.target armada-session-default.service
+Before=display-manager.service
+ConditionPathExists=/usr/libexec/armada/armada-boot-hotkeys
+ConditionPathExists=!/etc/armada/boot-hotkeys-disabled
+
+[Service]
+Type=simple
+ExecStart=/usr/libexec/armada/armada-boot-hotkeys
+TimeoutStopSec=5
+
+[Install]
+WantedBy=graphical.target

--- a/system_files/usr/libexec/armada/armada-boot-hotkeys
+++ b/system_files/usr/libexec/armada/armada-boot-hotkeys
@@ -1,0 +1,124 @@
+#!/usr/bin/bash
+# Hold a key during the boot splash to change what the device boots into.
+# EVIOCGKEY state, not an event stream: reads through InputPlumber's grab.
+set -uo pipefail
+
+source "${ARMADA_INPUT_LIB:-/usr/lib/armada/input-lib}"
+
+HOLD_MS="${ARMADA_BOOT_HOTKEY_HOLD_MS:-3000}"
+POLL_MS="${ARMADA_BOOT_HOTKEY_POLL_MS:-500}"
+MAX_SECS="${ARMADA_BOOT_HOTKEY_MAX:-600}"
+RESCAN_MS="${ARMADA_BOOT_HOTKEY_RESCAN_MS:-5000}"
+CEF_PORT="${ARMADA_SPLASH_CEF_PORT:-8080}"
+SESSION_CONTROL="${ARMADA_SESSION_CONTROL:-/usr/libexec/armada/session-control}"
+STATUS="${ARMADA_SPLASH_STATUS:-/run/armada/splash/status}"
+PROGRESS="${ARMADA_SPLASH_PROGRESS:-/usr/libexec/armada/armada-splash-progress}"
+RECOVERY_MARKER="${ARMADA_RECOVERY_MARKER:-/run/armada/recovery-mode}"
+INPUT_DEV_DIR="${ARMADA_INPUT_DEV_DIR:-/dev/input}"
+
+log() { logger -t armada-boot-hotkeys -- "$*" 2>/dev/null; return 0; }
+
+# One write at the switch; anything needing restore races armada-splash-run.
+announce() { [[ -x "$PROGRESS" ]] && ARMADA_SPLASH_STATUS="$STATUS" "$PROGRESS" "$@"; return 0; }
+
+action_desktop() {
+    announce "Starting Desktop"
+    # Runtime marker distinguishing a hotkey boot from a chosen one.
+    : > "$RECOVERY_MARKER" 2>/dev/null
+    if systemctl is-active --quiet display-manager.service 2>/dev/null; then
+        "$SESSION_CONTROL" switch-desktop
+        return
+    fi
+    # session-control clears the failure state, so a failed sddm has to be
+    # started here; checked before that reset, not after.
+    local was_failed=0
+    systemctl is-failed --quiet display-manager.service 2>/dev/null && was_failed=1
+    "$SESSION_CONTROL" default-desktop
+    (( was_failed )) && systemctl --no-block start display-manager.service
+    return 0
+}
+
+# code:evdev name:label:action. Start because no capability map translates it,
+# so it reaches the raw node unchanged; not a volume key, which ABL owns.
+hotkeys=(
+    "315:BTN_START:Desktop Mode:action_desktop"
+)
+
+(( POLL_MS > 0 )) || POLL_MS=500
+hold_polls=$(( HOLD_MS / POLL_MS ))
+(( hold_polls > 0 )) || hold_polls=1
+rescan_polls=$(( RESCAN_MS / POLL_MS ))
+(( rescan_polls > 0 )) || rescan_polls=1
+sleep_arg=$(printf '%d.%03d' $(( POLL_MS / 1000 )) $(( POLL_MS % 1000 )))
+
+declare -A hotkey_devices=()
+have_devices=0
+
+scan_devices() {
+    local entry code devs dev
+    have_devices=0
+    for entry in "${hotkeys[@]}"; do
+        IFS=: read -r code _ _ _ <<<"$entry"
+        devs=""
+        for dev in "$INPUT_DEV_DIR"/event*; do
+            [[ -e "$dev" ]] || continue
+            armada_dev_has_key "$dev" "$code" && devs+=" $dev"
+        done
+        hotkey_devices[$code]="${devs# }"
+        [[ -n "$devs" ]] && have_devices=1
+    done
+}
+
+held_hotkey() {
+    local entry code name dev rc
+    for entry in "${hotkeys[@]}"; do
+        IFS=: read -r code name _ _ <<<"$entry"
+        for dev in ${hotkey_devices[$code]}; do
+            evtest --query "$dev" EV_KEY "$name" >/dev/null 2>&1; rc=$?
+            (( rc == 10 )) && { printf '%s\n' "$entry"; return 0; }
+        done
+    done
+    return 1
+}
+
+# Steam owns this button once up; the gamescope unit goes active too early.
+steam_up() {
+    (exec 3<>"/dev/tcp/127.0.0.1/${CEF_PORT}") 2>/dev/null
+}
+
+current=""
+held=0
+waited=0
+polls=0
+max_ms=$(( MAX_SECS * 1000 ))
+
+while (( waited < max_ms )); do
+    steam_up && exit 0
+    if (( have_devices == 0 || polls % rescan_polls == 0 )); then
+        scan_devices
+    fi
+    polls=$(( polls + 1 ))
+
+    entry=$(held_hotkey) || entry=""
+    if [[ -n "$entry" ]]; then
+        IFS=: read -r _ _ label action <<<"$entry"
+        if [[ "$entry" != "$current" ]]; then
+            current="$entry"
+            held=0
+            log "holding ${label}"
+        fi
+        held=$(( held + 1 ))
+        if (( held > hold_polls )); then
+            log "triggering ${label}"
+            "$action"
+            exit 0
+        fi
+    elif [[ -n "$current" ]]; then
+        log "released before the hold completed"
+        current=""
+        held=0
+    fi
+
+    sleep "$sleep_arg"
+    waited=$(( waited + POLL_MS ))
+done

--- a/system_files/usr/libexec/armada/armada-boot-hotkeys
+++ b/system_files/usr/libexec/armada/armada-boot-hotkeys
@@ -18,13 +18,14 @@ INPUT_DEV_DIR="${ARMADA_INPUT_DEV_DIR:-/dev/input}"
 
 log() { logger -t armada-boot-hotkeys -- "$*" 2>/dev/null; return 0; }
 
-# One write at the switch; anything needing restore races armada-splash-run.
 announce() { [[ -x "$PROGRESS" ]] && ARMADA_SPLASH_STATUS="$STATUS" "$PROGRESS" "$@"; return 0; }
 
 action_desktop() {
     announce "Starting Desktop"
     # Runtime marker distinguishing a hotkey boot from a chosen one.
     : > "$RECOVERY_MARKER" 2>/dev/null
+    # The per-boot gamemode reset must land before this override does.
+    systemctl start armada-session-default.service 2>/dev/null
     if systemctl is-active --quiet display-manager.service 2>/dev/null; then
         "$SESSION_CONTROL" switch-desktop
         return
@@ -38,10 +39,10 @@ action_desktop() {
     return 0
 }
 
-# code:evdev name:label:action. Start because no capability map translates it,
-# so it reaches the raw node unchanged; not a volume key, which ABL owns.
+# code:evdev name:label:action. Select because no capability map translates it,
+# so it reaches the raw node unchanged.
 hotkeys=(
-    "315:BTN_START:Desktop Mode:action_desktop"
+    "314:BTN_SELECT:Desktop Mode:action_desktop"
 )
 
 (( POLL_MS > 0 )) || POLL_MS=500

--- a/system_files/usr/libexec/armada/session-control
+++ b/system_files/usr/libexec/armada/session-control
@@ -123,7 +123,13 @@ case "${1:-}" in
         ;;
     switch-gamemode) session=gamescope-session-steam.desktop ;;
     default-gamemode) session=gamescope-session-steam.desktop; default_only=1 ;;
-    *) echo "usage: $0 {switch-desktop|switch-gamemode|default-gamemode}" >&2; exit 1 ;;
+    default-desktop)
+        initialize_plasma_configs
+        activate_plasma_config "${desktop_mode}"
+        session=$desktop_session
+        default_only=1
+        ;;
+    *) echo "usage: $0 {switch-desktop|switch-gamemode|default-gamemode|default-desktop}" >&2; exit 1 ;;
 esac
 
 printf '[Autologin]\nSession=%s\n' "${session}" > /etc/sddm.conf.d/zz-steamos-autologin.conf

--- a/tests/boot-hotkeys-test.sh
+++ b/tests/boot-hotkeys-test.sh
@@ -17,12 +17,12 @@ BIN="$WORK/bin"; DEV="$WORK/dev"; SYS="$WORK/sys"
 mkdir -p "$BIN" "$DEV" "$SYS"
 export WORK
 
-# event0 has no EV_KEY bitmap at all, event1 carries BTN_START (315), and
-# event2 carries the neighbouring BTN_MODE (316): only event1 may be polled.
+# event0 has no EV_KEY bitmap at all, event1 carries BTN_SELECT (314), and
+# event2 carries the neighbouring BTN_START (315): only event1 may be polled.
 for n in 0 1 2; do : > "$DEV/event$n"; mkdir -p "$SYS/event$n/device/capabilities"; done
 printf '0\n' > "$SYS/event0/device/capabilities/key"
-printf '800000000000000 0 0 0 0\n' > "$SYS/event1/device/capabilities/key"
-printf '1000000000000000 0 0 0 0\n' > "$SYS/event2/device/capabilities/key"
+printf '400000000000000 0 0 0 0\n' > "$SYS/event1/device/capabilities/key"
+printf '800000000000000 0 0 0 0\n' > "$SYS/event2/device/capabilities/key"
 
 cat > "$BIN/evtest" <<'STUB'
 #!/usr/bin/env bash
@@ -56,7 +56,7 @@ STUB
 chmod 0755 "$BIN"/* "$WORK/session-control" "$WORK/progress"
 
 run_hotkeys() {
-    rm -f "$WORK/queried" "$WORK/log" "$WORK/session.log" "$WORK/status.log" "$WORK/systemctl.log" "$WORK/recovery-mode"
+    rm -f "$WORK/queried" "$WORK/log" "$WORK/session.log" "$WORK/systemctl.log" "$WORK/recovery-mode" "$WORK/status.log"
     PATH="$BIN:$PATH" \
     ARMADA_INPUT_LIB="$INPUT_LIB" \
     ARMADA_INPUT_CLASS="$SYS" \
@@ -75,7 +75,6 @@ run_hotkeys() {
 rm -f "$WORK/pressed" "$WORK/dm-active"
 run_hotkeys
 [[ -e "$WORK/session.log" ]] && fail "no hold: switched sessions anyway"
-[[ -e "$WORK/status.log" ]] && fail "no hold: wrote to the splash anyway"
 [[ -e "$WORK/recovery-mode" ]] && fail "no hold: marked recovery mode anyway"
 sort -u "$WORK/queried" > "$WORK/queried.uniq"
 [[ "$(cat "$WORK/queried.uniq")" == "$DEV/event1" ]] \
@@ -85,15 +84,12 @@ sort -u "$WORK/queried" > "$WORK/queried.uniq"
 : > "$WORK/pressed"
 run_hotkeys
 assert_grep "$WORK/session.log" "default-desktop" "pre-sddm hold"
+assert_grep "$WORK/systemctl.log" "start armada-session-default.service" "waits for the autologin reset"
 # The marker is what a desktop recovery tool would key off.
 assert_file "$WORK/recovery-mode" "recovery marker written"
+assert_grep "$WORK/status.log" "Starting Desktop" "splash announce"
 assert_grep "$WORK/log" "holding Desktop Mode" "journal notes the hold"
 assert_grep "$WORK/log" "triggering Desktop Mode" "journal notes the trigger"
-assert_grep "$WORK/status.log" "Starting Desktop" "splash announce"
-# More than one write means a hold prompt crept back in, which is what races
-# armada-splash-run.
-[[ $(wc -l < "$WORK/status.log") == 1 ]] \
-    || fail "expected exactly one splash write, got $(wc -l < "$WORK/status.log")"
 
 # Held once the session is running: restart it the way Steam's own switch does.
 : > "$WORK/dm-active"
@@ -117,15 +113,15 @@ kill "$port_pid" 2>/dev/null || true
 # Fails without the periodic rescan, which is the point of the case.
 rm -f "$WORK/dm-active" "$WORK/dm-failed" "$WORK/session.log"
 printf '%s\n' "$DEV/event2" > "$WORK/pressed-dev"
-printf '800000000000000 0 0 0 0\n' > "$SYS/event1/device/capabilities/key"
+printf '400000000000000 0 0 0 0\n' > "$SYS/event1/device/capabilities/key"
 printf '0\n' > "$SYS/event2/device/capabilities/key"
 ( sleep 0.3
   printf '0\n' > "$SYS/event1/device/capabilities/key"
-  printf '800000000000000 0 0 0 0\n' > "$SYS/event2/device/capabilities/key" ) &
+  printf '400000000000000 0 0 0 0\n' > "$SYS/event2/device/capabilities/key" ) &
 appear_pid=$!
 PATH="$BIN:$PATH" \
 ARMADA_INPUT_LIB="$INPUT_LIB" ARMADA_INPUT_CLASS="$SYS" ARMADA_INPUT_DEV_DIR="$DEV" \
-ARMADA_SPLASH_PROGRESS="$WORK/progress" ARMADA_RECOVERY_MARKER="$WORK/recovery-mode" \
+ARMADA_RECOVERY_MARKER="$WORK/recovery-mode" \
 ARMADA_SESSION_CONTROL="$WORK/session-control" \
 ARMADA_BOOT_HOTKEY_POLL_MS=10 ARMADA_BOOT_HOTKEY_HOLD_MS=30 \
 ARMADA_BOOT_HOTKEY_RESCAN_MS=20 ARMADA_BOOT_HOTKEY_MAX=3 \
@@ -134,8 +130,8 @@ ARMADA_SPLASH_CEF_PORT=1 \
 wait "$appear_pid" 2>/dev/null || true
 assert_grep "$WORK/session.log" "default-desktop" "key moving to another node is rescanned"
 rm -f "$WORK/pressed-dev"
-printf '800000000000000 0 0 0 0\n' > "$SYS/event1/device/capabilities/key"
-printf '1000000000000000 0 0 0 0\n' > "$SYS/event2/device/capabilities/key"
+printf '400000000000000 0 0 0 0\n' > "$SYS/event1/device/capabilities/key"
+printf '800000000000000 0 0 0 0\n' > "$SYS/event2/device/capabilities/key"
 
 # Nothing else retries a failed sddm: session-control resets the failure state
 # without starting it.
@@ -150,13 +146,15 @@ rm -f "$WORK/dm-failed"
 run_hotkeys
 assert_no_grep "$WORK/systemctl.log" "start display-manager.service" "pre-sddm must not start it"
 
-grep -qE '^ *"315:BTN_START:Desktop Mode:action_desktop"' "$HOTKEYS" \
+grep -qE '^ *"314:BTN_SELECT:Desktop Mode:action_desktop"' "$HOTKEYS" \
     || fail "the hotkey table entry changed shape"
 grep -q 'Before=display-manager.service' "$UNIT" || fail "unit must start before sddm"
 grep -q 'ConditionPathExists=!/etc/armada/boot-hotkeys-disabled' "$UNIT" \
     || fail "unit needs an escape hatch"
-grep -q 'After=.*armada-session-default.service' "$UNIT" \
-    || fail "unit must be ordered after the gamemode autologin reset"
+grep -q 'WantedBy=sysinit.target' "$UNIT" \
+    || fail "unit must start with the splash, not at basic.target"
+grep -q 'After=.*armada-session-default' "$UNIT" \
+    && fail "static ordering after armada-session-default pins the hold onto sddm's start"
 grep -q 'systemctl enable armada-boot-hotkeys.service' "$ROOT/build_files/40-vendor-system-files.sh" \
     || fail "armada-boot-hotkeys.service is not enabled in the image"
 

--- a/tests/boot-hotkeys-test.sh
+++ b/tests/boot-hotkeys-test.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+HOTKEYS="$ROOT/system_files/usr/libexec/armada/armada-boot-hotkeys"
+UNIT="$ROOT/system_files/usr/lib/systemd/system/armada-boot-hotkeys.service"
+INPUT_LIB="$ROOT/system_files/usr/lib/armada/input-lib"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+assert_file() { [[ -e "$1" ]] || fail "$2: expected $1 to exist"; }
+assert_grep() { grep -qF -- "$2" "$1" || fail "$3: expected ${2@Q} in $1"; }
+assert_no_grep() { [[ -e "$1" ]] && grep -qF -- "$2" "$1" && fail "$3: unexpected ${2@Q} in $1"; return 0; }
+
+BIN="$WORK/bin"; DEV="$WORK/dev"; SYS="$WORK/sys"
+mkdir -p "$BIN" "$DEV" "$SYS"
+export WORK
+
+# event0 has no EV_KEY bitmap at all, event1 carries BTN_START (315), and
+# event2 carries the neighbouring BTN_MODE (316): only event1 may be polled.
+for n in 0 1 2; do : > "$DEV/event$n"; mkdir -p "$SYS/event$n/device/capabilities"; done
+printf '0\n' > "$SYS/event0/device/capabilities/key"
+printf '800000000000000 0 0 0 0\n' > "$SYS/event1/device/capabilities/key"
+printf '1000000000000000 0 0 0 0\n' > "$SYS/event2/device/capabilities/key"
+
+cat > "$BIN/evtest" <<'STUB'
+#!/usr/bin/env bash
+dev="${@: -3:1}"
+printf '%s\n' "$dev" >> "$WORK/queried"
+[[ -e "$WORK/pressed" ]] || exit 0
+[[ -r "$WORK/pressed-dev" ]] || exit 10
+[[ "$dev" == "$(cat "$WORK/pressed-dev")" ]] && exit 10
+exit 0
+STUB
+cat > "$BIN/systemctl" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$WORK/systemctl.log"
+[[ "$1" == start ]] && exit 0
+[[ "$1" == is-failed ]] && { [[ -e "$WORK/dm-failed" ]] && exit 0; exit 1; }
+[[ " $* " == *" display-manager.service "* && -e "$WORK/dm-active" ]] && exit 0
+exit 3
+STUB
+cat > "$BIN/logger" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "${@: -1}" >> "$WORK/log"
+STUB
+cat > "$WORK/progress" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$WORK/status.log"
+STUB
+cat > "$WORK/session-control" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$WORK/session.log"
+STUB
+chmod 0755 "$BIN"/* "$WORK/session-control" "$WORK/progress"
+
+run_hotkeys() {
+    rm -f "$WORK/queried" "$WORK/log" "$WORK/session.log" "$WORK/status.log" "$WORK/systemctl.log" "$WORK/recovery-mode"
+    PATH="$BIN:$PATH" \
+    ARMADA_INPUT_LIB="$INPUT_LIB" \
+    ARMADA_INPUT_CLASS="$SYS" \
+    ARMADA_INPUT_DEV_DIR="$DEV" \
+    ARMADA_SESSION_CONTROL="$WORK/session-control" \
+    ARMADA_SPLASH_PROGRESS="$WORK/progress" \
+    ARMADA_RECOVERY_MARKER="$WORK/recovery-mode" \
+    ARMADA_BOOT_HOTKEY_POLL_MS=10 \
+    ARMADA_BOOT_HOTKEY_HOLD_MS=30 \
+    ARMADA_BOOT_HOTKEY_MAX=1 \
+    ARMADA_SPLASH_CEF_PORT="${CEF_PORT:-1}" \
+    bash "$HOTKEYS" > "$WORK/out.log" 2>&1
+}
+
+# Only the device that reports the key code is polled.
+rm -f "$WORK/pressed" "$WORK/dm-active"
+run_hotkeys
+[[ -e "$WORK/session.log" ]] && fail "no hold: switched sessions anyway"
+[[ -e "$WORK/status.log" ]] && fail "no hold: wrote to the splash anyway"
+[[ -e "$WORK/recovery-mode" ]] && fail "no hold: marked recovery mode anyway"
+sort -u "$WORK/queried" > "$WORK/queried.uniq"
+[[ "$(cat "$WORK/queried.uniq")" == "$DEV/event1" ]] \
+    || fail "device selection: polled $(tr '\n' ' ' < "$WORK/queried.uniq")"
+
+# Held before the display manager is up: write the autologin drop-in only.
+: > "$WORK/pressed"
+run_hotkeys
+assert_grep "$WORK/session.log" "default-desktop" "pre-sddm hold"
+# The marker is what a desktop recovery tool would key off.
+assert_file "$WORK/recovery-mode" "recovery marker written"
+assert_grep "$WORK/log" "holding Desktop Mode" "journal notes the hold"
+assert_grep "$WORK/log" "triggering Desktop Mode" "journal notes the trigger"
+assert_grep "$WORK/status.log" "Starting Desktop" "splash announce"
+# More than one write means a hold prompt crept back in, which is what races
+# armada-splash-run.
+[[ $(wc -l < "$WORK/status.log") == 1 ]] \
+    || fail "expected exactly one splash write, got $(wc -l < "$WORK/status.log")"
+
+# Held once the session is running: restart it the way Steam's own switch does.
+: > "$WORK/dm-active"
+run_hotkeys
+assert_grep "$WORK/session.log" "switch-desktop" "post-sddm hold"
+
+# Steam's UI ends the watch, so the button goes back to being Steam's.
+python3 -c 'import socket,sys,time
+s=socket.socket(); s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1)
+s.bind(("127.0.0.1",0)); s.listen()
+print(s.getsockname()[1], flush=True)
+time.sleep(20)' > "$WORK/port" &
+port_pid=$!
+for _ in {1..100}; do [[ -s "$WORK/port" ]] && break; sleep 0.05; done
+CEF_PORT="$(cat "$WORK/port")" run_hotkeys
+kill "$port_pid" 2>/dev/null || true
+[[ -e "$WORK/session.log" ]] && fail "steam up: switched sessions anyway"
+[[ -e "$WORK/queried" ]] && fail "steam up: kept polling the volume key"
+
+# Device replacement: the key moves to another node after a successful scan.
+# Fails without the periodic rescan, which is the point of the case.
+rm -f "$WORK/dm-active" "$WORK/dm-failed" "$WORK/session.log"
+printf '%s\n' "$DEV/event2" > "$WORK/pressed-dev"
+printf '800000000000000 0 0 0 0\n' > "$SYS/event1/device/capabilities/key"
+printf '0\n' > "$SYS/event2/device/capabilities/key"
+( sleep 0.3
+  printf '0\n' > "$SYS/event1/device/capabilities/key"
+  printf '800000000000000 0 0 0 0\n' > "$SYS/event2/device/capabilities/key" ) &
+appear_pid=$!
+PATH="$BIN:$PATH" \
+ARMADA_INPUT_LIB="$INPUT_LIB" ARMADA_INPUT_CLASS="$SYS" ARMADA_INPUT_DEV_DIR="$DEV" \
+ARMADA_SPLASH_PROGRESS="$WORK/progress" ARMADA_RECOVERY_MARKER="$WORK/recovery-mode" \
+ARMADA_SESSION_CONTROL="$WORK/session-control" \
+ARMADA_BOOT_HOTKEY_POLL_MS=10 ARMADA_BOOT_HOTKEY_HOLD_MS=30 \
+ARMADA_BOOT_HOTKEY_RESCAN_MS=20 ARMADA_BOOT_HOTKEY_MAX=3 \
+ARMADA_SPLASH_CEF_PORT=1 \
+    bash "$HOTKEYS" > "$WORK/out.log" 2>&1
+wait "$appear_pid" 2>/dev/null || true
+assert_grep "$WORK/session.log" "default-desktop" "key moving to another node is rescanned"
+rm -f "$WORK/pressed-dev"
+printf '800000000000000 0 0 0 0\n' > "$SYS/event1/device/capabilities/key"
+printf '1000000000000000 0 0 0 0\n' > "$SYS/event2/device/capabilities/key"
+
+# Nothing else retries a failed sddm: session-control resets the failure state
+# without starting it.
+rm -f "$WORK/dm-active"
+: > "$WORK/dm-failed"
+run_hotkeys
+assert_grep "$WORK/session.log" "default-desktop" "failed sddm still sets autologin"
+assert_grep "$WORK/systemctl.log" "start display-manager.service" "failed sddm is started"
+rm -f "$WORK/dm-failed"
+
+# Not started yet is the normal case: systemd starts it next, so do not race it.
+run_hotkeys
+assert_no_grep "$WORK/systemctl.log" "start display-manager.service" "pre-sddm must not start it"
+
+grep -qE '^ *"315:BTN_START:Desktop Mode:action_desktop"' "$HOTKEYS" \
+    || fail "the hotkey table entry changed shape"
+grep -q 'Before=display-manager.service' "$UNIT" || fail "unit must start before sddm"
+grep -q 'ConditionPathExists=!/etc/armada/boot-hotkeys-disabled' "$UNIT" \
+    || fail "unit needs an escape hatch"
+grep -q 'After=.*armada-session-default.service' "$UNIT" \
+    || fail "unit must be ordered after the gamemode autologin reset"
+grep -q 'systemctl enable armada-boot-hotkeys.service' "$ROOT/build_files/40-vendor-system-files.sh" \
+    || fail "armada-boot-hotkeys.service is not enabled in the image"
+
+echo "PASS: boot-hotkeys"


### PR DESCRIPTION
- System for mapping controller hotkeys to actions during boot
- First action is hold select for 3 seconds to force desktop mode