### PR TITLE
ci: run just check on pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Tests and recipe checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # The Justfile uses [group(...)] attributes, which need just >= 1.22.
+      # Ubuntu 24.04's archive still ships 1.21, so just is installed here
+      # rather than with apt.
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+
+      # armada-control-rgb-test.sh checks for the absence of ARMADA_RGB_ with
+      # ripgrep; without ripgrep those two assertions pass vacuously.
+      - name: Install ripgrep
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq ripgrep
+
+      - name: just check (test suite + Justfile formatting)
+        run: just check

--- a/tests/armada-store-test.sh
+++ b/tests/armada-store-test.sh
@@ -65,7 +65,7 @@ store = pathlib.Path(sys.argv[1])
 rules = ET.parse(store / "templates/es-de/es_find_rules.xml").getroot()
 names = {e.get("name") for e in rules.findall("emulator")}
 # The emulators the store installs that ES-DE's linuxarm rules cannot find.
-assert names == {"ARMSX2", "CEMU", "PICO-8_64", "VITA3K", "XENIAEDGE"}, names
+assert names == {"ARMSX2", "BIGPEMU", "CEMU", "PICO-8_64", "VITA3K", "XENIAEDGE"}, names
 # Every entry here REPLACES the bundled one and takes its extensions and
 # alternative launch commands with it, so it must carry ES-DE's whole entry.
 systems = ET.parse(store / "templates/es-de/es_systems.xml").getroot()

--- a/tests/controller-profile-test.sh
+++ b/tests/controller-profile-test.sh
@@ -13,17 +13,46 @@ import sys
 root = Path(sys.argv[1])
 controller_type = root / "system_files/usr/libexec/armada/controller-type"
 devices = root / "system_files/usr/share/inputplumber/devices"
+device_env = root / "system_files/usr/libexec/armada/device-env"
+device_quirks = root / "system_files/usr/lib/armada/devices"
 udev_rules = root / "system_files/usr/lib/udev/rules.d/70-armada-inputplumber.rules"
 
+# Controller targets come from per-device ARMADA_IP_TARGETS and are
+# filtered against the types supported by controller-type.
 module = ast.parse(controller_type.read_text(encoding="utf-8"))
-profile_names = None
+controller_types = None
 for node in module.body:
     if not isinstance(node, ast.Assign):
         continue
-    if any(isinstance(target, ast.Name) and target.id == "ARMADA_PROFILE_NAMES" for target in node.targets):
-        profile_names = ast.literal_eval(node.value)
-if profile_names is None:
-    raise SystemExit("controller-type has no ARMADA_PROFILE_NAMES assignment")
+    if any(isinstance(target, ast.Name) and target.id == "CONTROLLER_TYPES" for target in node.targets):
+        controller_types = ast.literal_eval(node.value)
+if not isinstance(controller_types, dict) or not controller_types:
+    raise SystemExit("controller-type has no CONTROLLER_TYPES map")
+
+if "ARMADA_IP_TARGETS" not in device_env.read_text(encoding="utf-8"):
+    raise SystemExit("device-env does not publish ARMADA_IP_TARGETS")
+
+
+def ip_targets(path):
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("ARMADA_IP_TARGETS="):
+            return [item.strip() for item in line.split("=", 1)[1].split(",") if item.strip()]
+    return None
+
+
+default_targets = ip_targets(device_quirks / "defaults.conf")
+if not default_targets:
+    raise SystemExit("device quirks defaults.conf declares no ARMADA_IP_TARGETS")
+
+for conf in sorted(device_quirks.glob("*.conf")):
+    targets = ip_targets(conf)
+    if targets is None:
+        continue
+    unknown = [item for item in targets if item not in controller_types]
+    if unknown:
+        raise SystemExit(
+            f"{conf.relative_to(root)} offers unknown controller targets: {', '.join(unknown)}"
+        )
 
 shipped_names = set()
 passthrough_paths = set()
@@ -52,10 +81,6 @@ for profile in sorted(devices.glob("*.yaml")):
             raise SystemExit(f"{profile.relative_to(root)} has passthrough without phys_path")
         passthrough_paths.add(phys_path)
 
-missing_names = sorted(shipped_names - profile_names)
-if missing_names:
-    raise SystemExit(f"controller-type is missing profile names: {', '.join(missing_names)}")
-
 rules = udev_rules.read_text(encoding="utf-8")
 missing_rules = sorted(path for path in passthrough_paths if path not in rules)
 if missing_rules:
@@ -63,6 +88,7 @@ if missing_rules:
 
 print(
     f"controller profile test passed "
-    f"({len(shipped_names)} profiles, {len(passthrough_paths)} passthrough paths)"
+    f"({len(shipped_names)} profiles, {len(passthrough_paths)} passthrough paths, "
+    f"{len(default_targets)} default targets)"
 )
 PY

--- a/tests/perf-settings-test.sh
+++ b/tests/perf-settings-test.sh
@@ -151,7 +151,9 @@ check("factory game policy loaded",
 check("factory gamescope policy loaded",
       factory_global["gamescopeNice"] == -20 and factory_global["gamescopeRr"] is False and
       factory_global["gamescopeVulkanRealtime"] is True)
-check("factory scheduler loaded", factory_global["scheduler"] == "eevdf")
+# The shipped default deliberately forces no scheduler (05ccd27,
+# "restore default scheduler behavior"): null means "leave it alone".
+check("factory ships no scheduler override", factory_global["scheduler"] is None)
 check("factory thunk defaults loaded",
       set(factory_global["thunks"]) == {"Vulkan", "GL", "drm", "WaylandClient", "asound"} and
       all(factory_global["thunks"].values()))
@@ -182,7 +184,7 @@ check("user values override factory defaults",
       overlaid_global["gamescopeNice"] == 0 and
       overlaid_global["gamescopeVulkanRealtime"] is False)
 check("absent user values inherit factory defaults",
-      overlaid_global["scheduler"] == "eevdf" and
+      overlaid_global["scheduler"] is None and
       overlaid_global["gamescopeRr"] is False and
       overlaid_global["wineTopology"] is True)
 gt.OVERRIDES_CONFIG.unlink()

--- a/tests/run-bottom-test.sh
+++ b/tests/run-bottom-test.sh
@@ -59,6 +59,7 @@ mapfile -d '' -t actual <"$args_file"
 expected=(
     --backend drm
     --drm-lease-client "$lease_socket"
+    --drm-lease-yield
     --expose-wayland
     --force-windows-fullscreen
     --xwayland-count 1


### PR DESCRIPTION
**Stacked on #410** — that PR's three test commits are included here, so this diff will shrink to the workflow file once it lands. I'll rebase it onto `main` as soon as #410 merges.

The 30 scripts under `tests/` are only run by hand today: nothing in `.github/workflows/` references `tests/`, `just check` or `just lint`. A change that breaks a test looks green until someone happens to run the suite locally — which is how the three drifts in #410 got in.

This adds a job that runs `just check` (the 30 scripts plus the Justfile formatting check) on every pull request and on pushes to `main`.

Facts that shaped it:

- The suite needs bash, python3 and coreutils only — no device, no network, no container. `node` and `podman` appear in the scripts only inside strings and stubs.
- It finishes in ~9 seconds on an ordinary x86_64 Ubuntu 24.04 box (measured: 8.76s).
- `just` comes from `extractions/setup-just` rather than `apt-get`, because the Justfile's `[group(...)]` attributes need just >= 1.22 while Ubuntu 24.04's archive still ships 1.21 — `apt-get install just` fails with `Unknown attribute 'group'`.
- `just lint` is deliberately not wired up here. Its recipe is `find . -iname "*.sh" -exec shellcheck "{}" \;`, and `find` does not propagate the exit status of `-exec`, so the recipe returns 0 no matter what shellcheck reports (it currently reports ~210 findings). Fixing that needs a decision on severity scope or a cleanup pass, so it belongs in its own change.
- The runner is `ubuntu-latest` (x86_64) because that is where I verified the suite; the tests are arch-agnostic, so switching to `ubuntu-24.04-arm` for consistency with the other workflows is fine if you prefer.

Happy to adjust anything here — and if the tests are deliberately kept out of CI for a reason I have missed, I would rather know than guess.