### PR TITLE
Fix | Fix DP audio Hot pluggin

### DIFF
--- a/system_files/usr/share/alsa/ucm2/AYN/Odin3/HiFi.conf
+++ b/system_files/usr/share/alsa/ucm2/AYN/Odin3/HiFi.conf
@@ -72,18 +72,6 @@ SectionDevice."Headphones" {
 SectionDevice."HDMI" {
 	Comment "HDMI / DisplayPort playback"
 
-	EnableSequence [
-		cset "name='SECONDARY_MI2S_RX Audio Mixer MultiMedia1' 0"
-		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 0"
-		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia4' 1"
-	]
-
-	DisableSequence [
-		cset "name='SECONDARY_MI2S_RX Audio Mixer MultiMedia1' 1"
-		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 1"
-		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia4' 0"
-	]
-
 	Value {
 		PlaybackChannels 2
 		PlaybackPriority 100

--- a/system_files/usr/share/alsa/ucm2/AYN/Odin3/HiFi.conf
+++ b/system_files/usr/share/alsa/ucm2/AYN/Odin3/HiFi.conf
@@ -9,6 +9,13 @@ SectionVerb {
 		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia4' 1"
 	]
 
+	DisableSequence [
+		cset "name='SECONDARY_MI2S_RX Audio Mixer MultiMedia1' 0"
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 0"
+		cset "name='MultiMedia3 Mixer TX_CODEC_DMA_TX_3' 0"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia4' 0"
+	]
+
 	Include.wcde.File "/codecs/wcd939x/DefaultEnableSeq.conf"
 
 	Value {
@@ -21,7 +28,7 @@ SectionDevice."Speaker" {
 
 	Value {
 		PlaybackChannels 2
-		PlaybackPriority 100
+		PlaybackPriority 150
 		PlaybackPCM "hw:${CardId},0"
 		PlaybackMixer "default:${CardId}"
 	}
@@ -57,6 +64,7 @@ SectionDevice."Headphones" {
 		PlaybackMixer "default:${CardId}"
 		PlaybackMixerElem "HP Digital"
 		JackControl "Headphone Jack"
+		JackHWMute "Speaker"
 	}
 }
 
@@ -64,11 +72,24 @@ SectionDevice."Headphones" {
 SectionDevice."HDMI" {
 	Comment "HDMI / DisplayPort playback"
 
+	EnableSequence [
+		cset "name='SECONDARY_MI2S_RX Audio Mixer MultiMedia1' 0"
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 0"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia4' 1"
+	]
+
+	DisableSequence [
+		cset "name='SECONDARY_MI2S_RX Audio Mixer MultiMedia1' 1"
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 1"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia4' 0"
+	]
+
 	Value {
 		PlaybackChannels 2
-		PlaybackPriority 150
+		PlaybackPriority 100
 		PlaybackPCM "hw:${CardId},3"
 		PlaybackMixer "default:${CardId}"
 		JackControl "DP0 Jack"
+		JackHWMute "Speaker"
 	}
 }

--- a/system_files/usr/share/alsa/ucm2/KONKR/PocketFitElite/HiFi.conf
+++ b/system_files/usr/share/alsa/ucm2/KONKR/PocketFitElite/HiFi.conf
@@ -27,6 +27,13 @@ SectionVerb {
 		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia4' 1"
 	]
 
+	DisableSequence [
+		cset "name='SECONDARY_MI2S_RX Audio Mixer MultiMedia1' 0"
+		cset "name='RX_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 0"
+		cset "name='MultiMedia3 Mixer TX_CODEC_DMA_TX_3' 0"
+		cset "name='DISPLAY_PORT_RX_0 Audio Mixer MultiMedia4' 0"
+	]
+
 	Include.wcde.File "/codecs/wcd939x/DefaultEnableSeq.conf"
 
 	Value {
@@ -39,7 +46,7 @@ SectionDevice."Speaker" {
 
 	Value {
 		PlaybackChannels 2
-		PlaybackPriority 100
+		PlaybackPriority 150
 		PlaybackPCM "hw:${CardId},0"
 		PlaybackMixer "default:${CardId}"
 	}
@@ -74,6 +81,7 @@ SectionDevice."Headphones" {
 		PlaybackMixer "default:${CardId}"
 		PlaybackMixerElem "HP Digital"
 		JackControl "Headphone Jack"
+		JackHWMute "Speaker"
 	}
 }
 
@@ -83,9 +91,10 @@ SectionDevice."HDMI" {
 
 	Value {
 		PlaybackChannels 2
-		PlaybackPriority 150
+		PlaybackPriority 100
 		PlaybackPCM "hw:${CardId},3"
 		PlaybackMixer "default:${CardId}"
 		JackControl "DP0 Jack"
+		JackHWMute "Speaker"
 	}
 }


### PR DESCRIPTION
The recent changes that merged allowed you to use DP audio only if you went into desktop mode and set it as the primary audio out there. This PR fixes that work around by updating the HiFi conf to prioritize DP audio over the speaker and mute the speaker when DP audio is connected. This is inline with what the other HiFi conf files are doing in the repo.

I will note that I did not include an enable/disable sequence for DP/HDMI audio like the other confs. This was causing issues when unplugging the DP/HDMI out where the device could not immediately detect the speakers in game mode and required a change in desktop mode to turn them back on.  