### PR TITLE
fix(armada-control): restore Proton dropdown on Steam beta

### DIFF
--- a/decky/armada-control/src/lib/compatManager.ts
+++ b/decky/armada-control/src/lib/compatManager.ts
@@ -1,0 +1,97 @@
+import { findModuleExport } from "@decky/ui";
+
+export class CompatToolsRequest {
+  appid?: number;
+
+  serializeBinary(): Uint8Array {
+    if (this.appid === undefined) return new Uint8Array();
+    let value = this.appid >>> 0;
+    const bytes = [8]; // appid: uint32, field 1
+    while (value > 127) {
+      bytes.push((value & 127) | 128);
+      value >>>= 7;
+    }
+    bytes.push(value);
+    return new Uint8Array(bytes);
+  }
+}
+
+export class CompatToolsResponse {
+  tools: Array<{ name?: string; display_name?: string; is_incompatible?: boolean }> = [];
+
+  static deserializeBinaryFromReader(message: CompatToolsResponse, reader: any): void {
+    while (reader.nextField()) {
+      if (reader.isEndGroup()) break;
+      if (reader.getFieldNumber() !== 1) {
+        // Armada's default policy requires concrete tool IDs, not Steam aliases.
+        reader.skipField();
+        continue;
+      }
+      const tool: CompatToolsResponse["tools"][number] = {};
+      reader.readMessage(tool, (entry: typeof tool, fields: any) => {
+        while (fields.nextField()) {
+          if (fields.isEndGroup()) break;
+          switch (fields.getFieldNumber()) {
+            case 1: entry.name = fields.readString(); break;
+            case 2: entry.display_name = fields.readString(); break;
+            case 6: entry.is_incompatible = fields.readBool(); break;
+            default: fields.skipField();
+          }
+        }
+      });
+      message.tools.push(tool);
+    }
+  }
+}
+
+let transportStore: any;
+let messageClass: any;
+
+function compatTransport(): any {
+  if (!transportStore) {
+    // The minified getter has no stable signature; the module's diagnostic does.
+    let require: any;
+    window.webpackChunksteamui?.push([
+      [Symbol("armada-compat-transport")], {}, (loader: any) => { require = loader; },
+    ]);
+    const id = Object.keys(require?.m || {}).find((key) =>
+      require.m[key].toString().includes("Multiple attempts to set a default WebUI transport"),
+    );
+    if (id) {
+      for (const value of Object.values(require(id))) {
+        if (typeof value !== "function") continue;
+        let candidate;
+        try { candidate = value(); } catch { continue; }
+        if (typeof candidate?.GetDefaultTransport === "function") {
+          transportStore = candidate;
+          break;
+        }
+      }
+    }
+  }
+  messageClass ||= findModuleExport((value: any) =>
+    typeof value?.Init === "function"
+    && typeof value?.InitFromObject === "function"
+    && typeof value?.prototype?.SetBodyFields === "function",
+  );
+  const transport = transportStore?.GetDefaultTransport();
+  if (!transport?.SendMsg || !messageClass) {
+    throw new Error("Steam compatibility tool discovery is unavailable");
+  }
+  return transport;
+}
+
+export async function getCompatManagerTools(appid?: number): Promise<CompatToolsResponse> {
+  const transport = compatTransport();
+  const request = messageClass.Init(CompatToolsRequest);
+  request.Body().appid = appid;
+  const response = await transport.SendMsg(
+    "CompatManager.GetCompatTools#1", request, CompatToolsResponse,
+    // Steam's CompatManager privilege level (1), executing in clientdll (2).
+    { ePrivilege: 1, eClientExecutionSite: 2 },
+  );
+  if (!response.BSuccess()) {
+    throw new Error(`Steam compatibility tool discovery failed (${response.GetEResult()})`);
+  }
+  return response.Body();
+}

--- a/decky/armada-control/src/lib/compatTools.ts
+++ b/decky/armada-control/src/lib/compatTools.ts
@@ -1,0 +1,31 @@
+import type { CompatTool } from "./protonPolicy";
+
+export function mapCompatTools(raw: any): CompatTool[] {
+  const tools = Array.isArray(raw) ? raw : raw?.tools;
+  if (!Array.isArray(tools)) return [];
+  return tools
+    .filter((tool: any) => !tool?.is_incompatible)
+    .map((tool: any) => {
+      const id = String(tool?.strToolName ?? tool?.strName ?? tool?.name ?? "");
+      return {
+        id,
+        label: String(tool?.strDisplayName || tool?.display_name || id),
+      };
+    })
+    .filter((tool: CompatTool) => tool.id);
+}
+
+// An empty tool list is valid on older clients and must not trigger fallback.
+export async function readCompatTools(
+  client: any,
+  getCompatTools: (appid?: number) => Promise<unknown>,
+  appid?: number,
+): Promise<CompatTool[]> {
+  if (appid === undefined && client?.Settings?.GetGlobalCompatTools) {
+    return mapCompatTools(await client.Settings.GetGlobalCompatTools());
+  }
+  if (appid !== undefined && client?.Apps?.GetAvailableCompatTools) {
+    return mapCompatTools(await client.Apps.GetAvailableCompatTools(appid));
+  }
+  return mapCompatTools(await getCompatTools(appid));
+}

--- a/decky/armada-control/src/lib/steamCompat.ts
+++ b/decky/armada-control/src/lib/steamCompat.ts
@@ -2,6 +2,8 @@ import {
   defaultWindowsCompatTool,
   type CompatTool,
 } from "./protonPolicy";
+import { readCompatTools } from "./compatTools";
+import { getCompatManagerTools } from "./compatManager";
 export {
   defaultWindowsCompatTool,
 } from "./protonPolicy";
@@ -24,7 +26,6 @@ function isManagedType(type: number | null): boolean {
 }
 
 const apps = () => window.SteamClient?.Apps;
-const settings = () => window.SteamClient?.Settings;
 
 export const USE_DEFAULT_COMPAT = "__armada_default__";
 export const FOLLOW_STEAM_COMPAT = "__steam_default__";
@@ -90,23 +91,13 @@ export function markCompatHandled(appid: string): boolean {
   return handledAppids.size !== size;
 }
 
-function mapCompatTools(raw: any): CompatTool[] {
-  if (!Array.isArray(raw)) return [];
-  return raw
-    .map((tool: any) => ({
-      id: String(tool?.strToolName ?? tool?.strName ?? tool?.name ?? ""),
-      label: String(tool?.strDisplayName ?? tool?.strToolName ?? tool?.strName ?? ""),
-    }))
-    .filter((tool: CompatTool) => tool.id);
-}
-
 export async function getProtonTools(refresh = false): Promise<CompatTool[]> {
   if (!refresh && protonToolsCache.length && Date.now() - protonToolsCachedAt < 5000) return protonToolsCache;
   if (protonToolsRequest) return protonToolsRequest;
   protonToolsRequest = (async () => {
     try {
       // Steam exposes Proton globally; per-app Linux runtimes only appear in available tools.
-      const tools = mapCompatTools(await settings()?.GetGlobalCompatTools?.());
+      const tools = await readCompatTools(window.SteamClient, getCompatManagerTools);
       if (tools.length) {
         protonToolsCache = tools;
         protonToolsCachedAt = Date.now();
@@ -124,7 +115,7 @@ export async function getProtonTools(refresh = false): Promise<CompatTool[]> {
 // A game's supported tools per Steam's OS filtering (Proton, plus SLR for a Linux depot); for the per-game picker.
 export async function getAppCompatTools(appid: string): Promise<CompatTool[]> {
   try {
-    return mapCompatTools(await apps()?.GetAvailableCompatTools?.(Number(appid)));
+    return await readCompatTools(window.SteamClient, getCompatManagerTools, Number(appid));
   } catch (error) {
     return [];
   }

--- a/decky/armada-control/test/compatTools.test.ts
+++ b/decky/armada-control/test/compatTools.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mapCompatTools, readCompatTools } from "../src/lib/compatTools.ts";
+
+const id = "proton-experimental-arm64";
+const label = "Proton Experimental (ARM64)";
+const expected = [{ id, label }];
+const modern = {
+  tools: [{ name: id, display_name: label, is_incompatible: false }],
+  aliases: [{ alias: "proton-stable", current_tool_name: "proton_11-arm64" }],
+  selected_tool_identifier: "",
+  default_tool_identifier: "proton-stable",
+};
+
+test("maps the CompatManager response, keeping concrete tool IDs and labels", () => {
+  assert.deepEqual(mapCompatTools(modern), expected);
+});
+
+test("maps legacy native response fields and falls back to the tool ID for empty labels", () => {
+  assert.deepEqual(mapCompatTools([{ strToolName: id, strDisplayName: label }]), expected);
+  assert.deepEqual(mapCompatTools([{ strName: id, strDisplayName: "" }]), [{ id, label: id }]);
+  assert.deepEqual(mapCompatTools([{ name: id }]), [{ id, label: id }]);
+});
+
+test("ignores malformed entries and incompatible tools", () => {
+  assert.deepEqual(mapCompatTools({ tools: [null, {}, { name: id, is_incompatible: true }] }), []);
+  for (const raw of [null, undefined, {}, { tools: {} }]) assert.deepEqual(mapCompatTools(raw), []);
+});
+
+test("uses CompatManager when the beta removes the native methods", async () => {
+  const requests: Array<number | undefined> = [];
+  const fetch = async (appid?: number) => { requests.push(appid); return modern; };
+  assert.deepEqual(await readCompatTools({ Settings: {}, Apps: {} }, fetch), expected);
+  assert.deepEqual(await readCompatTools({ Settings: {}, Apps: {} }, fetch, 391220), expected);
+  assert.deepEqual(requests, [undefined, 391220]);
+});
+
+test("preserves native methods and their receiver on older clients", async () => {
+  const fallback = async () => { assert.fail("must use the native API"); };
+  const settings = {
+    async GetGlobalCompatTools() { assert.equal(this, settings); return [{ strToolName: id, strDisplayName: label }]; },
+  };
+  const apps = {
+    async GetAvailableCompatTools(appid: number) {
+      assert.equal(this, apps);
+      assert.equal(appid, 391220);
+      return [{ strToolName: id, strDisplayName: label }];
+    },
+  };
+  const client = { Settings: settings, Apps: apps };
+  assert.deepEqual(await readCompatTools(client, fallback), expected);
+  assert.deepEqual(await readCompatTools(client, fallback, 391220), expected);
+});
+
+test("does not switch APIs on a legitimate empty native response", async () => {
+  const client = { Settings: { GetGlobalCompatTools: async () => [] } };
+  assert.deepEqual(await readCompatTools(client, async () => { assert.fail(); }), []);
+});
+
+test("propagates discovery failures to the caller's existing cache/error handling", async () => {
+  const error = new Error("transport unavailable");
+  await assert.rejects(readCompatTools({}, async () => { throw error; }), error);
+});


### PR DESCRIPTION
Steam beta removed the native compatibility-list methods, leaving Armada Control’s Proton dropdown empty.

Use CompatManager.GetCompatTools for newer clients while retaining native discovery on older clients. Normalize tool responses and preserve existing default selection, caching, and error handling.