### PR TITLE
test: realign three drifted tests with the code they pin

### DIFF
--- a/tests/armada-store-test.sh
+++ b/tests/armada-store-test.sh
@@ -65,7 +65,7 @@ store = pathlib.Path(sys.argv[1])
 rules = ET.parse(store / "templates/es-de/es_find_rules.xml").getroot()
 names = {e.get("name") for e in rules.findall("emulator")}
 # The emulators the store installs that ES-DE's linuxarm rules cannot find.
-assert names == {"ARMSX2", "CEMU", "PICO-8_64", "VITA3K", "XENIAEDGE"}, names
+assert names == {"ARMSX2", "BIGPEMU", "CEMU", "PICO-8_64", "VITA3K", "XENIAEDGE"}, names
 # Every entry here REPLACES the bundled one and takes its extensions and
 # alternative launch commands with it, so it must carry ES-DE's whole entry.
 systems = ET.parse(store / "templates/es-de/es_systems.xml").getroot()

--- a/tests/controller-profile-test.sh
+++ b/tests/controller-profile-test.sh
@@ -13,17 +13,46 @@ import sys
 root = Path(sys.argv[1])
 controller_type = root / "system_files/usr/libexec/armada/controller-type"
 devices = root / "system_files/usr/share/inputplumber/devices"
+device_env = root / "system_files/usr/libexec/armada/device-env"
+device_quirks = root / "system_files/usr/lib/armada/devices"
 udev_rules = root / "system_files/usr/lib/udev/rules.d/70-armada-inputplumber.rules"
 
+# Controller targets come from per-device ARMADA_IP_TARGETS and are
+# filtered against the types supported by controller-type.
 module = ast.parse(controller_type.read_text(encoding="utf-8"))
-profile_names = None
+controller_types = None
 for node in module.body:
     if not isinstance(node, ast.Assign):
         continue
-    if any(isinstance(target, ast.Name) and target.id == "ARMADA_PROFILE_NAMES" for target in node.targets):
-        profile_names = ast.literal_eval(node.value)
-if profile_names is None:
-    raise SystemExit("controller-type has no ARMADA_PROFILE_NAMES assignment")
+    if any(isinstance(target, ast.Name) and target.id == "CONTROLLER_TYPES" for target in node.targets):
+        controller_types = ast.literal_eval(node.value)
+if not isinstance(controller_types, dict) or not controller_types:
+    raise SystemExit("controller-type has no CONTROLLER_TYPES map")
+
+if "ARMADA_IP_TARGETS" not in device_env.read_text(encoding="utf-8"):
+    raise SystemExit("device-env does not publish ARMADA_IP_TARGETS")
+
+
+def ip_targets(path):
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("ARMADA_IP_TARGETS="):
+            return [item.strip() for item in line.split("=", 1)[1].split(",") if item.strip()]
+    return None
+
+
+default_targets = ip_targets(device_quirks / "defaults.conf")
+if not default_targets:
+    raise SystemExit("device quirks defaults.conf declares no ARMADA_IP_TARGETS")
+
+for conf in sorted(device_quirks.glob("*.conf")):
+    targets = ip_targets(conf)
+    if targets is None:
+        continue
+    unknown = [item for item in targets if item not in controller_types]
+    if unknown:
+        raise SystemExit(
+            f"{conf.relative_to(root)} offers unknown controller targets: {', '.join(unknown)}"
+        )
 
 shipped_names = set()
 passthrough_paths = set()
@@ -52,10 +81,6 @@ for profile in sorted(devices.glob("*.yaml")):
             raise SystemExit(f"{profile.relative_to(root)} has passthrough without phys_path")
         passthrough_paths.add(phys_path)
 
-missing_names = sorted(shipped_names - profile_names)
-if missing_names:
-    raise SystemExit(f"controller-type is missing profile names: {', '.join(missing_names)}")
-
 rules = udev_rules.read_text(encoding="utf-8")
 missing_rules = sorted(path for path in passthrough_paths if path not in rules)
 if missing_rules:
@@ -63,6 +88,7 @@ if missing_rules:
 
 print(
     f"controller profile test passed "
-    f"({len(shipped_names)} profiles, {len(passthrough_paths)} passthrough paths)"
+    f"({len(shipped_names)} profiles, {len(passthrough_paths)} passthrough paths, "
+    f"{len(default_targets)} default targets)"
 )
 PY

--- a/tests/perf-settings-test.sh
+++ b/tests/perf-settings-test.sh
@@ -151,7 +151,9 @@ check("factory game policy loaded",
 check("factory gamescope policy loaded",
       factory_global["gamescopeNice"] == -20 and factory_global["gamescopeRr"] is False and
       factory_global["gamescopeVulkanRealtime"] is True)
-check("factory scheduler loaded", factory_global["scheduler"] == "eevdf")
+# The shipped default deliberately forces no scheduler (05ccd27,
+# "restore default scheduler behavior"): null means "leave it alone".
+check("factory ships no scheduler override", factory_global["scheduler"] is None)
 check("factory thunk defaults loaded",
       set(factory_global["thunks"]) == {"Vulkan", "GL", "drm", "WaylandClient", "asound"} and
       all(factory_global["thunks"].values()))
@@ -182,7 +184,7 @@ check("user values override factory defaults",
       overlaid_global["gamescopeNice"] == 0 and
       overlaid_global["gamescopeVulkanRealtime"] is False)
 check("absent user values inherit factory defaults",
-      overlaid_global["scheduler"] == "eevdf" and
+      overlaid_global["scheduler"] is None and
       overlaid_global["gamescopeRr"] is False and
       overlaid_global["wineTopology"] is True)
 gt.OVERRIDES_CONFIG.unlink()

--- a/tests/run-bottom-test.sh
+++ b/tests/run-bottom-test.sh
@@ -59,6 +59,7 @@ mapfile -d '' -t actual <"$args_file"
 expected=(
     --backend drm
     --drm-lease-client "$lease_socket"
+    --drm-lease-yield
     --expose-wayland
     --force-windows-fullscreen
     --xwayland-count 1


### PR DESCRIPTION
Three test scripts fail on a clean `main` checkout right now. Each one broke when the code it pins changed, and since nothing runs the suite automatically the drift went unnoticed for days.

| Test | Broken since | Cause |
| --- | --- | --- |
| `tests/controller-profile-test.sh` | `de2d5fb` (2026-09-05) | the vendored InputPlumber profiles were dropped for the upstream ones, and `ARMADA_PROFILE_NAMES` was removed with them; the test still looks for that assignment |
| `tests/run-bottom-test.sh` | `be8b568` (2026-09-06) | `--drm-lease-yield` was added to `armada-run-bottom` without updating the expected argument list |
| `tests/perf-settings-test.sh` | `05ccd27` (2026-09-04) | the shipped default `scheduler` became `null` ("leave the system default alone"); two checks still expect `"eevdf"` |

What this changes:

- **`controller-profile-test.sh`** — the profile-name allowlist lost its object when the vendored profiles were dropped. What the controller UI offers now comes from the per-device quirks: `defaults.conf` sets `ARMADA_IP_TARGETS`, a device may override it, `device-env` publishes the value, and `controller-type` filters it against `CONTROLLER_TYPES`. The test now pins that contract — including that every shipped `*.conf` only offers targets `controller-type` knows — and keeps the profile-name and passthrough/udev checks unchanged.
- **`run-bottom-test.sh`** — add `--drm-lease-yield` to the expected gamescope arguments.
- **`perf-settings-test.sh`** — expect no scheduler override (`None`) in both the factory-defaults and the inheritance check.

`just check` passes locally on a clean checkout: 30/30 scripts plus the Justfile format check.

Separately, I'd like to propose running `just check` on pull requests so this class of drift is caught at review time instead of accumulating silently — I'll open that as its own issue.