### PR TITLE
feat(armada-control): add global Follow Steam option

### DIFF
--- a/decky/armada-control/src/lib/steamCompat.ts
+++ b/decky/armada-control/src/lib/steamCompat.ts
@@ -43,6 +43,7 @@ export function setWindowsCompatTool(toolName: string | undefined): void {
 
 // A saved default can name a tool a later release stopped shipping.
 async function effectiveWindowsCompatTool(): Promise<string> {
+  if (windowsCompatTool === FOLLOW_STEAM_COMPAT) return FOLLOW_STEAM_COMPAT;
   const tools = await getProtonTools();
   if (!tools.length) return "";
   if (windowsCompatTool && tools.some((tool) => tool.id === windowsCompatTool)) return windowsCompatTool;
@@ -146,7 +147,7 @@ export function compatSelection(state: CompatState | null, defaultTool?: string)
 export async function specifyCompatTool(appid: string, toolName: string): Promise<void> {
   const store = apps();
   if (!store?.SpecifyCompatTool) throw new Error("Steam compatibility settings are unavailable");
-  await store.SpecifyCompatTool(Number(appid), toolName);
+  await store.SpecifyCompatTool(Number(appid), toolName === FOLLOW_STEAM_COMPAT ? "" : toolName);
 }
 
 const delay = (ms: number) => new Promise<void>((resolve) => window.setTimeout(resolve, ms));
@@ -297,6 +298,7 @@ async function clearCompatToolAndResolveRoute(appid: string): Promise<CompatRout
 }
 
 async function applyCompatDefaultForRoute(appid: string, route: CompatRoute | null): Promise<boolean> {
+  if (windowsCompatTool === FOLLOW_STEAM_COMPAT) return repinToTool(appid, "");
   if (route === null) return false;
   if (route === "linux") {
     markCompatHandled(appid);
@@ -368,7 +370,7 @@ async function applyWindowsCompatDefault(appid: string): Promise<boolean> {
   if (handledAppids.has(appid)) return true;
   const details = await resolveSettledCompatDetails(appid);
   if (!details) return false;
-  if (!autoApplyCompat || Number(details.nCompatToolPriority || 0) >= 250) {
+  if (!autoApplyCompat || windowsCompatTool === FOLLOW_STEAM_COMPAT || Number(details.nCompatToolPriority || 0) >= 250) {
     markCompatHandled(appid);
     return true;
   }
@@ -402,8 +404,10 @@ export async function migrateWindowsCompatTool(
   pinnedAppids?: string[] | null,
 ): Promise<void> {
   if (!oldTool || oldTool === newTool) return;
-  const protonTools = await getProtonTools();
-  if (!protonTools.some((tool) => tool.id === newTool)) return;
+  if (newTool !== FOLLOW_STEAM_COMPAT) {
+    const protonTools = await getProtonTools();
+    if (!protonTools.some((tool) => tool.id === newTool)) return;
+  }
   setWindowsCompatTool(newTool);
   const pinned = pinnedAppids ? new Set(pinnedAppids.map(String)) : null;
   let next = 0;
@@ -422,7 +426,12 @@ export async function migrateWindowsCompatTool(
         await repinToTool(appid, newTool);
         continue;
       }
-      if (priority < 250 || String(details.strCompatToolName || "") !== oldTool) continue;
+      const currentTool = String(details.strCompatToolName || "");
+      if (oldTool === FOLLOW_STEAM_COMPAT) {
+        if (priority >= 250 || await resolveCompatRoute(currentTool) !== "windows") continue;
+      } else if (priority < 250 || currentTool !== oldTool) {
+        continue;
+      }
       for (let attempt = 0; attempt < 3; attempt++) {
         if (await applyCompatDefaultForRoute(appid, "windows")) break;
       }
@@ -439,6 +448,11 @@ export async function resetCompatToolToDefault(appid: string, pinnedAppids?: str
   }
   if (!isManagedType(type)) return "";
   const tool = await effectiveWindowsCompatTool();
+  if (tool === FOLLOW_STEAM_COMPAT) {
+    await specifyCompatTool(appid, "");
+    markCompatHandled(appid);
+    return "";
+  }
   // Clearing first needs a default to put back and a known pin state; null is unknown.
   if (!tool || pinnedAppids === null) {
     const state = await resolveCompatState(appid);
@@ -470,7 +484,9 @@ export async function resetAllGamePolicies(appids: string[], pinnedAppids?: stri
         continue;
       }
       if (!isManagedType(type)) continue;
-      if (canResetCompat && pinned?.has(appid)) {
+      if (tool === FOLLOW_STEAM_COMPAT) {
+        await repinToTool(appid, "");
+      } else if (canResetCompat && pinned?.has(appid)) {
         await repinToTool(appid, tool);
       } else if (canResetCompat) {
         await applyCompatDefaultForRoute(appid, await clearCompatToolAndResolveRoute(appid));

--- a/decky/armada-control/src/tabs/Compatibility.tsx
+++ b/decky/armada-control/src/tabs/Compatibility.tsx
@@ -233,7 +233,7 @@ export function Compatibility({ config, setConfig }: { config: Config; setConfig
     compatTools, config.protonDefaults,
   );
   // The setting is kept rather than rewritten: reinstalling the tool restores the choice.
-  const globalToolMissing = !!globalTool && compatTools.length > 0
+  const globalToolMissing = !!globalTool && globalTool !== FOLLOW_STEAM_COMPAT && compatTools.length > 0
     && !compatTools.some((tool) => tool.id === globalTool);
   const activeGlobalTool = !globalTool || globalToolMissing ? resolvedDefaultTool : globalTool;
   const runtimeGame = config.game;
@@ -483,7 +483,10 @@ export function Compatibility({ config, setConfig }: { config: Config; setConfig
     setConfig((current) => (current ? { ...current, selectedGame: saved || null } : current));
   };
 
-  const toolOptions = compatTools.map((tool) => ({ data: tool.id, label: tool.label }));
+  const toolOptions = [
+    { data: FOLLOW_STEAM_COMPAT, label: "Follow Steam" },
+    ...compatTools.map((tool) => ({ data: tool.id, label: tool.label })),
+  ];
   const onSelectGlobalDefault = async (choice: any) => {
     if (switchingDefault) return;
     const name = String(choice);
@@ -805,14 +808,18 @@ export function Compatibility({ config, setConfig }: { config: Config; setConfig
                 {globalTool} is no longer installed. Choose a new default for your games.
               </div>
             ) : null}
-            <ToggleField
-              label="Apply to New Games"
-              checked={tweaks.global.autoApplyCompat !== false}
-              onChange={(enabled) => {
-                setAutoApplyCompat(enabled);
-                patchSettings({ autoApplyCompat: enabled });
-              }}
-            />
+            {activeGlobalTool === FOLLOW_STEAM_COMPAT ? (
+              <div className="armada-compat-note">Steam chooses the compatibility tool for each game.</div>
+            ) : (
+              <ToggleField
+                label="Apply to New Games"
+                checked={tweaks.global.autoApplyCompat !== false}
+                onChange={(enabled) => {
+                  setAutoApplyCompat(enabled);
+                  patchSettings({ autoApplyCompat: enabled });
+                }}
+              />
+            )}
             <SelectEdit label="Game Resolution" value={defaultResolution} options={resolutionOptions} onChange={setSteamDefaultResolution} />
           </>
         ) : (

--- a/decky/armada-control/test/steamCompat.test.ts
+++ b/decky/armada-control/test/steamCompat.test.ts
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { runInNewContext } from "node:vm";
+import ts from "typescript";
+
+import * as protonPolicy from "../src/lib/protonPolicy.ts";
+import * as compatTools from "../src/lib/compatTools.ts";
+
+const experimental = "proton-experimental-arm64";
+const stable = "proton_11-arm64";
+const source = readFileSync(new URL("../src/lib/steamCompat.ts", import.meta.url), "utf8");
+const compiled = ts.transpileModule(source, {
+  compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020 },
+}).outputText;
+
+function setup(tools = [experimental, stable]) {
+  const details = new Map<number, any>();
+  const types = new Map<number, number>();
+  const listeners = new Map<number, Set<(value: any) => void>>();
+  const writes: Array<[number, string]> = [];
+  const launchWrites: number[] = [];
+  const exports: any = {};
+  runInNewContext(compiled, {
+    exports,
+    require: (id: string) => {
+      if (id === "./protonPolicy") return protonPolicy;
+      if (id === "./compatTools") return compatTools;
+      if (id === "./compatManager") return {
+        getCompatManagerTools: async () => { throw new Error("Discovery unavailable"); },
+      };
+      throw new Error(`Unexpected import: ${id}`);
+    },
+    window: {
+      setTimeout, clearTimeout, setInterval, clearInterval,
+      appStore: { GetAppOverviewByAppID: (appid: number) => ({ app_type: types.get(appid) ?? 1 }) },
+      SteamClient: {
+        Settings: { GetGlobalCompatTools: async () => tools.map((name) => ({ name })) },
+        Apps: {
+          RegisterForAppDetails: (appid: number, callback: (value: any) => void) => {
+            const callbacks = listeners.get(appid) || new Set();
+            listeners.set(appid, callbacks);
+            callbacks.add(callback);
+            callback(details.get(appid));
+            return { unregister: () => callbacks.delete(callback) };
+          },
+          SpecifyCompatTool: async (appid: number, name: string) => {
+            writes.push([appid, name]);
+            const current = details.get(appid);
+            current.strCompatToolName = name || stable;
+            current.nCompatToolPriority = name ? 250 : 0;
+            for (const callback of listeners.get(appid) || []) callback(current);
+          },
+          SetAppLaunchOptions: async (appid: number) => { launchWrites.push(appid); },
+        },
+      },
+    },
+  });
+  function game(appid: number, tool = stable, priority = 0, type = 1) {
+    types.set(appid, type);
+    details.set(appid, { strCompatToolName: tool, nCompatToolPriority: priority });
+    return { appid: String(appid) };
+  }
+  return { api: exports as typeof import("../src/lib/steamCompat.ts"), game, writes, launchWrites };
+}
+
+test("global Follow Steam leaves new games and existing overrides alone, while adding the launch wrapper", async () => {
+  const { api, game, writes, launchWrites } = setup();
+  api.configureCompatPolicy(api.FOLLOW_STEAM_COMPAT, true, [], [experimental]);
+  await api.sweepInstalledGames([game(1), game(2, experimental, 250), game(3, "steamlinuxruntime")]);
+  assert.deepEqual(writes, []);
+  assert.deepEqual(launchWrites.sort(), [1, 2, 3]);
+  assert.deepEqual(Array.from(api.handledGameAppids()), ["1", "2", "3"]);
+  assert.equal(protonPolicy.factoryDefaultTransition(api.FOLLOW_STEAM_COMPAT, true, stable, experimental), null);
+});
+
+test("changing a named default to Follow Steam clears only matching game pins", async () => {
+  const { api, game, writes } = setup();
+  game(1, experimental, 250);
+  game(2, stable, 250);
+  game(3, experimental, 0);
+  game(4, experimental, 250, 4);
+  api.configureCompatPolicy(experimental, true, [], [experimental]);
+  await api.migrateWindowsCompatTool(["1", "2", "3", "4"], experimental, api.FOLLOW_STEAM_COMPAT);
+  assert.deepEqual(writes, [[1, ""]]);
+});
+
+test("Follow Steam can clear known pins to a missing default without tool discovery", async () => {
+  const { api, game, writes } = setup([]);
+  game(1, "", 0);
+  game(2, stable, 250);
+  game(3, "", 0);
+  await api.migrateWindowsCompatTool(["1", "2", "3"], "removed-proton", api.FOLLOW_STEAM_COMPAT, ["1", "2"]);
+  assert.deepEqual(writes, [[1, ""]]);
+});
+
+test("Use Default clears the mapping when the global choice is Follow Steam", async () => {
+  const { api, game, writes } = setup();
+  game(1, experimental, 250);
+  await api.specifyCompatTool("1", api.FOLLOW_STEAM_COMPAT);
+  assert.deepEqual(writes, [[1, ""]]);
+  assert.equal(api.compatSelection({ tool: stable, priority: 0 }, api.FOLLOW_STEAM_COMPAT), api.FOLLOW_STEAM_COMPAT);
+});
+
+test("resetting a game under Follow Steam clears its pin without discovery or a known pin state", async () => {
+  const { api, game, writes } = setup([]);
+  game(1, experimental, 250);
+  api.configureCompatPolicy(api.FOLLOW_STEAM_COMPAT, true, [], [experimental]);
+  assert.equal(await api.resetCompatToolToDefault("1", null), "");
+  assert.deepEqual(writes, [[1, ""]]);
+});
+
+test("reset all under Follow Steam clears game pins and preserves tool apps", async () => {
+  const { api, game, writes, launchWrites } = setup([]);
+  game(1, experimental, 250);
+  game(2, stable, 250);
+  game(3, experimental, 250, 4);
+  api.configureCompatPolicy(api.FOLLOW_STEAM_COMPAT, true, [], [experimental]);
+  await api.resetAllGamePolicies(["1", "2", "3"], null);
+  assert.deepEqual(writes, [[1, ""], [2, ""]]);
+  assert.deepEqual(launchWrites.sort(), [1, 2]);
+});
+
+test("switching away from Follow Steam migrates handled Windows games and preserves pins and Linux routes", async () => {
+  const { api, game, writes } = setup();
+  const games = [game(1), game(2, stable, 250), game(3, "steamlinuxruntime"), game(4, ""), game(5, stable, 0, 4)];
+  api.configureCompatPolicy(api.FOLLOW_STEAM_COMPAT, false, games.map(g => g.appid), [experimental]);
+  await api.migrateWindowsCompatTool(games.map(g => g.appid), api.FOLLOW_STEAM_COMPAT, experimental);
+  assert.deepEqual(writes, [[1, experimental]]);
+  api.setAutoApplyCompat(true);
+  await api.sweepInstalledGames([...games, game(6)]);
+  assert.deepEqual(writes, [[1, experimental], [6, experimental]]);
+});
+
+test("a named default round trip through Follow Steam restores its game pins", async () => {
+  const { api, game, writes } = setup();
+  const games = [game(1, experimental, 250), game(2, stable, 250)];
+  api.configureCompatPolicy(experimental, true, games.map(g => g.appid), [experimental]);
+  await api.migrateWindowsCompatTool(["1", "2"], experimental, api.FOLLOW_STEAM_COMPAT);
+  await api.migrateWindowsCompatTool(["1", "2"], api.FOLLOW_STEAM_COMPAT, experimental);
+  assert.deepEqual(writes, [[1, ""], [1, experimental]]);
+});
+
+test("named defaults still migrate matching pins and honor Apply to New Games", async () => {
+  const { api, game, writes } = setup();
+  game(1, stable, 250);
+  api.configureCompatPolicy(stable, false, [], [experimental]);
+  await api.migrateWindowsCompatTool(["1"], stable, experimental);
+  await api.sweepInstalledGames([game(2)]);
+  assert.deepEqual(writes, [[1, experimental]]);
+});


### PR DESCRIPTION
Add a persistent Follow Steam choice to the global Proton dropdown. Migrate matching pins when enabling it, and unpinned Windows games when switching back, preserving other overrides and Linux routes.

Honor the choice in per-game defaults and resets, and hide Apply to New Games while active.